### PR TITLE
fix: correct 'villian' misspelling in stored enums

### DIFF
--- a/lib/sanctum/games/game.ex
+++ b/lib/sanctum/games/game.ex
@@ -49,7 +49,7 @@ defmodule Sanctum.Games.Game do
     uuid_v7_primary_key :id
 
     attribute :state, :atom,
-      constraints: [one_of: [:setup, :player, :villian, :complete]],
+      constraints: [one_of: [:setup, :player, :villain, :complete]],
       public?: true,
       allow_nil?: false
 

--- a/lib/sanctum/games/game_card.ex
+++ b/lib/sanctum/games/game_card.ex
@@ -102,7 +102,7 @@ defmodule Sanctum.Games.GameCard do
           :hero_play,
           :encounter_deck,
           :encounter_discard,
-          :villian_play,
+          :villain_play,
           :facedown_encounter,
           :main_scheme,
           :side_scheme,

--- a/priv/repo/migrations/20260710161027_rename_villian_enum_values.exs
+++ b/priv/repo/migrations/20260710161027_rename_villian_enum_values.exs
@@ -1,0 +1,22 @@
+defmodule Sanctum.Repo.Migrations.RenameVillianEnumValues do
+  @moduledoc """
+  Data-only migration to correct the "villian" -> "villain" misspelling in
+  stored enum values. These values are persisted as TEXT (Ash `one_of` atom
+  constraints are app-level only), so `ash.codegen` generates no schema change
+  for this rename.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    execute("UPDATE games SET state = 'villain' WHERE state = 'villian'")
+
+    execute("UPDATE game_cards SET zone = 'villain_play' WHERE zone = 'villian_play'")
+  end
+
+  def down do
+    execute("UPDATE games SET state = 'villian' WHERE state = 'villain'")
+
+    execute("UPDATE game_cards SET zone = 'villian_play' WHERE zone = 'villain_play'")
+  end
+end

--- a/test/sanctum/games_test.exs
+++ b/test/sanctum/games_test.exs
@@ -24,6 +24,97 @@ defmodule Sanctum.GamesTest do
     {:ok, card}
   end
 
+  describe "villain enum values" do
+    setup do
+      {:ok, scenario} =
+        Games.create_scenario(%{
+          name: "Villain Zone Scenario",
+          set: "villain_zone_scenario",
+          recommended_modular_sets: []
+        })
+
+      {:ok, card} =
+        create_card_with_side(
+          %{
+            base_code: "zonev01",
+            code: "zonev01",
+            set: "villain_zone_scenario",
+            pack: "villain_zone_scenario"
+          },
+          %{
+            name: "Zone Test Villain",
+            type: :villain,
+            health: 10,
+            attack: 2,
+            scheme: 1
+          }
+        )
+
+      {:ok, user} =
+        Sanctum.Accounts.User
+        |> Ash.Changeset.for_create(:create, %{
+          email: "villain-zone@example.com",
+          confirmed_at: DateTime.utc_now()
+        })
+        |> Ash.create(authorize?: false)
+
+      %{card: card, scenario: scenario, user: user}
+    end
+
+    test "game card can be created in the :villain_play zone", %{card: card} do
+      assert {:ok, game_card} =
+               Sanctum.Games.GameCard
+               |> Ash.Changeset.for_create(:create, %{
+                 card_id: card.id,
+                 zone: :villain_play,
+                 order: 0
+               })
+               |> Ash.create(authorize?: false)
+
+      assert game_card.zone == :villain_play
+    end
+
+    test "game card can be moved to the :villain_play zone", %{
+      card: card,
+      scenario: scenario,
+      user: user
+    } do
+      {:ok, game} = Games.create_game(%{scenario_id: scenario.id, modular_sets: []}, actor: user)
+      game = Games.get_game!(game.id, load: [:game_players])
+      game_player = hd(game.game_players)
+
+      {:ok, game_card} =
+        Sanctum.Games.GameCard
+        |> Ash.Changeset.for_create(:create, %{
+          card_id: card.id,
+          game_player_id: game_player.id,
+          zone: :hero_hand,
+          order: 0
+        })
+        |> Ash.create(authorize?: false)
+
+      assert {:ok, moved} =
+               Games.move_game_card(
+                 game_card,
+                 %{game_player_id: game_player.id, zone: :villain_play},
+                 authorize?: false
+               )
+
+      assert moved.zone == :villain_play
+    end
+
+    test "the misspelled :villian_play zone is rejected", %{card: card} do
+      assert {:error, _} =
+               Sanctum.Games.GameCard
+               |> Ash.Changeset.for_create(:create, %{
+                 card_id: card.id,
+                 zone: :villian_play,
+                 order: 0
+               })
+               |> Ash.create(authorize?: false)
+    end
+  end
+
   describe "create_scenario" do
     test "creates a scenario with valid input" do
       attrs = %{


### PR DESCRIPTION
## Summary

Fixes the `villian` -> `villain` misspelling that was baked into two stored enum values (and their app-level Ash constraints):

- `Game.state`: `:villian` -> `:villain`
- `GameCard.zone`: `:villian_play` -> `:villain_play`

These values persist as TEXT in Postgres (`games.state`, `game_cards.zone`). Ash `one_of` constraints are validated at the app layer only, so `mix ash.codegen` generates no schema change for this rename. A data-only migration backfills any existing rows.

## What changed

- `lib/sanctum/games/game.ex` — `Game.state` `one_of` now lists `:villain`.
- `lib/sanctum/games/game_card.ex` — `GameCard.zone` `one_of` now lists `:villain_play`.
- `priv/repo/migrations/20260710161027_rename_villian_enum_values.exs` — new data-only migration with `up`/`down` `execute/2` statements:
  - up: `UPDATE games SET state = 'villain' WHERE state = 'villian'` and `UPDATE game_cards SET zone = 'villain_play' WHERE zone = 'villian_play'`
  - down: the reverse
- `test/sanctum/games_test.exs` — new `describe "villain enum values"` block: creates a game card in `:villain_play`, moves a game card to `:villain_play` through the real `:move` action, and asserts the misspelled `:villian_play` is now rejected.

No correctly-spelled identifiers were touched (`GameVillain`, `game_villains`, `:villain` card types, etc.).

## Migration exception note

Per the project rule "migrations are managed via `ash.codegen`", this is a **deliberate, flagged exception**: because the enum values are stored as plain TEXT and the Ash constraints are app-level, `ash.codegen` produces nothing for this rename. A hand-written **data-only** migration (`mix ecto.gen.migration`) is the only way to backfill existing rows. It contains no schema/DDL changes — only `UPDATE` statements. Reviewer can veto this approach.

## `game_villians` table finding (documentation only, no change here)

While investigating the stale snapshot dir `priv/resource_snapshots/repo/game_villians/` (misspelled), I found:

- The old `game_villians` table is created by `20250822185959_add_game_villians.exs` and altered by `20250822193019_modify_game_villians.exs`. **No `up` migration ever drops it** (the only `drop table(:game_villians)` is in the create migration's `down`).
- The resource was later renamed/replaced: the correct `game_villains` (and `villains`) tables are created in `20250924193504_add_hand_size_to_game_player.exs`, backing the current `Sanctum.Games.GameVillain` resource.
- Result: after running all migrations, an orphaned, empty `game_villians` table remains alongside the live `game_villains` table, and the stale `priv/resource_snapshots/repo/game_villians/` snapshot dir lingers.
- `mix ash.codegen` does **not** cleanly generate a drop for it (the resource that pointed at `game_villians` no longer exists, so Ash doesn't track it). Per the task's scope guidance, I left the table and snapshot in place and am only documenting it. Cleaning it up should be a separate, dedicated migration.

Note: `mix ash.codegen --check` currently fails on this branch, but only because of pre-existing `--dev` migrations already committed to `feat/heros` (`20250925142932_migrate_resources1_dev.exs`, `20250925145338_migrate_resources2_dev.exs`) — unrelated to this change.

## Tests

- `MIX_TEST_PARTITION=p1 mix test` — **89 tests, 0 failures, 1 skipped** (baseline was 86; +3 new).

## How to verify

```bash
mix deps.get
MIX_TEST_PARTITION=p1 mix test

# Confirm no stray misspelling remains in code
grep -rn "villian" lib/    # only expected: none

# Reviewers with existing dev data should migrate and confirm the backfill:
mix ecto.migrate
# then in `iex -S mix` or psql:
#   select distinct state from games;      -> no 'villian'
#   select distinct zone from game_cards;  -> no 'villian_play'
```

---

Stacked on #31 (`feat/heros`) — merge that first; GitHub retargets this PR automatically when the base branch is merged and deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)