### PR TITLE
ci: run on Elixir 1.18 / OTP 28 (match prod)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       MIX_ENV: dev
     strategy:
       matrix:
-        elixir: ["1.16"]
-        otp: ["26"]
+        elixir: ["1.18"]
+        otp: ["28"]
 
     steps:
       - name: Checkout repository
@@ -66,8 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ["1.16"]
-        otp: ["26"]
+        elixir: ["1.18"]
+        otp: ["28"]
 
     steps:
       - name: Checkout repository
@@ -104,8 +104,8 @@ jobs:
       MIX_ENV: test
     strategy:
       matrix:
-        elixir: ["1.16"]
-        otp: ["26"]
+        elixir: ["1.18"]
+        otp: ["28"]
     services:
       postgres:
         image: postgres:16

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 28.0.2
+elixir 1.18.4-otp-28

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Sanctum.MixProject do
     [
       app: :sanctum,
       version: "0.12.0",
-      elixir: "~> 1.15",
+      elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
## Summary
CI ran on **Elixir 1.16 / OTP 26** while production (`Dockerfile`) builds on **1.18.4 / OTP 28** — so CI wasn't testing what ships. This aligns CI with prod.

## Why
- Tests the toolchain we actually deploy.
- Satisfies the ecosystem floor — `ash_ai` (and others) declare `~> 1.17`; on 1.16 they emitted version warnings.
- Ends the recurring `mix.lock` `heroicons depth:` churn, which came from 1.16's mix disagreeing with the newer mix that generated the committed lock. Verified: `mix.lock` is unchanged under 1.18.

## What changed
- `.github/workflows/ci.yml` — all three job matrices: Elixir 1.16→1.18, OTP 26→28.
- `mix.exs` — `elixir: "~> 1.15"` → `"~> 1.17"` (document the real floor).
- Added `.tool-versions` (erlang 28.0.2, elixir 1.18.4-otp-28) so local dev matches CI and prod.

## Verification (locally under Elixir 1.18.4 / OTP 28)
- `mix compile --all-warnings --warnings-as-errors` — clean
- `mix format --check-formatted` — clean (no drift)
- `mix credo --min-priority=normal`, `mix sobelow --config --exit`, `mix deps.unlock --check-unused` — pass
- `mix test` — 107 tests, 0 failures, 2 excluded, 1 skipped

First of three stacked upgrade PRs (this → ash_authentication → major deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)