### PR TITLE
chore(db): migrate production database from Supabase to Neon

### DIFF
--- a/.agents/skills/neon-postgres/SKILL.md
+++ b/.agents/skills/neon-postgres/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: neon-postgres
+description: >-
+  Guides and best practices for working with Neon Serverless Postgres.
+  Covers setup, connection methods, branching, autoscaling, scale-to-zero,
+  read replicas, connection pooling, Neon Auth, and the Neon CLI, MCP server,
+  REST API, TypeScript SDK, and Python SDK.
+  Use when users ask about "Neon setup", "connect to Neon", "Neon project",
+  "DATABASE_URL", "serverless Postgres", "Neon CLI", "neon", "Neon MCP",
+  "Neon Auth", "@neondatabase/serverless", "@neondatabase/neon-js",
+  "scale to zero", "Neon autoscaling", "Neon read replica", or
+  "Neon connection pooling".
+---
+
+# Neon Serverless Postgres
+
+Guide the user through any Neon-related task: setup, connections, branching, and advanced features. Deliver a working Neon connection, a completed feature configuration, or a specific answer from the official Neon docs.
+
+Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.
+
+## Neon Documentation
+
+The Neon documentation is the source of truth for all Neon-related information. Always verify claims against the official docs before responding. Neon features and APIs evolve, so prefer fetching current docs over relying on training data.
+
+### Fetching Docs as Markdown
+
+Any Neon doc page can be fetched as markdown in two ways:
+
+1. **Append `.md` to the URL** (simplest): https://neon.com/docs/introduction/branching.md
+2. **Request `text/markdown`** on the standard URL: `curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branching`
+
+Both return the same markdown content. Use whichever method your tools support.
+
+### Finding the Right Page
+
+The docs index lists every available page with its URL and a short description:
+
+```
+https://neon.com/docs/llms.txt
+```
+
+Common doc URLs are organized in the topic links below. If you need a page not listed here, search the docs index: https://neon.com/docs/llms.txt. Don't guess URLs.
+
+## What Is Neon
+
+Use this for architecture explanations and terminology (organizations, projects, branches, endpoints) before giving implementation advice.
+
+Link: https://neon.com/docs/introduction/architecture-overview.md
+
+## Getting Started
+
+Use this section when guiding a user through first-time Neon setup.
+
+### Check Status Quo
+
+Before starting setup, inspect the user's codebase and environment:
+
+- Existing database connection code
+- Existing Neon MCP server or Neon CLI configuration
+- Existence of a `.env` file and `DATABASE_URL` environment variable
+- Existing ORM (Prisma, Drizzle, TypeORM) configuration
+
+### Self-Driving Setup With Neon's CLI or MCP Server
+
+Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run init with the `--agent` flag. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
+
+```bash
+npx -y neon@latest init --agent <agent-name>
+```
+
+Supported `--agent` values: `cursor`, `copilot`, `claude`, `claude-desktop`, `codex`, `opencode`, `cline`, `gemini-cli`, `goose`, `zed`.
+
+This installs the Neon extension (for Cursor/VS Code) or MCP server (for other agents), creates an API key, and adds the `neon-postgres` agent skill to the project.
+
+If `init` is not suitable, the individual steps can be run non-interactively:
+
+- **Extension:** `cursor --install-extension databricks.neon-local-connect`
+- **MCP server:** `npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a <agent-name>`
+- **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon-postgres --agent <agent-name> -y`
+
+For full CLI installation options, see https://neon.com/docs/reference/cli-install.md
+
+### Setup Flow
+
+**1. Select Organization and Project**
+
+Use MCP server or CLI to list organizations and projects. Let the user select an existing project or create a new one.
+
+**2. Get Connection String**
+
+Use MCP server or CLI to get the connection string. Store it in `.env` as `DATABASE_URL`. Read the file first before modifying to avoid overwriting existing values.
+
+**3. Pick Connection Method & Driver**
+
+Refer to the connection methods guide to pick the correct driver based on deployment platform: https://neon.com/docs/connect/choose-connection.md
+
+**4. User Authentication with Neon Auth (if needed)**
+
+Skip for CLI tools, scripts, or apps without user accounts. If the app needs auth: use MCP server `provision_neon_auth` tool, then see the auth overview (https://neon.com/docs/auth/overview.md) for setup. For auth + database queries, see the JavaScript SDK reference (https://neon.com/docs/reference/javascript-sdk.md).
+
+**5. ORM Setup (optional)**
+
+Check for existing ORM (Prisma, Drizzle, TypeORM). If none, ask if they want one. For Drizzle integration, see https://neon.com/docs/guides/drizzle.md.
+
+**6. Schema Setup**
+
+- Check for existing migration files or ORM schemas
+- If none: offer to create an example schema or design one together
+
+### Resume Support
+
+If resuming setup, check what's already configured (MCP connection, `.env` with `DATABASE_URL`, dependencies, schema) and continue from the next incomplete step.
+
+### Security Reminders
+
+Remind users to use environment variables for credentials, never commit connection strings, and use least-privilege database roles.
+
+## Connection Methods & Drivers
+
+Use this when you need to pick the correct transport and driver based on runtime constraints (TCP, HTTP, WebSocket, edge, serverless, long-running).
+
+Link: https://neon.com/docs/connect/choose-connection.md
+
+### Recommended: Drizzle + the right driver for your runtime
+
+Always pair Neon with an ORM such as **Drizzle** for easy schema management and migrations. Pick the driver based on how the runtime treats your code:
+
+- **Long-running or shared-runtime environments → node-postgres (`pg`).** Neon Functions, and any host where the function runtime is shared across requests / runs on fluid compute (e.g. **Vercel** with Fluid compute), keep a module-scope process alive across many requests. Open a `pg` pool **once at module scope** and reuse it across requests.
+- **Fully isolated serverless (Lambda-style) → Neon's serverless driver (`@neondatabase/serverless`).** Hosts like **Netlify** spin up a fresh, isolated instance per request, so a persistent TCP pool can't be reused; the serverless driver queries over HTTP and is built for this.
+
+**Neon Functions / Vercel / fluid compute — Drizzle + node-postgres:**
+
+```typescript
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import * as schema from "./schema";
+
+// Created once at module scope; reused by every request the instance handles.
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+const db = drizzle({ client: pool, schema });
+```
+
+On **Vercel** (Fluid compute) also attach the pool with `attachDatabasePool` from `@vercel/functions`, so the function runtime drains idle connections before an instance suspends:
+
+```typescript
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { attachDatabasePool } from "@vercel/functions";
+import * as schema from "./schema";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+attachDatabasePool(pool); // let the Vercel runtime manage the pooled connections
+const db = drizzle({ client: pool, schema });
+```
+
+**Netlify and other fully-isolated serverless — Drizzle + Neon serverless driver:**
+
+```typescript
+import { drizzle } from "drizzle-orm/neon-http";
+import { neon } from "@neondatabase/serverless";
+
+const sql = neon(process.env.DATABASE_URL!);
+const db = drizzle({ client: sql });
+```
+
+### Serverless Driver
+
+Use this for `@neondatabase/serverless` patterns, including HTTP queries, WebSocket transactions, and runtime-specific optimizations.
+
+Link: https://neon.com/docs/serverless/serverless-driver.md
+
+### Neon JS SDK
+
+Use this for combined Neon Auth + Data API workflows with PostgREST-style querying and typed client setup.
+
+Link: https://neon.com/docs/reference/javascript-sdk.md
+
+## Developer Tools
+
+Use this for local development enablement with `npx -y neon@latest init --agent <agent-name>`, VSCode extension setup, and Neon MCP server configuration.
+
+| Tool             | URL                                             |
+| ---------------- | ----------------------------------------------- |
+| CLI Init Command | https://neon.com/docs/reference/cli-init.md     |
+| VSCode Extension | https://neon.com/docs/local/vscode-extension.md |
+| MCP Server       | https://neon.com/docs/ai/neon-mcp-server.md     |
+| Neon CLI         | https://neon.com/docs/reference/neon-cli.md     |
+
+### Neon CLI
+
+Use this for terminal-first workflows, scripts, and CI/CD automation with `neon`.
+
+Link: https://neon.com/docs/reference/neon-cli.md
+
+## Neon Admin API
+
+The Neon Admin API can be used to manage Neon resources programmatically. It is used behind the scenes by the Neon CLI and MCP server, but can also be used directly for more complex automation workflows or when embedding Neon in other applications.
+
+### Neon REST API
+
+Use this for direct HTTP automation, endpoint-level control, API key auth, rate-limit handling, and operation polling.
+
+Link: https://neon.com/docs/reference/api-reference.md
+
+### Neon TypeScript SDK
+
+Use this when implementing typed programmatic control of Neon resources in TypeScript via `@neon/sdk` (the fetch-based, zero-dependency successor to `@neondatabase/api-client`).
+
+Link: https://neon.com/docs/reference/typescript-sdk.md
+
+### Neon Python SDK
+
+Use this when implementing programmatic Neon management in Python with the `neon-api` package.
+
+Link: https://neon.com/docs/reference/python-sdk.md
+
+## Neon Auth
+
+Use this for managed user authentication setup, UI components, auth methods, and Neon Auth integration pitfalls in Next.js and React apps.
+
+Link: https://neon.com/docs/auth/overview.md
+
+Neon Auth is also embedded in the Neon JS SDK. Depending on your use case, you may want to use the Neon JS SDK instead of Neon Auth alone. See https://neon.com/docs/connect/choose-connection.md for more details.
+
+## Neon Infrastructure as Code (`neon.ts`)
+
+`neon.ts` is Neon's branch config and infrastructure-as-code file: declare which services your branches have, get type-safe env vars, and program per-branch compute — all in TypeScript (see the `neon` skill for the full reference). Postgres always exists on every branch, so you never declare the database itself; what you codify here is the Postgres-adjacent surface — Neon Auth, the Data API, and per-branch compute settings (autoscaling and scale-to-zero).
+
+Add it with `@neon/config`:
+
+```bash
+npm i @neon/config
+```
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  auth: true, // Neon Auth (adds NEON_AUTH_* env vars)
+  dataApi: true, // Data API (adds NEON_DATA_API_URL); requires auth: true (or an external IdP)
+  // Postgres exists on every branch; tune its compute per branch:
+  branch: (branch) => {
+    if (branch.exists) return {}; // leave existing branches untouched
+    if (branch.isDefault) return { protected: true }; // prod keeps default compute
+    return {
+      ttl: "7d", // non-prod branches auto-expire (max 30d)
+      postgres: {
+        computeSettings: {
+          autoscalingLimitMinCu: 0.25, // scale to zero
+          autoscalingLimitMaxCu: 1, // keep dev/preview cheap
+          suspendTimeout: "5m",
+        },
+      },
+    };
+  },
+});
+```
+
+Reconcile the declaration from the CLI — the Neon equivalent of `terraform plan` / `apply`:
+
+```bash
+neon config status   # print the branch's live config
+neon config plan     # dry-run diff of what apply would change
+neon config apply    # provision the declared services / settings
+neon deploy          # alias for `neon config apply`
+```
+
+Because `neon checkout` applies the policy as it **creates** a branch, a fresh branch comes up with these compute settings (and Auth / Data API) already in place. Checking out an _existing_ branch never reconciles it — run `neon deploy` to apply changes.
+
+Since `neon.ts` is TypeScript, invalid combinations fail to compile with an actionable message: the Data API verifies requests with Neon Auth by default, so `dataApi: true` without `auth: true` is a type error (the fix — `auth: true`, or `authProvider: 'external'` with a `jwksUrl` — is in the message). See the `neon` skill's type-safe config note.
+
+Read the resulting env back, typed and validated against the policy, with `parseEnv` from `@neon/env`:
+
+```typescript
+import { parseEnv } from "@neon/env";
+import config from "./neon";
+
+const env = parseEnv(config);
+env.postgres.databaseUrl; // typed; enabling auth / dataApi above surfaces env.auth / env.dataApi
+```
+
+## Branching
+
+Use this when the user is planning isolated environments, schema migration testing, preview deployments, or branch lifecycle automation.
+
+Key points:
+
+- Branches are instant, copy-on-write clones (no full data copy).
+- Each branch has its own compute endpoint.
+- Use the neon CLI or MCP server to create, inspect, and compare branches.
+
+Link: https://neon.com/docs/introduction/branching.md
+
+For detailed branch creation workflows (normal vs schema-only branches, reset-from-parent, CLI/MCP selection), use the `neon-postgres-branches` skill if available
+
+Or fetch the full branching skill from the following URL:
+
+https://neon.com/docs/ai/skills/neon-postgres-branches/SKILL.md
+
+If this skill is not installed you can use the following command to install it:
+
+```bash
+npx skills add neondatabase/agent-skills --skill neon-postgres-branches
+```
+
+## Autoscaling
+
+Use this when the user needs compute to scale automatically with workload and wants guidance on CU sizing and runtime behavior.
+
+Link: https://neon.com/docs/introduction/autoscaling.md
+
+## Scale to Zero
+
+Use this when optimizing idle costs and discussing suspend/resume behavior, including cold-start trade-offs.
+
+Key points:
+
+- Idle computes suspend automatically (default 5 minutes, configurable) (unless disabled - launch & scale plan only)
+- First query after suspend typically has a cold-start penalty (around hundreds of ms)
+- Storage remains active while compute is suspended.
+
+Link: https://neon.com/docs/introduction/scale-to-zero.md
+
+## Instant Restore
+
+Use this when the user needs point-in-time recovery or wants to restore data state without traditional backup restore workflows.
+
+Key points:
+
+- History windows for instant restore depend on plan limits.
+- Users can create branches from historical points-in-time.
+- Time Travel queries can be used for historical inspection workflows.
+
+Link: https://neon.com/docs/introduction/branch-restore.md
+
+## Read Replicas
+
+Use this for read-heavy workloads where the user needs dedicated read-only compute without duplicating storage.
+
+Key points:
+
+- Replicas are read-only compute endpoints sharing the same storage.
+- Creation is fast and scaling is independent from primary compute.
+- Typical use cases: analytics, reporting, and read-heavy APIs.
+
+Link: https://neon.com/docs/introduction/read-replicas.md
+
+## Connection Pooling
+
+Use this when the user is in serverless or high-concurrency environments and needs safe, scalable Postgres connection management.
+
+Key points:
+
+- Neon pooling uses PgBouncer.
+- Add `-pooler` to endpoint hostnames to use pooled connections.
+- Pooling is especially important in serverless runtimes with bursty concurrency.
+
+Link: https://neon.com/docs/connect/connection-pooling.md
+
+## IP Allow Lists
+
+Use this when the user needs to restrict database access by trusted networks, IPs, or CIDR ranges.
+
+Link: https://neon.com/docs/introduction/ip-allow.md
+
+## Logical Replication
+
+Use this when integrating CDC pipelines, external Postgres sync, or replication-based data movement.
+
+Key points:
+
+- Neon supports native logical replication workflows.
+- Useful for replicating to/from external Postgres systems.
+
+Link: https://neon.com/docs/guides/logical-replication-guide.md

--- a/.agents/skills/neon/SKILL.md
+++ b/.agents/skills/neon/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: neon
+description: >-
+  Overview of the Neon platform for apps and agents, spanning Postgres, Auth,
+  Data API, and the new services: Object Storage, Compute Functions, and AI
+  Gateway. Use whenever "Neon" is mentioned for an overview of how to work with Neon and how to get started. Otherwise, the individual capabilities are the triggers: "object storage" or "S3-compatible
+  storage", "serverless functions", "background jobs", or
+  "run code near my database", "AI gateway", "LLM proxy",
+  "model routing", or "call an LLM" → AI Gateway; "database", "Postgres", or
+  "authentication" → Postgres and Auth.
+---
+
+# Neon
+
+Important: Neon is no longer just a Serverless Postgres provider. Neon is the backend for apps and agents with Serverless Postgres, Auth, Functions, Storage, and an AI Gateway: instant, branchable, serverless.
+
+Use this skill as the starting point for anything Neon: get an overview of its capabilities, find your way around the Neon agent skills and documentation, and follow best practices for getting started and for branch-first development workflows.
+
+## Platform Services
+
+Neon bundles several backend primitives for building apps and agents that all branch together with your project:
+
+- **Postgres** — Serverless Postgres that scales and branches with your app. _Generally available._
+- **Auth** — Managed authentication with users and sessions stored in Postgres. _Generally available._
+- **Object Storage** — S3-compatible object storage that branches with your projects. _Preview / early access._
+- **Compute Functions** — Long-running serverless functions running close to your database — for WebSocket servers, long agent HTTP streams, APIs, and server-sent event servers. _Preview / early access._
+- **AI Gateway** — One API for all frontier and open-source models, with routing, logging, and cost controls, powered by Databricks. _Preview / early access._
+
+### Preview Service Availability
+
+Object Storage, Compute Functions, and AI Gateway are preview (early access) features.
+
+Early access features are only available on net-new projects created in the `us-east-2` region; they cannot be enabled on existing projects for now. Before guiding a user through any of these services, confirm they are working with a new project in `us-east-2`. If not, they will need to create a new project in that region. Then confirm the user already has early access; otherwise, point them to the private beta sign-up: https://neon.com/blog/were-building-backends#access.
+
+## Architecture: how Neon fits
+
+Neon is **not** a place to host your full-stack app — it's backend primitives (Postgres, Auth, Object Storage, Functions, AI Gateway) that **compose with** the application platform you already use. Host the app on **Vercel** (or Netlify, or another frontend/app host); Neon is the backend it talks to.
+
+A typical setup:
+
+- **Full-stack app on Vercel** (or Netlify) — e.g. Next.js or TanStack Start. It owns your UI and auth (e.g. **Neon Auth**) and talks directly to your **Neon Postgres** database and **Neon Object Storage**.
+- **Reach for Neon Functions when you outgrow the host's limits** — a WebSocket or SSE server, or long-running agents that risk timing out on short, lambda-style serverless. Run that one piece on a Neon Function, next to your data.
+
+You can also move your **whole backend control plane** onto Neon Functions. This is especially useful when the frontend is **client-only** rather than full-stack — TanStack Router, React Router in client mode, and similar SPAs hosted on Vercel or Netlify. The client talks **directly to Neon Functions**, where you build REST APIs and request/response agents, host **MCP servers**, and run anything stateful or that should live close to Postgres and Object Storage. Secure these functions like any standalone REST API — verify a JWT or API key at the top of each handler (see the `neon-functions` skill).
+
+Because Functions are just your backend, they compose with a full-stack app too: if you already have a backend (Next.js route handlers, etc.), Neon Functions sit alongside it, and you can **move pieces between the two** — e.g. relocate a long-running agent or a stateful WebSocket server off your host onto a Function when it needs more runtime.
+
+## Neon Documentation
+
+The Neon documentation is the source of truth for all Neon-related information. Always verify claims against the official docs before responding. Neon features and APIs evolve, so prefer fetching current docs over relying on training data.
+
+### Fetching Docs as Markdown
+
+Any Neon doc page can be fetched as markdown in two ways:
+
+1. **Append `.md` to the URL** (simplest): https://neon.com/docs/introduction/branching.md
+2. **Request `text/markdown`** on the standard URL: `curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branching`
+
+Both return the same markdown content. Use whichever method your tools support.
+
+### Finding the Right Page
+
+The docs index lists every available page with its URL and a short description:
+
+```
+https://neon.com/docs/llms.txt
+```
+
+Common doc URLs are organized in the topic links below. If you need a page not listed here, search the docs index: https://neon.com/docs/llms.txt. Don't guess URLs.
+
+## Choosing the Right Skill
+
+- Working with the database, connections, schema, queries, autoscaling, or the CLI/MCP/API → `neon-postgres`.
+- Choosing or creating the right branch type for dev, preview, test, or CI workflows → `neon-postgres-branches`.
+- Storing and serving files (uploads, images, blobs) that branch with the database → `neon-object-storage`.
+- Deploying long-running or streaming serverless functions — APIs, agents, SSE/WebSocket servers — next to the database → `neon-functions`.
+- Calling an LLM or routing across model providers with one credential → `neon-ai-gateway`.
+- Provisioning instant, claimable temporary Postgres databases (for example, one per end user or demo) → `claimable-postgres`.
+- Diagnosing or fixing excessive Postgres egress (network data-transfer) costs in a codebase → `neon-postgres-egress-optimizer`.
+
+### Installing the Right Skill
+
+First check whether the target skill is already installed and accessible (for example, it appears in the available skills list or its `SKILL.md` is present). If it is, use it directly. If it is not installed, install it via the `skills` CLI with `npx`/`bunx`:
+
+```bash
+npx skills add neondatabase/agent-skills -s <skill-name>
+```
+
+Replace `<skill-name>` with the skill you need (for example, `neon-object-storage`, `neon-functions`, or `neon-ai-gateway`). Useful flags:
+
+- `-g` — install globally instead of into the current project.
+- `-y` — non-interactive mode (skip prompts).
+- `-a <agent-name>` — pick the target agent(s) for non-interactive mode.
+
+For example, to install the object storage skill globally for a specific agent without prompts:
+
+```bash
+npx skills add neondatabase/agent-skills -s neon-object-storage -g -y -a <agent-name>
+```
+
+## Getting Started with Neon
+
+Use this section when guiding a user through first-time Neon setup, or when adding a new Neon service (Auth, object storage, functions, and so on) to a project that is already onboarded (for example, one already using Neon Postgres).
+
+### Check Status Quo
+
+Before starting setup, inspect the user's codebase and environment:
+
+- Existing database connection code
+- Existing `.neon` or `neon.ts` files in the workspace
+- Existing Neon MCP server or Neon CLI configuration
+- Existence of a `.env` file and `DATABASE_URL` environment variable
+- Existing ORM (Prisma, Drizzle, TypeORM) configuration
+
+### Self-Driving Setup With Neon's CLI or MCP Server
+
+Offer to inspect existing connected Neon projects or create new ones using the Neon CLI or MCP server. If neither is set up yet, run `npx -y neon init`. Use `npx -y` to skip the package install prompt. Auth is handled automatically. If the user is not logged in, it opens their browser for OAuth and waits for completion before proceeding.
+
+```bash
+npx -y neon@latest init
+```
+
+This installs the Neon CLI and MCP server globally, installs the VSCode extension (for Cursor/VS Code), and adds the `neon` and `neon-postgres` agent skills to the project.
+
+If `init` is not suitable, the individual steps can be run non-interactively, using the user's preferred package manager (npm, bun, pnpm):
+
+- **CLI:** `npm i -g neon`
+- **Extension:** `cursor --install-extension databricks.neon-local-connect`
+- **MCP server:** `npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a <agent-name>`
+- **Agent skill:** `npx skills add neondatabase/agent-skills --skill neon-postgres --skill neon --agent <agent-name> -y`
+
+Prefer the CLI over the MCP server unless the user instructs otherwise, since it provides more capabilities, including deploying Neon Functions. For full CLI installation options, see https://neon.com/docs/reference/cli-install.md
+
+### Setup Flow
+
+Once the CLI, MCP server, and agent skills are installed, ensure the local workspace is linked to a Neon project through the `neon init` flow. If it isn't, run `npx -y neon link` to let the user interactively link a project. This produces a `.neon` file pointing to the organization, project, and branch the user wants to work with.
+
+For each Neon service, consult that component's agent skill for service-specific setup instructions (Functions, Postgres, Object Storage, Gateway, and so on).
+
+### Resume Support
+
+If resuming setup, check what's already configured (MCP connection, `.env` with `DATABASE_URL`, dependencies, schema) and continue from the next incomplete step.
+
+### Security Reminders
+
+Remind users to use environment variables for credentials, never commit connection strings, and use least-privilege database roles.
+
+## Branch-First Dev Flow
+
+Default to a branch-first loop that mirrors `git`: one isolated Neon branch per feature, so nothing leaks between features and there are no shared connection strings to copy around. Two commands drive it — `link` once per project, then `checkout` per feature — and a third, `env pull`, runs automatically under the hood so the branch you pin is immediately usable:
+
+- `neon link` — Interactively links the workspace to a Neon org, project, and branch, writing the IDs to a git-ignored `.neon` file. Run once per project. Once linked, project- and branch-scoped commands no longer need `--project-id` or `--branch` (for example, `neon branch list`).
+- `neon checkout <branch-name>` — Creates the branch if it doesn't exist, or checks out the existing one, by updating only the branch pointer in `.neon`. Run without a name for an interactive picker. It does not touch code or local Postgres.
+- `neon env pull` — Fetches the current branch's Neon environment variables (`DATABASE_URL`, …) into your existing `.env`, or `.env.local` if you don't have one (override the target with `--file`). No branch ID needed; it reads `.neon`. **`link` and `checkout` run this for you by default**, so you rarely call it directly.
+
+Run `link` once when starting on a project, then `checkout` per feature:
+
+```bash
+neon link                     # once; also pulls the linked branch's env
+neon checkout dev-add-search  # per feature; also pulls the branch's env
+```
+
+Because `link` and `checkout` pull env by default, the branch's `DATABASE_URL` lands in your local `.env` automatically — build against it, then `checkout` the next branch and repeat. As the agent, drive this loop yourself: run `checkout` between tasks to get a fresh, isolated database per feature with no shared state to corrupt.
+
+### Updating `.neon` without interactive prompts
+
+Plain `neon link` / `neon checkout` prompt interactively, which an agent can't answer. Use one of these non-interactive paths instead:
+
+- **`neon link --agent`** — a JSON state machine for agents. Each call returns a single JSON object with a `status` (`needs_org` → `needs_project` → `needs_project_details` → `linked`, or `error`), the available `options`, and the exact `next_command_template` to run next. Drive it step by step until `status: "linked"`. (Errors also come back as JSON with exit code 1, so you can always parse the result.)
+- **`neon set-context --project-id <id> --org-id <id> --branch-id <id>`** — when you already know the IDs, write all three into `.neon` in one shot. This is a **destructive write**: it replaces the file's contents entirely with exactly these fields, so it's the most direct way to point `.neon` at a specific org / project / branch.
+
+Both avoid prompts entirely; reach for `set-context` when you have the IDs and `link --agent` when you need to discover them.
+
+### Opting out of local env vars
+
+If env vars are injected at runtime instead of written to disk — or you simply don't want secrets in the working tree — pass `--no-env-pull` to `link` / `checkout` and supply the env another way:
+
+- `neon-env run -- <your dev command>` (from `@neon/env`) fetches the branch's vars from your `neon.ts` and injects them into the child process at runtime — no `.env` file needed. This is the runtime counterpart to the on-disk `env pull`.
+- `neon-env export` (from `@neon/env`) prints the branch's env to stdout as dotenv lines or, with `--format json`, JSON — for piping into another env manager rather than running a command. For example, [varlock](https://varlock.dev) can bulk-load it from a `.env.schema` with `@setValuesBulk(exec("neon-env export --format json"), format=json)`.
+- `fetchEnv` from `@neon/env` is the programmatic version of the same thing: resolve the branch's env in code at runtime instead of shelling out to `neon-env run`.
+- `neon dev` injects the same vars into your local dev server — it's part of Neon Functions local development (a private preview feature).
+
+When an agent should not write a local `.env`, instruct it (for example in your `AGENTS.md`) to run `neon checkout <branch> --no-env-pull` and rely on runtime injection.
+
+For reading env you _already_ have on disk (typed and validated against your `neon.ts`), use `parseEnv` — see [Neon Infrastructure as Code](#neon-infrastructure-as-code) below.
+
+## Neon Infrastructure as Code
+
+`neon.ts` is Neon's branch config and infrastructure-as-code file: declare which Neon services your project's branches should have, get type-safe env vars, and program branch settings — all in TypeScript. It's the config layer for Neon as a platform, and it composes with the branch-first loop above. Add it with `@neon/config`:
+
+```bash
+npm i @neon/config
+```
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+});
+```
+
+### Provision services with neon config
+
+Every project ships with serverless Postgres; `neon.ts` lets you also declare Neon Auth and the Data API today, with Functions, buckets, and the AI Gateway under a `preview` block — every service for the branch composes in one file:
+
+```typescript
+// neon.ts
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+  preview: {
+    functions: { /* ... */ }, // see the neon-functions skill
+    buckets: { /* ... */ },    // see the neon-object-storage skill
+    aiGateway: true,           // see the neon-ai-gateway skill
+  },
+});
+```
+
+Reconcile the declaration from the CLI — the Neon equivalent of `terraform status` / `plan` / `apply`:
+
+```bash
+neon config status   # print the branch's live config (read-only)
+neon config plan     # dry-run diff of what apply would change (read-only)
+neon config apply    # provision the declared services
+neon deploy          # alias for `neon config apply`
+```
+
+`config status` and `config plan` only read state. `apply` / `deploy` — like `link` and `checkout` — provision the declared services **and then pull the branch's env into your local `.env.local`** (e.g. `Pulled 5 Neon variables into .env.local: DATABASE_URL, …`), so your local env always matches what's deployed.
+
+### Type-safe env vars with parseEnv
+
+`@neon/env`'s `parseEnv` takes your `neon.ts` config object and returns a parsed, typed env object, validated against the services you declared. The shape of `env` follows your config — enable `auth` and you get `env.auth`, enable `dataApi` and you get `env.dataApi` — and missing variables are flagged with clear errors (for you and your agents). Use it to read env you already have (typically pulled into `.env` by `checkout` / `env pull`); for fetching env at runtime without a file, reach for `fetchEnv` / `neon-env run` instead.
+
+```bash
+npm i @neon/env
+```
+
+```typescript
+import { parseEnv } from "@neon/env";
+import config from "./neon";
+
+const env = parseEnv(config);
+
+console.log(env.postgres.databaseUrl);
+console.log(env.auth.baseUrl);
+```
+
+By default `parseEnv` requires _every_ variable your config implies. When a process only uses a subset — a common case in frameworks like Next.js, where you might read `DATABASE_URL` but never the unpooled URL — pass an array of env-var keys to require and return only those. The keys are typesafe: autocomplete only offers variables your config enables, and the returned shape is narrowed to exactly what you selected (so unselected variables are neither enforced nor present).
+
+```typescript
+import { parseEnv } from "@neon/env";
+import config from "./neon";
+
+// Only DATABASE_URL is required and returned; DATABASE_URL_UNPOOLED is not enforced.
+const { postgres } = parseEnv(config, ["DATABASE_URL"]);
+console.log(postgres.databaseUrl);
+
+// Selecting across services — only these keys are validated/returned.
+const env = parseEnv(config, ["DATABASE_URL", "NEON_AUTH_BASE_URL"]);
+console.log(env.postgres.databaseUrl, env.auth.baseUrl);
+```
+
+### How checkout composes with neon.ts
+
+When a `neon.ts` is present, `neon checkout` applies your policy as it **creates** a branch, so a fresh branch comes up with its declared settings and services already in place. Checking out an _existing_ branch never reconciles it — apply config changes to it explicitly with `neon config apply` (or `neon deploy`). The bundled `env pull` also checks `neon.ts` against the linked branch and fails fast if the branch is missing a declared service, pointing you at `neon deploy` to provision it, so your local env and the remote branch never drift apart silently.
+
+### Branch configuration
+
+Beyond services, `neon.ts` can program what configuration _new_ branches receive via the `branch` property — a function of the branch being evaluated that returns its settings:
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+  branch: (branch) => {
+    if (branch.exists) {
+      // leave existing branches untouched
+      return {};
+    }
+    if (branch.name.startsWith("dev")) {
+      return {
+        ttl: "7d", // clean up the branch after 7 days
+        postgres: {
+          computeSettings: {
+            autoscalingLimitMinCu: 0.25, // scale to zero
+            autoscalingLimitMaxCu: 1, // keep it cheap
+            suspendTimeout: "5m",
+          },
+        },
+      };
+    }
+    return {};
+  },
+});
+```
+
+The `branch` function receives the target branch (its `name`, whether it `exists` yet, whether it's the default, and more) and returns the tuning you want. Here new `dev-*` branches get a 7-day TTL so they clean themselves up, plus a cheap scale-to-zero compute profile, while existing branches and everything else fall through to the defaults. Because `neon checkout` applies this policy on create, a fresh `dev-*` branch comes up with these settings already in place.
+
+### Type-safe config: invalid setups don't compile
+
+Because `neon.ts` is TypeScript, the compiler catches invalid infrastructure before you ever deploy — and Neon encodes the actual rules (and their fixes) into the types, so the error tells you what to do rather than failing with a useless `Type 'true' is not assignable to type 'never'`. The canonical case: the Data API verifies requests with Neon Auth by default, so enabling it on its own is a type error _on_ `dataApi`:
+
+```typescript
+export default defineConfig({
+  dataApi: true, // type error: `dataApi` (default authProvider 'neon') requires Neon Auth
+});
+```
+
+The message names both fixes, so pick one:
+
+```typescript
+// 1. Enable Neon Auth (the default Data API auth provider):
+export default defineConfig({ auth: true, dataApi: true });
+
+// 2. Or verify a third-party IdP instead of Neon Auth:
+export default defineConfig({
+  dataApi: { authProvider: "external", jwksUrl: "https://your-idp/.well-known/jwks.json" },
+});
+```
+
+Treat a `neon.ts` type error as the config telling you which services must go together — read the message, it spells out the valid combinations.
+
+## Gotchas
+
+### Neon Auth: "invalid domain"
+
+Neon Auth only redirects back to domains on its trusted-domains list. Anytime the domain your app runs on changes — a new production custom domain, a new deploy/preview URL, moving from `localhost` to a hosted environment, and so on — you must register the new domain with Neon Auth. Otherwise sign-in and OAuth callbacks fail with an **`invalid domain`** error because the redirect target isn't trusted.
+
+The easiest way to fix this is the CLI. With the workspace linked to the project (see the branch-first flow above), add the new domain to the trusted list:
+
+```bash
+neon neon-auth domain add <domain>   # e.g. neon neon-auth domain add https://app.example.com
+neon neon-auth domain list           # verify what's currently trusted
+neon neon-auth domain delete <domain> # remove one you no longer use
+```
+
+If the workspace isn't linked, pass `--project-id <id>` (and `--branch <id|name>`) explicitly. For local development, `neon neon-auth domain allow-localhost` manages whether `localhost` is permitted. Register the domain before pointing users at the new URL, so they never hit the `invalid domain` error.

--- a/.neon
+++ b/.neon
@@ -1,0 +1,4 @@
+{
+  "orgId": "org-odd-heart-71452058",
+  "projectId": "still-violet-26861131"
+}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,7 +35,14 @@ if config_env() == :prod do
   maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
 
   config :sanctum, Sanctum.Repo,
-    # ssl: true,
+    ssl: [
+      verify: :verify_peer,
+      cacerts: :public_key.cacerts_get(),
+      server_name_indication: String.to_charlist(URI.parse(database_url).host),
+      customize_hostname_check: [
+        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+      ]
+    ],
     url: database_url,
     pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
     # For machines with several cores, consider starting multiple pools of `pool_size`

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "neon": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/neon/SKILL.md",
+      "computedHash": "1159ab3e02a317e45a6cf0a42c0138b173ead24921b2712b5ef8c90a7a5ef89d"
+    },
+    "neon-postgres": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "skillPath": "skills/neon-postgres/SKILL.md",
+      "computedHash": "800cc5890f74962e4e0dc15584cc17ea6f4c49f73dda35704f9630981abc3e5d"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Moves the production database from Supabase to a Neon serverless Postgres project (`aws-us-east-1`, adjacent to Fly `iad`). Neon's free tier matches this app's scale-to-zero deployment: compute suspends alongside the Fly machines, and branching gives us copy-on-write clones for testing migrations.

## Changes

- **`config/runtime.exs`** — enable TLS for the prod Repo with full peer verification: system CAs via `:public_key.cacerts_get/0`, SNI derived from the `DATABASE_URL` host, and the `https` wildcard hostname match fun. Neon requires TLS; the Supabase setup ran without `ssl`.
- **`.neon`** — Neon CLI project context (org/project ids only, no secrets).
- **`.agents/skills/` + `skills-lock.json`** — neon-postgres agent skills installed by `neon init`.

## Ops (already done, outside this diff)

- `DATABASE_URL` is canonical in Doppler (`prd`) and set on Fly
- `SECRET_KEY_BASE` / `TOKEN_SIGNING_SECRET` rotated and consolidated into Doppler
- Deployed and verified: app serving 200s against Neon Postgres 18; migrations ran via the release command
- Supabase project can be deleted once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)