### PR TITLE
ci(fly): use Depot builder to fix deploy (drop --depot=false)

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # allow manual redeploys from the Actions tab / gh CLI
 jobs:
   deploy:
     name: Deploy app
@@ -13,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only --depot=false
+      - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Problem
Fly Deploy fails on every `main` push with:
```
WARN Failed to start remote builder heartbeat: unauthorized
Error: failed to fetch an image or build from source: unauthorized
```

## Root cause (not the token)
The token is valid — the failure is at the **builder** layer. The workflow used `flyctl deploy --remote-only --depot=false`. `--depot=false` opts out of Depot (Fly's managed builder) and forces the **legacy remote builder**, which needs a `fly-builder-*` machine in the org. There is **none**, and an **app-scoped deploy token can't provision org-level resources**, so it fails `unauthorized`. Local `fly deploy` works only because full user auth *can* create a builder.

## Fix
- Drop `--depot=false` → `flyctl deploy --remote-only`, so flyctl uses **Depot** (managed, ephemeral, needs no org builder, works with a deploy token). This is Fly's current recommended CI command.
- Add a `workflow_dispatch` trigger so deploys can be re-run manually (Actions tab or `gh workflow run fly-deploy.yml`) without a dummy commit.

## Verification
This workflow only runs on push to `main` (or manual dispatch), so it can't be exercised from a PR branch. **On merge it triggers a deploy** — or trigger it manually afterward. If Depot turns out not to be enabled for the org, the guaranteed fallback is `--local-only` (build in the runner and push with the deploy token); say the word and I'll switch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)