### PR TITLE
test: fix main — supply required card_id/game_id in stale fixtures

### DIFF
--- a/test/sanctum/decks/deck_test.exs
+++ b/test/sanctum/decks/deck_test.exs
@@ -181,7 +181,8 @@ defmodule Sanctum.Decks.DeckTest do
         hero_name: "She-Hulk",
         alter_ego_name: "Jennifer Walters",
         set: "she_hulk",
-        base_code: hero_card.base_code
+        base_code: hero_card.base_code,
+        card_id: hero_card.id
       })
 
     cards = create(Sanctum.Games.Card, count: 3)

--- a/test/sanctum/games/game_card_test.exs
+++ b/test/sanctum/games/game_card_test.exs
@@ -102,6 +102,7 @@ defmodule Sanctum.Games.GameCardTest do
         {:ok, game_card} =
           GameCard
           |> Ash.Changeset.for_create(:create, %{
+            game_id: game.id,
             game_player_id: game_player.id,
             card_id: card.id,
             zone: :hero_deck,

--- a/test/sanctum/games_test.exs
+++ b/test/sanctum/games_test.exs
@@ -525,7 +525,8 @@ defmodule Sanctum.GamesTest do
           hero_name: "Test Hero",
           alter_ego_name: "Test Alter Ego",
           set: "test_hero",
-          base_code: hero_card.base_code
+          base_code: hero_card.base_code,
+          card_id: hero_card.id
         })
 
       # A couple of playable cards for the deck.


### PR DESCRIPTION
## Summary
`main` went red after the refactor stack merged: two PRs developed on parallel branches each added a **required** field, and older fixtures on the other branch never set it. Individually every PR was green; combined, four tests fail.

## Root cause
- #38 made `Hero.card_id` required (allow_nil? false). Fixtures in the deck re-import test (#32) and `games_test` (#45 chain) call `find_or_create_hero` without `card_id`.
- #45 made `GameCard.game_id` required. The `game_card_test` deck fixture (#35) creates GameCards without `game_id`.

## What changed (tests only, no product code)
- `test/sanctum/decks/deck_test.exs` — re-import test hero fixture passes `card_id`.
- `test/sanctum/games_test.exs` — deck-select hero fixture passes `card_id`.
- `test/sanctum/games/game_card_test.exs` — deck-card fixture passes `game_id`.

## Tests
104 tests, 0 failures, 2 excluded, 1 skipped (Elixir 1.16, `--warnings-as-errors`).

## How to verify
`mix test` on main after merge — green.

Merge this promptly to get `main` green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)