### PR TITLE
fix: scope villain stage sides by set; pin hero side loading with tests

### DIFF
--- a/lib/sanctum/manual_relationships/has_one_through.ex
+++ b/lib/sanctum/manual_relationships/has_one_through.ex
@@ -5,15 +5,17 @@ defmodule Sanctum.ManualRelationships.HasOneThrough do
 
   require Ash.Query
 
-  def load(records, [through: through], %{query: _query} = context) do
+  def load(records, [through: through], %{query: query} = context) do
     source = context.relationship.source
+    cardinality = context.relationship.cardinality
 
+    # Build a nested load where the final hop carries the relationship's
+    # query (which already has the declared relationship filter applied),
+    # e.g. through: [:card, :card_sides] => [card: [card_sides: query]].
     load =
       through
       |> Enum.reverse()
-      |> Enum.reduce(fn t, prev ->
-        [{t, [prev]}]
-      end)
+      |> Enum.reduce(query, fn t, acc -> [{t, acc}] end)
 
     record_ids = Enum.map(records, fn r -> r.id end)
 
@@ -23,13 +25,20 @@ defmodule Sanctum.ManualRelationships.HasOneThrough do
       |> Ash.Query.load(load)
       |> Ash.read!(actor: context.actor)
       |> Map.new(fn record ->
-        {record.id,
-         Enum.reduce(through, record, fn
-           _, nil -> nil
-           k, r -> Map.get(r, k)
-         end)}
+        value =
+          Enum.reduce(through, record, fn
+            _, nil -> nil
+            k, r -> Map.get(r, k)
+          end)
+
+        {record.id, cast_cardinality(value, cardinality)}
       end)
 
     {:ok, res}
   end
+
+  # has_one traverses a has_many at the final hop, which yields a list.
+  # Reduce it to a single record (or nil) to match the declared cardinality.
+  defp cast_cardinality(value, :many), do: List.wrap(value)
+  defp cast_cardinality(value, _one), do: value |> List.wrap() |> List.first()
 end

--- a/lib/sanctum/villains/villain.ex
+++ b/lib/sanctum/villains/villain.ex
@@ -46,7 +46,7 @@ defmodule Sanctum.Villains.Villain do
     has_many :stage_sides, Sanctum.Games.CardSide do
       source_attribute :villain_name
       destination_attribute :name
-      filter expr(type == :villain)
+      filter expr(type == :villain and card.set == parent(set))
     end
   end
 

--- a/test/sanctum/heroes/hero_test.exs
+++ b/test/sanctum/heroes/hero_test.exs
@@ -1,0 +1,106 @@
+defmodule Sanctum.Heroes.HeroTest do
+  use Sanctum.DataCase, async: true
+
+  alias Sanctum.Heroes
+
+  describe "hero_side and alter_ego_side relationships" do
+    setup do
+      set_name = "test_hero_#{:rand.uniform(100_000)}"
+      base_code = "hero#{:rand.uniform(100_000)}"
+
+      {:ok, card} =
+        Sanctum.Games.Card
+        |> Ash.Changeset.for_create(:create, %{
+          base_code: base_code,
+          code: base_code,
+          set: set_name,
+          pack: set_name,
+          is_multi_sided: true
+        })
+        |> Ash.create()
+
+      {:ok, hero_side} =
+        Sanctum.Games.CardSide
+        |> Ash.Changeset.for_create(:create, %{
+          card_id: card.id,
+          name: "Test Hero",
+          code: "#{base_code}a",
+          side_identifier: "A",
+          is_primary_side: true,
+          type: :hero,
+          health: 11,
+          hand_size: 5,
+          attack: 2,
+          thwart: 2,
+          defense: 1
+        })
+        |> Ash.create()
+
+      {:ok, alter_ego_side} =
+        Sanctum.Games.CardSide
+        |> Ash.Changeset.for_create(:create, %{
+          card_id: card.id,
+          name: "Test Alter Ego",
+          code: "#{base_code}b",
+          side_identifier: "B",
+          is_primary_side: false,
+          type: :alter_ego,
+          health: 11,
+          hand_size: 6,
+          recover: 3
+        })
+        |> Ash.create()
+
+      {:ok, hero} =
+        Heroes.find_or_create_hero(%{
+          hero_name: "Test Hero",
+          alter_ego_name: "Test Alter Ego",
+          set: set_name,
+          base_code: base_code
+        })
+
+      %{
+        hero: hero,
+        card: card,
+        hero_side: hero_side,
+        alter_ego_side: alter_ego_side
+      }
+    end
+
+    test "hero_side loads the single hero card side", %{hero: hero, hero_side: hero_side} do
+      loaded = Ash.load!(hero, [:hero_side])
+
+      refute is_list(loaded.hero_side)
+      refute is_nil(loaded.hero_side)
+      assert %Sanctum.Games.CardSide{} = loaded.hero_side
+      assert loaded.hero_side.id == hero_side.id
+      assert loaded.hero_side.type == :hero
+      assert loaded.hero_side.health == 11
+    end
+
+    test "alter_ego_side loads the single alter_ego card side", %{
+      hero: hero,
+      alter_ego_side: alter_ego_side
+    } do
+      loaded = Ash.load!(hero, [:alter_ego_side])
+
+      refute is_list(loaded.alter_ego_side)
+      refute is_nil(loaded.alter_ego_side)
+      assert %Sanctum.Games.CardSide{} = loaded.alter_ego_side
+      assert loaded.alter_ego_side.id == alter_ego_side.id
+      assert loaded.alter_ego_side.type == :alter_ego
+    end
+
+    test "loads both sides distinctly at once", %{
+      hero: hero,
+      hero_side: hero_side,
+      alter_ego_side: alter_ego_side
+    } do
+      loaded = Ash.load!(hero, [:hero_side, :alter_ego_side])
+
+      assert loaded.hero_side.id == hero_side.id
+      assert loaded.alter_ego_side.id == alter_ego_side.id
+      assert loaded.hero_side.id != loaded.alter_ego_side.id
+    end
+  end
+end

--- a/test/sanctum/villains/villain_test.exs
+++ b/test/sanctum/villains/villain_test.exs
@@ -247,6 +247,74 @@ defmodule Sanctum.Villains.VillainTest do
       assert length(loaded_villain.stage_sides) == 1
       assert hd(loaded_villain.stage_sides).id == matching_side.id
     end
+
+    test "scopes stage sides by set when the same villain name exists in multiple sets" do
+      villain_name = "Duplicate Villain"
+      set1 = "test_dup_set_1_#{:rand.uniform(100_000)}"
+      set2 = "test_dup_set_2_#{:rand.uniform(100_000)}"
+
+      # Two villains sharing a name, but in different sets
+      {:ok, villain1} =
+        Villains.find_or_create_villain(%{villain_name: villain_name, set: set1})
+
+      {:ok, villain2} =
+        Villains.find_or_create_villain(%{villain_name: villain_name, set: set2})
+
+      # Stage side belonging to set1
+      {:ok, card1} =
+        Sanctum.Games.Card
+        |> Ash.Changeset.for_create(:create, %{
+          base_code: "dup1",
+          code: "dup1",
+          set: set1,
+          pack: set1
+        })
+        |> Ash.create()
+
+      {:ok, side1} =
+        Sanctum.Games.CardSide
+        |> Ash.Changeset.for_create(:create, %{
+          card_id: card1.id,
+          name: villain_name,
+          code: "dup1",
+          side_identifier: "A",
+          is_primary_side: true,
+          type: :villain,
+          stage: 1
+        })
+        |> Ash.create()
+
+      # Stage side belonging to set2
+      {:ok, card2} =
+        Sanctum.Games.Card
+        |> Ash.Changeset.for_create(:create, %{
+          base_code: "dup2",
+          code: "dup2",
+          set: set2,
+          pack: set2
+        })
+        |> Ash.create()
+
+      {:ok, side2} =
+        Sanctum.Games.CardSide
+        |> Ash.Changeset.for_create(:create, %{
+          card_id: card2.id,
+          name: villain_name,
+          code: "dup2",
+          side_identifier: "A",
+          is_primary_side: true,
+          type: :villain,
+          stage: 1
+        })
+        |> Ash.create()
+
+      loaded_villain1 = Ash.load!(villain1, [:stage_sides])
+      loaded_villain2 = Ash.load!(villain2, [:stage_sides])
+
+      # Each villain should only see the stage side from its own set
+      assert Enum.map(loaded_villain1.stage_sides, & &1.id) == [side1.id]
+      assert Enum.map(loaded_villain2.stage_sides, & &1.id) == [side2.id]
+    end
   end
 
   describe "read actions" do


### PR DESCRIPTION
## Summary

Two catalog-relationship correctness fixes in the heroes/villains domains, each covered by tests.

## What changed

- **Villain stage scoping** (`lib/sanctum/villains/villain.ex`): the `stage_sides` has_many joined `CardSide` only by `villain_name` and `type == :villain`, ignoring the villain's `set`. A villain whose name appears in multiple card sets would pull stage sides from ALL sets. The relationship is now scoped to the parent villain's set: `filter expr(type == :villain and card.set == parent(set))` (`set` lives on the parent `Card`, not on `CardSide`). Ash's `parent/1` works here; `GameVillain.advance_stage` still walks the relationship correctly.
- **Hero side loading** (`lib/sanctum/manual_relationships/has_one_through.ex`): the `HasOneThrough` manual relationship had two bugs. (a) It ignored the declared relationship filter (never used `context.query`), and (b) reducing through `:card_sides` (a has_many) produced a LIST, not a single record. Result: `hero_side`/`alter_ego_side` returned the wrong side (or a list). Since `Sanctum.Games.Changes.SetHealth` reads `hero.hero_side.health` on deck select, this was load-bearing. The fix builds the nested load so the final hop carries the relationship's filtered query (`[card: [card_sides: query]]`) and casts the result to the declared cardinality (single record for has_one, list for has_many).

## Tests

- New `test/sanctum/heroes/hero_test.exs`: asserts `hero_side` and `alter_ego_side` each load the single correct `%CardSide{}` (right `type`, not a list, not nil), individually and together. These failed before the `HasOneThrough` fix.
- New regression test in `test/sanctum/villains/villain_test.exs`: two villains sharing a name in different sets each see only their own set's stage sides.
- Full suite: 90 tests, 0 failures, 1 skipped.

## How to verify

```bash
git checkout fix/villain-stage-scoping
mix deps.get
# scoped tests for the two fixes
MIX_TEST_PARTITION=p3 mix test test/sanctum/heroes/hero_test.exs test/sanctum/villains/villain_test.exs test/sanctum/games/game_villain_test.exs
# full suite
MIX_TEST_PARTITION=p3 mix test
```

To confirm the hero fix catches a regression, revert `lib/sanctum/manual_relationships/has_one_through.ex` and re-run the hero test — it fails (wrong side returned).

Stacked on #31 (`feat/heros`) — merge that first; GitHub retargets this PR automatically when the base branch is merged and deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)