### PR TITLE
feat(cards): sync catalog from MarvelCDB with images mirrored to Tigris

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -63,6 +63,14 @@ config :sanctum,
   generators: [timestamp_type: :utc_datetime],
   ash_domains: [Sanctum.Accounts, Sanctum.Decks, Sanctum.Games, Sanctum.Heroes, Sanctum.Villains]
 
+# Public base URL of the bucket that mirrors MarvelCDB card scans (see
+# `mix sanctum.sync_cards`). Dev and prod share the same public bucket.
+config :sanctum, :card_image_base_url, "https://sanctum-cards.fly.storage.tigris.dev"
+
+# Extra Req options merged into every MarvelCDB request; test.exs uses this
+# to route requests to a Req.Test stub.
+config :sanctum, :marvel_cdb_req_options, []
+
 # Configures the endpoint
 config :sanctum, SanctumWeb.Endpoint,
   url: [host: "localhost"],

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,6 @@
 import Config
 config :sanctum, Oban, testing: :manual
+config :sanctum, :marvel_cdb_req_options, plug: {Req.Test, Sanctum.MarvelCdb}
 config :sanctum, token_signing_secret: "/oZ9ck2w3h4oPYA4x7ZebHnqCh1MKXIp"
 config :bcrypt_elixir, log_rounds: 1
 config :ash, policies: [show_policy_breakdowns?: true]

--- a/lib/mix/tasks/sanctum.sync_cards.ex
+++ b/lib/mix/tasks/sanctum.sync_cards.ex
@@ -1,0 +1,60 @@
+defmodule Mix.Tasks.Sanctum.SyncCards do
+  @shortdoc "Syncs Marvel Champions cards and images from MarvelCDB"
+
+  @moduledoc """
+  Upserts the card catalog from MarvelCDB into the database and mirrors card
+  scans into the public bucket.
+
+      mix sanctum.sync_cards                  # all cards + images
+      mix sanctum.sync_cards --pack core      # one pack (repeatable)
+      mix sanctum.sync_cards --skip-images    # card data only
+      mix sanctum.sync_cards --images-only    # bucket mirror only
+      mix sanctum.sync_cards --dry-run        # report counts, write nothing
+      mix sanctum.sync_cards --force          # re-upload existing objects
+
+  Image mirroring needs `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+  `AWS_ENDPOINT_URL_S3`, and `BUCKET_NAME` in the environment. The bucket is
+  shared between dev and prod, so images only ever need mirroring once; sync
+  prod card data with:
+
+      fly ssh console -a sanctum -C "/app/bin/sanctum eval 'Sanctum.Release.sync_cards()'"
+  """
+
+  use Mix.Task
+
+  @requirements ["app.start"]
+
+  @switches [
+    all: :boolean,
+    pack: :keep,
+    images_only: :boolean,
+    skip_images: :boolean,
+    dry_run: :boolean,
+    force: :boolean
+  ]
+
+  @impl true
+  def run(argv) do
+    {opts, _argv} = OptionParser.parse!(argv, strict: @switches)
+
+    packs =
+      case Keyword.get_values(opts, :pack) do
+        [] -> :all
+        packs -> packs
+      end
+
+    sync_opts = [
+      packs: packs,
+      data?: not Keyword.get(opts, :images_only, false),
+      images?: not Keyword.get(opts, :skip_images, false),
+      dry_run?: Keyword.get(opts, :dry_run, false),
+      force?: Keyword.get(opts, :force, false)
+    ]
+
+    case Sanctum.CardSync.run(sync_opts) do
+      {:ok, _summary} -> :ok
+      {:error, %{}} -> Mix.raise("Card sync completed with failures (see output above)")
+      {:error, reason} -> Mix.raise("Card sync failed: #{inspect(reason)}")
+    end
+  end
+end

--- a/lib/sanctum/card_images.ex
+++ b/lib/sanctum/card_images.ex
@@ -1,0 +1,120 @@
+defmodule Sanctum.CardImages do
+  @moduledoc """
+  Mirrors MarvelCDB card scans into the public object-storage bucket and builds
+  the public URLs the app renders from.
+
+  Rendering never needs credentials — `image_url` on card sides points straight
+  at the public bucket. Only `mirror/2` (run from `mix sanctum.sync_cards`)
+  needs the S3 env vars: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+  `AWS_ENDPOINT_URL_S3`, and `BUCKET_NAME`.
+  """
+
+  @user_agent "sanctum (personal Marvel Champions smart table; one-time mirror)"
+
+  @doc """
+  Bucket object key for a MarvelCDB `imagesrc` path.
+
+  Filenames are taken verbatim from `imagesrc` — MarvelCDB's naming doesn't
+  follow card codes (`01097.png` is the front of `01097a`; extensions vary
+  between `.png` and `.jpg`), so the basename must never be reconstructed.
+  """
+  def object_key(nil), do: nil
+  def object_key(""), do: nil
+  def object_key(imagesrc) when is_binary(imagesrc), do: "cards/" <> Path.basename(imagesrc)
+
+  @doc "Public bucket URL for a MarvelCDB `imagesrc` path, or nil."
+  def public_url(imagesrc) do
+    case object_key(imagesrc) do
+      nil -> nil
+      key -> base_url() <> "/" <> key
+    end
+  end
+
+  def base_url, do: Application.fetch_env!(:sanctum, :card_image_base_url)
+
+  @doc "Whether the object already exists in the bucket (unsigned HEAD on the public URL)."
+  def exists?(key) when is_binary(key) do
+    case Req.head(base_url() <> "/" <> key, retry: false) do
+      {:ok, %Req.Response{status: 200}} -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  Downloads one scan from marvelcdb.com and uploads it to the bucket.
+
+  Skips the download entirely when the object already exists (unless
+  `force: true`), which makes interrupted syncs resumable by re-running.
+
+  Returns `{:ok, :uploaded | :skipped | :no_image}` or `{:error, reason}`.
+  """
+  def mirror(imagesrc, opts \\ []) do
+    case object_key(imagesrc) do
+      nil ->
+        {:ok, :no_image}
+
+      key ->
+        if not Keyword.get(opts, :force, false) and exists?(key) do
+          {:ok, :skipped}
+        else
+          download_and_upload(imagesrc, key)
+        end
+    end
+  end
+
+  defp download_and_upload(imagesrc, key) do
+    with {:ok, body} <- download(imagesrc),
+         :ok <- upload(key, body) do
+      {:ok, :uploaded}
+    end
+  end
+
+  defp download(imagesrc) do
+    source =
+      if String.starts_with?(imagesrc, "http"),
+        do: imagesrc,
+        else: "https://marvelcdb.com" <> imagesrc
+
+    # Unlike the API (where 500 means "not found"), scans are static files —
+    # transient errors are worth retrying, and a missing scan is a plain 404.
+    source
+    |> Req.get([headers: [user_agent: @user_agent], max_retries: 2] ++ req_options())
+    |> case do
+      {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
+      {:ok, %Req.Response{status: status}} -> {:error, {:download_failed, status, imagesrc}}
+      {:error, exception} -> {:error, {:download_failed, exception, imagesrc}}
+    end
+  end
+
+  defp upload(key, body) do
+    endpoint = System.fetch_env!("AWS_ENDPOINT_URL_S3")
+    bucket = System.fetch_env!("BUCKET_NAME")
+
+    "#{endpoint}/#{bucket}/#{key}"
+    |> Req.put(
+      body: body,
+      headers: [content_type: content_type(key)],
+      aws_sigv4: [
+        access_key_id: System.fetch_env!("AWS_ACCESS_KEY_ID"),
+        secret_access_key: System.fetch_env!("AWS_SECRET_ACCESS_KEY"),
+        service: :s3,
+        region: "auto"
+      ]
+    )
+    |> case do
+      {:ok, %Req.Response{status: status}} when status in 200..299 -> :ok
+      {:ok, %Req.Response{status: status}} -> {:error, {:upload_failed, status, key}}
+      {:error, exception} -> {:error, {:upload_failed, exception, key}}
+    end
+  end
+
+  defp content_type(key) do
+    case Path.extname(key) do
+      ".png" -> "image/png"
+      ext when ext in [".jpg", ".jpeg"] -> "image/jpeg"
+      _ -> "application/octet-stream"
+    end
+  end
+
+  defp req_options, do: Application.get_env(:sanctum, :marvel_cdb_req_options, [])
+end

--- a/lib/sanctum/card_sync.ex
+++ b/lib/sanctum/card_sync.ex
@@ -1,0 +1,156 @@
+defmodule Sanctum.CardSync do
+  @moduledoc """
+  Bulk-syncs the Marvel Champions card catalog from MarvelCDB.
+
+  Card data upserts into Postgres via `Sanctum.MarvelCdb.sync_entries/2` with
+  `image_url` pointing at the public bucket; scans are mirrored into that
+  bucket once via `Sanctum.CardImages.mirror/2`. Everything is idempotent —
+  re-running updates card data and skips images already in the bucket, so an
+  interrupted run resumes by re-running.
+
+  Entry points: `mix sanctum.sync_cards` (dev) and
+  `Sanctum.Release.sync_cards/1` (prod, data only — the bucket is shared).
+  """
+
+  alias Sanctum.CardImages
+  alias Sanctum.MarvelCdb
+
+  # Pause between actual downloads from marvelcdb.com — the API asks
+  # consumers to be polite. Skipped objects don't sleep.
+  @download_pause_ms 200
+  @progress_every 25
+
+  @doc """
+  Runs the sync. Options:
+
+    * `:packs` — `:all` (default, one all-cards request) or a list of pack codes
+    * `:data?` — upsert cards/sides (default true)
+    * `:images?` — mirror scans to the bucket (default true; needs AWS env vars)
+    * `:dry_run?` — report counts without writing (default false)
+    * `:force?` — re-upload images that already exist (default false)
+
+  Returns `{:ok, summary}`, `{:error, summary}` when any card or image failed
+  (the run still processes everything), or `{:error, reason}` when the payload
+  fetch itself failed.
+  """
+  def run(opts \\ []) do
+    packs = Keyword.get(opts, :packs, :all)
+
+    with {:ok, entries} <- fetch_entries(packs) do
+      entries = Enum.uniq_by(entries, & &1["code"])
+
+      if Keyword.get(opts, :dry_run?, false) do
+        report_dry_run(entries)
+      else
+        run_sync(entries, opts)
+      end
+    end
+  end
+
+  defp run_sync(entries, opts) do
+    data = if Keyword.get(opts, :data?, true), do: sync_data(entries)
+
+    images =
+      if Keyword.get(opts, :images?, true),
+        do: sync_images(entries, Keyword.get(opts, :force?, false))
+
+    summary = %{data: data, images: images}
+
+    if failed?(summary), do: {:error, summary}, else: {:ok, summary}
+  end
+
+  defp fetch_entries(:all), do: MarvelCdb.get_all_cards()
+
+  defp fetch_entries(packs) when is_list(packs) do
+    Enum.reduce_while(packs, {:ok, []}, fn pack, {:ok, acc} ->
+      case MarvelCdb.get_cards_by_pack(pack) do
+        {:ok, cards} -> {:cont, {:ok, acc ++ cards}}
+        err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp sync_data(entries) do
+    log("Syncing card data for #{length(entries)} entries...")
+
+    {synced, failures} =
+      MarvelCdb.sync_entries(entries, image_url_fun: &CardImages.public_url/1)
+
+    Enum.each(failures, fn {base_code, error} ->
+      log("  FAILED card #{base_code}: #{inspect(error)}")
+    end)
+
+    log("Card data: #{synced} cards synced, #{length(failures)} failed")
+    %{synced: synced, failures: failures}
+  end
+
+  defp sync_images(entries, force?) do
+    paths = image_paths(entries)
+    total = length(paths)
+    log("Mirroring #{total} images into #{CardImages.base_url()}...")
+
+    {counts, failures} =
+      paths
+      |> Enum.with_index(1)
+      |> Enum.reduce({%{uploaded: 0, skipped: 0}, []}, fn {path, index}, {counts, failures} ->
+        result = CardImages.mirror(path, force: force?)
+
+        if rem(index, @progress_every) == 0 or index == total do
+          log("  #{index}/#{total} images processed")
+        end
+
+        case result do
+          {:ok, :uploaded} ->
+            Process.sleep(@download_pause_ms)
+            {Map.update!(counts, :uploaded, &(&1 + 1)), failures}
+
+          {:ok, _skipped_or_no_image} ->
+            {Map.update!(counts, :skipped, &(&1 + 1)), failures}
+
+          {:error, reason} ->
+            {counts, [reason | failures]}
+        end
+      end)
+
+    failures = Enum.reverse(failures)
+    Enum.each(failures, &log("  FAILED image: #{inspect(&1)}"))
+
+    log(
+      "Images: #{counts.uploaded} uploaded, #{counts.skipped} skipped, #{length(failures)} failed"
+    )
+
+    Map.put(counts, :failures, failures)
+  end
+
+  # Every scan referenced by the payload: side images plus the parent-only
+  # front/back files (e.g. 01097.png) that no side entry mentions directly.
+  defp image_paths(entries) do
+    entries
+    |> Enum.flat_map(&[&1["imagesrc"], &1["backimagesrc"]])
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.uniq_by(&CardImages.object_key/1)
+  end
+
+  defp report_dry_run(entries) do
+    cards =
+      entries
+      |> Enum.map(&MarvelCdb.extract_base_code(&1["code"]))
+      |> Enum.uniq()
+      |> length()
+
+    images = entries |> image_paths() |> length()
+
+    log(
+      "Dry run: #{length(entries)} entries -> #{cards} cards, #{images} images. Nothing written."
+    )
+
+    {:ok, :dry_run}
+  end
+
+  defp failed?(%{data: data, images: images}) do
+    (data != nil and data.failures != []) or (images != nil and images.failures != [])
+  end
+
+  # Plain IO so progress shows for both `mix sanctum.sync_cards` and release eval.
+  defp log(message), do: IO.puts(message)
+end

--- a/lib/sanctum/games.ex
+++ b/lib/sanctum/games.ex
@@ -16,8 +16,14 @@ defmodule Sanctum.Games do
 
     resource Sanctum.Games.CardSide do
       define :create_card_side, action: :create
+      define :update_card_side, action: :update
       define :get_card_side, get_by: :id, action: :read
       define :get_card_side_by_code, args: [:code], get?: true, action: :by_code
+
+      define :get_card_side_by_card_and_side,
+        args: [:card_id, :side_identifier],
+        get?: true,
+        action: :by_card_and_side
     end
 
     resource Sanctum.Games.Game do

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -1,5 +1,24 @@
 defmodule Sanctum.MarvelCdb do
-  @moduledoc false
+  @moduledoc """
+  Client for the MarvelCDB public API.
+
+  Cards are processed as *groups*: all payload entries sharing a base code
+  (e.g. `01097`, `01097a`, `01097b`) resolve to one `Card` with one `CardSide`
+  per face. Grouping is required because MarvelCDB's representation varies by
+  card type:
+
+    * heroes are suffixed sibling entries only (`01001a`/`01001b`, up to `c`
+      for 3-form heroes like Angel — nothing links `c`, so link-chains can't
+      be trusted)
+    * main schemes add a `double_sided` parent entry that alone carries the
+      front image (`imagesrc`) and back image (`backimagesrc`); the `a` entry
+      has no image of its own
+    * a few double-sided cards (Intangible, `26002`) have *only* the parent —
+      both faces must be synthesized from it
+
+  Unknown card codes answer with HTTP 500 (not 404), so single-card fetches
+  never retry.
+  """
 
   require Logger
 
@@ -16,7 +35,7 @@ defmodule Sanctum.MarvelCdb do
 
   def load_deck(mcdb_deck_id) when is_binary(mcdb_deck_id) do
     "#{@base_url}/decklist/#{mcdb_deck_id}"
-    |> Req.get(max_retries: 1)
+    |> Req.get([max_retries: 1] ++ req_options())
     |> handle_response()
     |> case do
       {:ok, decklist} ->
@@ -94,13 +113,40 @@ defmodule Sanctum.MarvelCdb do
 
   defp create_or_find_villain(_card, _side), do: {:ok, nil}
 
-  def load_pack(pack_code) when is_binary(pack_code) do
-    get_cards_by_pack(pack_code)
-    |> case do
-      {:ok, cards} ->
-        cards
-        |> Enum.each(&create_card_with_sides/1)
+  def load_pack(pack_code, opts \\ []) when is_binary(pack_code) do
+    with {:ok, cards} <- get_cards_by_pack(pack_code) do
+      case sync_entries(cards, opts) do
+        {_synced, []} -> :ok
+        {_synced, failures} -> {:error, failures}
+      end
     end
+  end
+
+  @doc """
+  Upserts cards and their sides from a list of raw MarvelCDB payload entries.
+
+  Entries are grouped by base code and each group is processed as one card.
+  Returns `{synced_count, failures}` where failures are `{base_code, error}`
+  tuples; a failing group never aborts the rest.
+
+  Options:
+
+    * `:image_url_fun` — maps a resolved `imagesrc` path (or nil) to the URL
+      stored on the side. Defaults to an absolute marvelcdb.com URL;
+      `Sanctum.CardSync` passes `Sanctum.CardImages.public_url/1` to point at
+      the mirrored bucket instead.
+  """
+  def sync_entries(entries, opts \\ []) do
+    entries
+    |> Enum.uniq_by(& &1["code"])
+    |> Enum.group_by(&extract_base_code(&1["code"]))
+    |> Enum.reduce({0, []}, fn {base_code, group}, {synced, failures} ->
+      case create_card_from_entries(group, opts) do
+        {:ok, _card} -> {synced + 1, failures}
+        {:error, error} -> {synced, [{base_code, error} | failures]}
+      end
+    end)
+    |> then(fn {synced, failures} -> {synced, Enum.reverse(failures)} end)
   end
 
   def load_card(card_id) when is_integer(card_id) do
@@ -118,16 +164,24 @@ defmodule Sanctum.MarvelCdb do
         {:ok, card}
 
       _ ->
-        "#{@base_url}/card/#{card_id}"
-        |> Req.get(max_retries: 1)
-        |> handle_response()
-        |> case do
-          {:ok, resp} ->
-            create_card_with_sides(resp)
+        fetch_and_create_card(card_id)
+    end
+  end
 
-          err ->
-            err
-        end
+  # Fetches the card, then its pack listing, and processes every entry sharing
+  # the card's base code — the only reliable way to find all sides (parents,
+  # orphaned `c`/`d` sides) without probing guessed codes.
+  defp fetch_and_create_card(card_id) do
+    with {:ok, mcdb_card} <- fetch_card(card_id),
+         {:ok, pack_entries} <- get_cards_by_pack(mcdb_card["pack_code"]) do
+      base_code = extract_base_code(mcdb_card["code"])
+
+      pack_entries
+      |> Enum.filter(&(extract_base_code(&1["code"]) == base_code))
+      |> case do
+        [] -> create_card_from_entries([mcdb_card])
+        group -> create_card_from_entries(group)
+      end
     end
   end
 
@@ -141,70 +195,93 @@ defmodule Sanctum.MarvelCdb do
     end
   end
 
-  @spec get_cards_by_pack(String.t()) :: {:ok, list(map())}
+  @spec get_cards_by_pack(String.t()) :: {:ok, list(map())} | {:error, term()}
   def get_cards_by_pack(pack_code) when is_binary(pack_code) do
     "#{@base_url}/cards/#{pack_code}"
-    |> Req.get(max_retries: 1)
+    |> Req.get([max_retries: 1] ++ req_options())
     |> handle_response()
-    |> case do
-      {:ok, cards} ->
-        {:ok, cards}
-
-      err ->
-        err
-    end
   end
 
-  defp create_card_with_sides(mcdb_card) do
-    code = mcdb_card["code"]
-    base_code = extract_base_code(code)
-    side_identifier = extract_side_identifier(code)
+  @doc "Fetches every card (player + encounter) as a single payload."
+  @spec get_all_cards() :: {:ok, list(map())} | {:error, term()}
+  def get_all_cards do
+    "#{@base_url}/cards/?encounter=1"
+    |> Req.get([max_retries: 1] ++ req_options())
+    |> handle_response()
+  end
 
-    # Determine if card is multi-sided based on multiple indicators
-    is_multi_sided = detect_multi_sided_card(mcdb_card, code, side_identifier)
+  # MarvelCDB answers unknown card codes with HTTP 500, which Req's default
+  # retry treats as transient — never retry single-card fetches.
+  defp fetch_card(card_id) do
+    "#{@base_url}/card/#{card_id}"
+    |> Req.get([retry: false] ++ req_options())
+    |> handle_response()
+  end
 
-    # Don't create a side for base codes without side identifiers when double_sided is true
-    # This represents the card metadata, not a specific side
-    should_create_side = should_create_card_side?(mcdb_card, code, side_identifier)
+  @doc """
+  Creates/updates one card and all its sides from the payload entries sharing
+  a base code. See `sync_entries/2` for options.
+  """
+  def create_card_from_entries(entries, opts \\ []) do
+    image_url_fun = Keyword.get(opts, :image_url_fun, &build_image_url/1)
 
-    card_attrs = prepare_card_attrs(mcdb_card, is_multi_sided)
+    parent = Enum.find(entries, &(!suffixed?(&1["code"])))
+    side_entries = side_entries(entries, parent)
 
-    with {:ok, card} <- Sanctum.Games.create_card(card_attrs),
-         :ok <- maybe_create_primary_side(card, mcdb_card, code, should_create_side) do
-      if is_multi_sided, do: load_additional_sides(card, base_code)
+    card_entry = parent || hd(side_entries)
+    primary_code = side_entries |> hd() |> Map.fetch!("code")
+    card_attrs = prepare_card_attrs(card_entry, primary_code, length(side_entries) > 1)
+
+    with {:ok, card} <- Games.create_card(card_attrs),
+         :ok <- upsert_sides(card, side_entries, parent, image_url_fun) do
       {:ok, card}
     end
   end
 
-  # Creates the card's primary side if needed, reusing an existing side when one
-  # already exists for this code. Returns :ok or an error tuple.
-  defp maybe_create_primary_side(_card, _mcdb_card, _code, false), do: :ok
+  defp side_entries(entries, parent) do
+    sides = entries |> Enum.filter(&suffixed?(&1["code"])) |> Enum.sort_by(& &1["code"])
 
-  defp maybe_create_primary_side(card, mcdb_card, code, true) do
-    case Sanctum.Games.get_card_side_by_code(code) do
-      {:ok, existing_side} ->
-        create_or_find_villain(card, existing_side)
-        :ok
-
-      {:error, _} ->
-        create_side(card, prepare_card_side_attrs(mcdb_card))
+    if parent && parent["double_sided"] do
+      fill_missing_sides(sides, parent)
+    else
+      if sides == [], do: [parent], else: sides
     end
   end
 
-  defp load_additional_sides(card, base_code) do
-    # For multi-sided cards, try to load sides b, c, etc.
-    Enum.each(["b", "c", "d"], fn suffix ->
-      case fetch_card_side(base_code <> suffix) do
-        {:ok, side_data} -> create_side(card, prepare_card_side_attrs(side_data))
-        # Side doesn't exist, continue
-        _ -> :ok
+  # Pack payloads omit hidden side entries (main-scheme B sides only appear in
+  # the all-cards payload), and a few cards have no side entries at all
+  # (Intangible) — fill whatever is missing from the parent, which alone
+  # carries both faces.
+  defp fill_missing_sides(sides, parent) do
+    identifiers = MapSet.new(sides, &extract_side_identifier(&1["code"]))
+    [front, back] = synthesize_side_entries(parent)
+
+    sides
+    |> then(&if MapSet.member?(identifiers, "a"), do: &1, else: [front | &1])
+    |> then(&if MapSet.member?(identifiers, "b"), do: &1, else: &1 ++ [back])
+    |> Enum.sort_by(& &1["code"])
+  end
+
+  defp upsert_sides(card, side_entries, parent, image_url_fun) do
+    Enum.reduce_while(side_entries, :ok, fn entry, :ok ->
+      image_url = entry |> resolve_imagesrc(parent) |> image_url_fun.()
+
+      case upsert_side(card, prepare_card_side_attrs(entry, image_url)) do
+        :ok -> {:cont, :ok}
+        err -> {:halt, err}
       end
     end)
   end
 
-  # Creates a card side and, when it is a villain side, the backing Villain.
-  defp create_side(card, side_attrs) do
-    case Sanctum.Games.create_card_side(Map.put(side_attrs, :card_id, card.id)) do
+  defp upsert_side(card, side_attrs) do
+    attrs = Map.put(side_attrs, :card_id, card.id)
+
+    find_existing_side(card, attrs)
+    |> case do
+      {:ok, existing} -> Games.update_card_side(existing, attrs)
+      {:error, _not_found} -> Games.create_card_side(attrs)
+    end
+    |> case do
       {:ok, side} ->
         create_or_find_villain(card, side)
         :ok
@@ -214,11 +291,54 @@ defmodule Sanctum.MarvelCdb do
     end
   end
 
-  defp fetch_card_side(side_code) do
-    "#{@base_url}/card/#{side_code}"
-    |> Req.get(max_retries: 1)
-    |> handle_response()
+  # The card+identifier fallback catches rows written by older sync logic
+  # under a differently-suffixed code (e.g. "01144" where the payload now says
+  # "01144a"); updating them corrects the code in place.
+  defp find_existing_side(card, attrs) do
+    case Games.get_card_side_by_code(attrs.code) do
+      {:ok, existing} -> {:ok, existing}
+      {:error, _} -> Games.get_card_side_by_card_and_side(card.id, attrs.side_identifier)
+    end
   end
+
+  # The side's image with fallback to the double-sided parent entry, which
+  # alone carries the front (`imagesrc`) and back (`backimagesrc`) scans for
+  # main schemes and friends.
+  defp resolve_imagesrc(entry, parent) do
+    cond do
+      src = presence(entry["imagesrc"]) -> src
+      is_nil(parent) -> nil
+      extract_side_identifier(entry["code"]) == "a" -> presence(parent["imagesrc"])
+      extract_side_identifier(entry["code"]) == "b" -> presence(parent["backimagesrc"])
+      true -> nil
+    end
+  end
+
+  # Double-sided cards without their own side entries (Intangible, 26002)
+  # carry both faces on the parent: front as the entry itself, back via
+  # back_name/back_text/backimagesrc.
+  defp synthesize_side_entries(parent) do
+    code = parent["code"]
+
+    front = Map.put(parent, "code", code <> "a")
+
+    back =
+      Map.merge(parent, %{
+        "code" => code <> "b",
+        "name" => parent["back_name"] || parent["name"],
+        "real_name" => nil,
+        "text" => parent["back_text"],
+        "real_text" => nil,
+        "imagesrc" => presence(parent["backimagesrc"])
+      })
+
+    [front, back]
+  end
+
+  defp suffixed?(code), do: String.match?(code, ~r/[a-z]$/)
+
+  defp presence(value) when value in [nil, ""], do: nil
+  defp presence(value), do: value
 
   def extract_base_code(code) do
     # Remove trailing letter (e.g., "01001a" -> "01001")
@@ -233,34 +353,14 @@ defmodule Sanctum.MarvelCdb do
     end
   end
 
-  def detect_multi_sided_card(mcdb_card, code, _side_identifier) do
-    explicit_double_sided = mcdb_card["double_sided"] || false
-    has_side_suffix = String.match?(code, ~r/[a-z]$/)
-
-    # A card is multi-sided if:
-    # 1. MarvelCDB explicitly says it's double_sided, OR
-    # 2. The code has a side suffix (a, b, c), which implies multiple sides exist
-    explicit_double_sided || has_side_suffix
-  end
-
-  def should_create_card_side?(mcdb_card, code, _side_identifier) do
-    has_side_suffix = String.match?(code, ~r/[a-z]$/)
-    explicit_double_sided = mcdb_card["double_sided"] || false
-
-    # Create a side if:
-    # 1. Code has a side suffix (represents a specific side), OR
-    # 2. Code has no suffix AND double_sided is false (single-sided card, treat as side 'a')
-    has_side_suffix || (!has_side_suffix && !explicit_double_sided)
-  end
-
-  defp prepare_card_attrs(%{} = mcdb_card, is_multi_sided) do
+  defp prepare_card_attrs(%{} = mcdb_card, primary_code, is_multi_sided) do
     %{
       # Multi-sided card support
       is_multi_sided: is_multi_sided,
       base_code: extract_base_code(mcdb_card["code"]),
 
       # Primary side code (for compatibility)
-      code: mcdb_card["code"],
+      code: primary_code,
 
       # Card-level properties
       deck_limit: mcdb_card["quantity"] || 1,
@@ -275,7 +375,7 @@ defmodule Sanctum.MarvelCdb do
     |> Map.new()
   end
 
-  defp prepare_card_side_attrs(%{} = mcdb_card) do
+  defp prepare_card_side_attrs(%{} = mcdb_card, image_url) do
     side_identifier = extract_side_identifier(mcdb_card["code"])
 
     %{
@@ -332,7 +432,7 @@ defmodule Sanctum.MarvelCdb do
       boost_star: mcdb_card["boost_star"] || false,
 
       # Image
-      image_url: build_image_url(mcdb_card["imagesrc"])
+      image_url: image_url
     }
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
     |> Map.new()
@@ -345,6 +445,9 @@ defmodule Sanctum.MarvelCdb do
       "I" -> 1
       "II" -> 2
       "III" -> 3
+      "1" -> 1
+      "2" -> 2
+      "3" -> 3
       "1A" -> 1
       "1B" -> 1
       "1C" -> 1
@@ -354,6 +457,7 @@ defmodule Sanctum.MarvelCdb do
       "3A" -> 3
       "3B" -> 3
       "3C" -> 3
+      _ -> nil
     end
   end
 
@@ -392,7 +496,6 @@ defmodule Sanctum.MarvelCdb do
   end
 
   defp build_image_url(nil), do: nil
-  defp build_image_url(""), do: nil
 
   defp build_image_url(imagesrc) when is_binary(imagesrc) do
     case String.starts_with?(imagesrc, "http") do
@@ -433,4 +536,6 @@ defmodule Sanctum.MarvelCdb do
       {:error, exception} -> {:error, exception}
     end
   end
+
+  defp req_options, do: Application.get_env(:sanctum, :marvel_cdb_req_options, [])
 end

--- a/lib/sanctum/release.ex
+++ b/lib/sanctum/release.ex
@@ -18,6 +18,19 @@ defmodule Sanctum.Release do
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
   end
 
+  @doc """
+  Syncs the card catalog from MarvelCDB. Defaults to card data only — images
+  live in the shared public bucket and are mirrored from a dev machine with
+  `mix sanctum.sync_cards`.
+
+      /app/bin/sanctum eval 'Sanctum.Release.sync_cards()'
+  """
+  def sync_cards(opts \\ []) do
+    # Unlike migrations, the sync needs the whole app (Repo, Ash) running.
+    {:ok, _} = Application.ensure_all_started(@app)
+    Sanctum.CardSync.run(Keyword.merge([packs: :all, images?: false], opts))
+  end
+
   defp repos do
     Application.fetch_env!(@app, :ecto_repos)
   end

--- a/lib/sanctum_web/plugs/content_security_policy.ex
+++ b/lib/sanctum_web/plugs/content_security_policy.ex
@@ -24,14 +24,26 @@ defmodule SanctumWeb.Plugs.ContentSecurityPolicy do
       :prod ->
         "default-src 'self';" <>
           "connect-src wss://#{host} https://#{host}:*;" <>
-          "img-src 'self' blob: data: https://marvelcdb.com;" <>
+          "img-src 'self' blob: data: #{img_src_hosts()};" <>
           "font-src 'self' data:;"
 
       _ ->
         "default-src 'self' 'unsafe-eval' 'unsafe-inline' #{host}:4007;" <>
           "connect-src * ws://#{host}:* http://#{host}:*;" <>
-          "img-src 'self' blob: data: https://marvelcdb.com;" <>
+          "img-src 'self' blob: data: #{img_src_hosts()};" <>
           "font-src 'self' data:;"
     end
+  end
+
+  # marvelcdb.com stays allowed: ad-hoc deck/card loads and fresh seeds store
+  # marvelcdb image URLs until `mix sanctum.sync_cards` rewrites them.
+  defp img_src_hosts do
+    bucket_host =
+      :sanctum
+      |> Application.fetch_env!(:card_image_base_url)
+      |> URI.parse()
+      |> Map.fetch!(:host)
+
+    "https://marvelcdb.com https://#{bucket_host}"
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,6 +1,8 @@
 alias Sanctum.Games
 alias Sanctum.MarvelCdb
 
+# Seeds only the core set with marvelcdb-hosted image URLs; run
+# `mix sanctum.sync_cards` to load everything and point images at the bucket.
 :ok = MarvelCdb.load_pack("core")
 
 {:ok, _modular_set} = Games.create_modular_set(%{name: "Bomb Scare", set_code: "bomb_scare"})

--- a/test/sanctum/card_images_test.exs
+++ b/test/sanctum/card_images_test.exs
@@ -1,0 +1,38 @@
+defmodule Sanctum.CardImagesTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias Sanctum.CardImages
+
+  describe "object_key/1" do
+    test "keys are the imagesrc basename under cards/" do
+      assert CardImages.object_key("/bundles/cards/01001a.png") == "cards/01001a.png"
+      # main scheme fronts are unsuffixed; extensions vary
+      assert CardImages.object_key("/bundles/cards/01097.png") == "cards/01097.png"
+      assert CardImages.object_key("/bundles/cards/26002a.jpg") == "cards/26002a.jpg"
+    end
+
+    test "absolute URLs keep their basename" do
+      assert CardImages.object_key("https://marvelcdb.com/bundles/cards/01001a.png") ==
+               "cards/01001a.png"
+    end
+
+    test "nil and empty are nil" do
+      assert CardImages.object_key(nil) == nil
+      assert CardImages.object_key("") == nil
+    end
+  end
+
+  describe "public_url/1" do
+    test "prefixes the configured bucket base URL" do
+      assert CardImages.public_url("/bundles/cards/01097b.png") ==
+               CardImages.base_url() <> "/cards/01097b.png"
+    end
+
+    test "nil and empty are nil" do
+      assert CardImages.public_url(nil) == nil
+      assert CardImages.public_url("") == nil
+    end
+  end
+end

--- a/test/sanctum/card_sync_test.exs
+++ b/test/sanctum/card_sync_test.exs
@@ -1,0 +1,239 @@
+defmodule Sanctum.CardSyncTest do
+  @moduledoc false
+
+  use Sanctum.DataCase, async: true
+
+  alias Sanctum.CardImages
+  alias Sanctum.CardSync
+  alias Sanctum.Games
+
+  # Trimmed real shapes from the /cards/?encounter=1 payload, covering every
+  # multi-sided representation MarvelCDB uses.
+  @entries [
+    # Single-sided card
+    %{
+      "code" => "01050",
+      "name" => "Hulk",
+      "type_code" => "ally",
+      "faction_code" => "aggression",
+      "pack_code" => "core",
+      "card_set_code" => nil,
+      "quantity" => 1,
+      "imagesrc" => "/bundles/cards/01050.png"
+    },
+    # Hero pair: both sides are their own entries with their own images
+    %{
+      "code" => "01001a",
+      "name" => "Spider-Man",
+      "type_code" => "hero",
+      "faction_code" => "hero",
+      "pack_code" => "core",
+      "card_set_code" => "spider_man",
+      "imagesrc" => "/bundles/cards/01001a.png"
+    },
+    %{
+      "code" => "01001b",
+      "name" => "Peter Parker",
+      "type_code" => "alter_ego",
+      "faction_code" => "hero",
+      "pack_code" => "core",
+      "card_set_code" => "spider_man",
+      "imagesrc" => "/bundles/cards/01001b.png"
+    },
+    # 3-form hero (Angel): three sibling entries, no parent, c is orphaned
+    %{
+      "code" => "42001a",
+      "name" => "Angel",
+      "type_code" => "hero",
+      "pack_code" => "angel",
+      "imagesrc" => "/bundles/cards/42001a.png"
+    },
+    %{
+      "code" => "42001b",
+      "name" => "Warren Worthington III",
+      "type_code" => "alter_ego",
+      "pack_code" => "angel",
+      "imagesrc" => "/bundles/cards/42001b.png"
+    },
+    %{
+      "code" => "42001c",
+      "name" => "Archangel",
+      "type_code" => "hero",
+      "pack_code" => "angel",
+      "imagesrc" => "/bundles/cards/42001c.png"
+    },
+    # Main scheme: parent alone carries the front image; the a-side has none
+    %{
+      "code" => "01097",
+      "name" => "The Break-In!",
+      "type_code" => "main_scheme",
+      "pack_code" => "core",
+      "card_set_code" => "rhino",
+      "stage" => "1",
+      "double_sided" => true,
+      "imagesrc" => "/bundles/cards/01097.png",
+      "backimagesrc" => "/bundles/cards/01097b.png"
+    },
+    %{
+      "code" => "01097a",
+      "name" => "The Break-In!",
+      "type_code" => "main_scheme",
+      "pack_code" => "core",
+      "card_set_code" => "rhino",
+      "stage" => "1A",
+      "imagesrc" => nil
+    },
+    %{
+      "code" => "01097b",
+      "name" => "The Break-In!",
+      "type_code" => "main_scheme",
+      "pack_code" => "core",
+      "card_set_code" => "rhino",
+      "stage" => "1B",
+      "imagesrc" => "/bundles/cards/01097b.png"
+    },
+    # Double-sided card with NO side entries (Intangible): synthesize both
+    %{
+      "code" => "26002",
+      "name" => "Intangible",
+      "type_code" => "upgrade",
+      "faction_code" => "hero",
+      "pack_code" => "vision",
+      "permanent" => true,
+      "double_sided" => true,
+      "text" => "Mass form.",
+      "back_name" => "Dense",
+      "back_text" => "Mass form, but dense.",
+      "imagesrc" => "/bundles/cards/26002a.jpg",
+      "backimagesrc" => "/bundles/cards/26002b.png"
+    },
+    # Pack-payload shape: hidden B-side entries are omitted from /cards/{pack}
+    # (only the all-cards payload includes them) — the B side must be
+    # synthesized from the parent
+    %{
+      "code" => "77001",
+      "name" => "Hidden Agenda",
+      "type_code" => "main_scheme",
+      "pack_code" => "future",
+      "stage" => "1",
+      "double_sided" => true,
+      "back_text" => "Scheme text for the hidden side.",
+      "imagesrc" => "/bundles/cards/77001.png",
+      "backimagesrc" => "/bundles/cards/77001b.png"
+    },
+    %{
+      "code" => "77001a",
+      "name" => "Hidden Agenda",
+      "type_code" => "main_scheme",
+      "pack_code" => "future",
+      "stage" => "1A",
+      "imagesrc" => nil
+    },
+    # Card with no scan at all
+    %{
+      "code" => "99001",
+      "name" => "No Scan Yet",
+      "type_code" => "event",
+      "pack_code" => "future"
+    }
+  ]
+
+  setup do
+    Req.Test.stub(Sanctum.MarvelCdb, fn conn ->
+      Req.Test.json(conn, @entries)
+    end)
+
+    :ok
+  end
+
+  test "syncs every multi-sided card shape with bucket image URLs" do
+    assert {:ok, %{data: %{synced: 7, failures: []}, images: nil}} =
+             CardSync.run(packs: :all, images?: false)
+
+    # Single-sided card gets one side with its own image
+    assert [%{side_identifier: "a", image_url: url}] = sides("01050")
+    assert url == bucket_url("01050.png")
+
+    # Hero pair
+    assert [%{code: "01001a"}, %{code: "01001b"}] = sides("01001")
+
+    # 3-form hero: all three sides on ONE card
+    assert [%{name: "Angel"}, %{name: "Warren Worthington III"}, %{name: "Archangel"}] =
+             sides("42001")
+
+    # Main scheme: the a-side inherits the PARENT's front image (01097.png,
+    # not 01097a.png which doesn't exist); stages parse to integers
+    assert [side_a, side_b] = sides("01097")
+    assert side_a.image_url == bucket_url("01097.png")
+    assert side_a.stage == 1
+    assert side_b.image_url == bucket_url("01097b.png")
+
+    # Intangible: both sides synthesized from the lone parent entry
+    assert [front, back] = sides("26002")
+    assert front.name == "Intangible"
+    assert front.image_url == bucket_url("26002a.jpg")
+    assert back.name == "Dense"
+    assert back.text == "Mass form, but dense."
+    assert back.image_url == bucket_url("26002b.png")
+    assert Games.get_card_by_code!("26002").permanent
+
+    # Hidden B side (absent from pack payloads) synthesized from the parent
+    assert [hidden_a, hidden_b] = sides("77001")
+    assert hidden_a.image_url == bucket_url("77001.png")
+    assert hidden_b.code == "77001b"
+    assert hidden_b.text == "Scheme text for the hidden side."
+    assert hidden_b.image_url == bucket_url("77001b.png")
+
+    # No scan -> nil image_url (UI falls back to card backs)
+    assert [%{image_url: nil}] = sides("99001")
+  end
+
+  test "re-running updates existing sides instead of skipping them" do
+    assert {:ok, _} = CardSync.run(packs: :all, images?: false)
+
+    # Simulate a pre-mirror row still pointing at marvelcdb.com
+    {:ok, side} = Games.get_card_side_by_code("01001a")
+    {:ok, _} = Games.update_card_side(side, %{image_url: "https://marvelcdb.com/old.png"})
+
+    assert {:ok, %{data: %{synced: 7, failures: []}}} =
+             CardSync.run(packs: :all, images?: false)
+
+    {:ok, side} = Games.get_card_side_by_code("01001a")
+    assert side.image_url == bucket_url("01001a.png")
+  end
+
+  test "migrates legacy sides stored under an unsuffixed code" do
+    # Older sync logic keyed sides by the raw entry code ("01001"); the new
+    # payload uses suffixed codes ("01001a") for the same physical side.
+    {:ok, card} =
+      Games.create_card(%{base_code: "01001", code: "01001", is_multi_sided: true})
+
+    {:ok, _} =
+      Games.create_card_side(%{
+        card_id: card.id,
+        code: "01001",
+        side_identifier: "a",
+        is_primary_side: true,
+        name: "Spider-Man (legacy row)"
+      })
+
+    assert {:ok, %{data: %{failures: []}}} = CardSync.run(packs: :all, images?: false)
+
+    # The legacy row was updated in place, not duplicated
+    assert [side_a, _side_b] = sides("01001")
+    assert side_a.code == "01001a"
+    assert side_a.name == "Spider-Man"
+  end
+
+  test "dry run writes nothing" do
+    assert {:ok, :dry_run} = CardSync.run(packs: :all, dry_run?: true)
+    assert {:error, _} = Games.get_card_side_by_code("01001a")
+  end
+
+  defp sides(base_code) do
+    card = Games.get_card_by_code!(base_code, load: [:card_sides])
+    Enum.sort_by(card.card_sides, & &1.side_identifier)
+  end
+
+  defp bucket_url(filename), do: CardImages.base_url() <> "/cards/" <> filename
+end

--- a/test/sanctum/marvel_cdb_test.exs
+++ b/test/sanctum/marvel_cdb_test.exs
@@ -110,30 +110,6 @@ defmodule Sanctum.MarvelCdbTest do
       assert MarvelCdb.extract_side_identifier("01001") == "a"
       assert MarvelCdb.extract_side_identifier("01123c") == "c"
     end
-
-    test "detect_multi_sided_card/3" do
-      # Explicit double_sided true
-      assert MarvelCdb.detect_multi_sided_card(%{"double_sided" => true}, "01001", "a") == true
-
-      # Has side suffix
-      assert MarvelCdb.detect_multi_sided_card(%{"double_sided" => false}, "01001a", "a") == true
-      assert MarvelCdb.detect_multi_sided_card(%{"double_sided" => false}, "01001b", "b") == true
-
-      # Single sided
-      assert MarvelCdb.detect_multi_sided_card(%{"double_sided" => false}, "01042", "a") == false
-    end
-
-    test "should_create_card_side?/3" do
-      # Should create side for codes with suffix
-      assert MarvelCdb.should_create_card_side?(%{"double_sided" => false}, "01001a", "a") == true
-      assert MarvelCdb.should_create_card_side?(%{"double_sided" => true}, "01001b", "b") == true
-
-      # Should create side for single-sided cards (no suffix, double_sided false)
-      assert MarvelCdb.should_create_card_side?(%{"double_sided" => false}, "01042", "a") == true
-
-      # Should NOT create side for base cards (no suffix, double_sided true)
-      assert MarvelCdb.should_create_card_side?(%{"double_sided" => true}, "01001", "a") == false
-    end
   end
 
   @tag :external


### PR DESCRIPTION

## What

Replaces the probe-based multi-sided card sync with group-based processing of MarvelCDB payload entries, and mirrors card scans into a public Tigris bucket (`sanctum-cards`) that both dev and prod render from directly.

## Why

The previous sync stored hotlinked `marvelcdb.com` URLs and made blind per-side HTTP requests to discover card faces. MarvelCDB answers unknown card codes with an HTTP 500 that Req retries (~2s each), so a single main scheme cost ~9s of mostly-wasted probes. It also dropped some images entirely.

## How

- Entries sharing a base code resolve to one `Card` + one `CardSide` per face — no per-side probing.
- Main-scheme A-sides inherit the parent entry's front image (`01097.png`), which the old code dropped; hidden B-sides (absent from pack payloads) and parent-only cards like Intangible (`26002`) are synthesized from the parent's `back_*` fields.
- 3-form heroes (Angel `42001a/b/c`) come straight from sibling entries; `linked_to_code` chains are never trusted (the `c` face is orphaned).
- `Sanctum.CardImages`: bucket object keys from `imagesrc` basenames (filenames don't follow card codes; extensions vary), HEAD-based skip for resumable runs, uploads via Req's built-in `aws_sigv4` — **no new deps**.
- `Sanctum.CardSync` + `mix sanctum.sync_cards` / `Sanctum.Release.sync_cards` entry points (`--pack`, `--skip-images`, `--images-only`, `--dry-run`, `--force`).
- CSP `img-src` allows the bucket host alongside `marvelcdb.com` (pre-sync rows still hotlink).

## Verification

Full catalog synced end-to-end: **3,887 cards, 0 failures; 3,598 images mirrored** (uploaded then all skipped on re-run, proving idempotency). Rhino's main scheme renders its real 1A face. Fixture covers every multi-sided payload shape.

## Notes

- The bucket (`sanctum-cards`) is already provisioned; credentials are in Doppler (dev) and set on the Fly app.
- Prod card data (images already in the shared bucket): `fly ssh console -a sanctum -C "/app/bin/sanctum eval 'Sanctum.Release.sync_cards()'"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)