### PR TITLE
test: make MarvelCDB live-HTTP tests opt-in; handle transport errors

### DIFF
--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -429,6 +429,7 @@ defmodule Sanctum.MarvelCdb do
       {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
       {:ok, %Req.Response{status: 404}} -> {:error, :not_found}
       {:ok, %Req.Response{status: status}} -> {:error, "Unexpected status code: #{status}"}
+      {:error, exception} -> {:error, exception}
     end
   end
 end

--- a/test/sanctum/marvel_cdb_test.exs
+++ b/test/sanctum/marvel_cdb_test.exs
@@ -12,7 +12,7 @@ defmodule Sanctum.MarvelCdbTest do
     assert {:ok, _} = MarvelCdb.load_deck(mcdb_deck_id)
   end
 
-  @tag :integration
+  @tag :external
   test "loads Rhino villain stages and creates proper Villain resource" do
     # Load the three Rhino stage cards
     rhino_stage_codes = ["01094", "01095", "01096"]
@@ -136,7 +136,8 @@ defmodule Sanctum.MarvelCdbTest do
     end
   end
 
+  @tag :external
   test "loads spider man hero" do
-    _card = MarvelCdb.load_card("01001a")
+    assert {:ok, _card} = MarvelCdb.load_card("01001a")
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,5 @@
-ExUnit.start()
+# Tests tagged :external hit the live MarvelCDB API and are excluded by default
+# (they are non-deterministic and flake on network errors). Run them explicitly
+# with `mix test --include external`.
+ExUnit.start(exclude: [:external])
 Ecto.Adapters.SQL.Sandbox.mode(Sanctum.Repo, :manual)


### PR DESCRIPTION
## Summary
CI has been flaking because two `MarvelCdbTest` cases call the live marvelcdb.com API on every run; when the API returns a 500 or drops the socket, the build fails (and `handle_response/1` raised `CaseClauseError` on transport errors). This makes the test suite deterministic.

## What changed
- `test/sanctum/marvel_cdb_test.exs` — tagged `loads spider man hero` and the Rhino integration test `@tag :external` (the latter was `:integration`, which was never excluded). The Spider-Man test now also asserts `{:ok, _}`.
- `test/test_helper.exs` — `ExUnit.start(exclude: [:external])`; run the live tests with `mix test --include external`.
- `lib/sanctum/marvel_cdb.ex` — `handle_response/1` now returns `{:error, exception}` for transport errors instead of falling through to a `CaseClauseError`.

## Tests
94 tests, 0 failures, 2 excluded, 1 skipped (Elixir 1.16, `--warnings-as-errors`). Suite now runs offline in ~0.3s.

## How to verify
- `mix test` — deterministic, no network.
- `mix test --include external` — runs the live MarvelCDB tests (requires network).

## Priority
Recommend merging this **before** the other open PRs (#35, #38, #40) so their CI stops flaking on the live API; rebasing them on main afterward picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)