### PR TITLE
feat(cards): admin LiveView to trigger and watch card syncs

### DIFF
--- a/lib/sanctum/application.ex
+++ b/lib/sanctum/application.ex
@@ -17,6 +17,8 @@ defmodule Sanctum.Application do
          Application.fetch_env!(:sanctum, Oban)
        )},
       {Phoenix.PubSub, name: Sanctum.PubSub},
+      {Task.Supervisor, name: Sanctum.TaskSupervisor},
+      Sanctum.CardSync.Server,
       # Start a worker by calling: Sanctum.Worker.start_link(arg)
       # {Sanctum.Worker, arg},
       # Start to serve requests, typically the last entry

--- a/lib/sanctum/card_sync.ex
+++ b/lib/sanctum/card_sync.ex
@@ -8,8 +8,9 @@ defmodule Sanctum.CardSync do
   re-running updates card data and skips images already in the bucket, so an
   interrupted run resumes by re-running.
 
-  Entry points: `mix sanctum.sync_cards` (dev) and
-  `Sanctum.Release.sync_cards/1` (prod, data only — the bucket is shared).
+  Entry points: `mix sanctum.sync_cards` (dev), `Sanctum.Release.sync_cards/1`
+  (prod, data only — the bucket is shared), and `Sanctum.CardSync.Server` for
+  the admin UI at `/cards/sync`.
   """
 
   alias Sanctum.CardImages
@@ -18,7 +19,6 @@ defmodule Sanctum.CardSync do
   # Pause between actual downloads from marvelcdb.com — the API asks
   # consumers to be polite. Skipped objects don't sleep.
   @download_pause_ms 200
-  @progress_every 25
 
   @doc """
   Runs the sync. Options:
@@ -28,6 +28,14 @@ defmodule Sanctum.CardSync do
     * `:images?` — mirror scans to the bucket (default true; needs AWS env vars)
     * `:dry_run?` — report counts without writing (default false)
     * `:force?` — re-upload images that already exist (default false)
+    * `:progress_fun` — receives progress events (see below); defaults to
+      printing CLI-style progress to stdout
+
+  Progress events: `{:data_started, %{entries, cards}}`,
+  `{:card, %{index, total, base_code, name, ok?}}`, `{:data_done, %{synced,
+  failures}}`, `{:images_started, %{total}}`, `{:image, %{index, total, file,
+  result}}`, `{:images_done, %{uploaded, skipped, failures}}`, and
+  `{:dry_run, %{entries, cards, images}}`.
 
   Returns `{:ok, summary}`, `{:error, summary}` when any card or image failed
   (the run still processes everything), or `{:error, reason}` when the payload
@@ -35,24 +43,25 @@ defmodule Sanctum.CardSync do
   """
   def run(opts \\ []) do
     packs = Keyword.get(opts, :packs, :all)
+    progress = Keyword.get(opts, :progress_fun, &log_progress/1)
 
     with {:ok, entries} <- fetch_entries(packs) do
       entries = Enum.uniq_by(entries, & &1["code"])
 
       if Keyword.get(opts, :dry_run?, false) do
-        report_dry_run(entries)
+        report_dry_run(entries, progress)
       else
-        run_sync(entries, opts)
+        run_sync(entries, opts, progress)
       end
     end
   end
 
-  defp run_sync(entries, opts) do
-    data = if Keyword.get(opts, :data?, true), do: sync_data(entries)
+  defp run_sync(entries, opts, progress) do
+    data = if Keyword.get(opts, :data?, true), do: sync_data(entries, progress)
 
     images =
       if Keyword.get(opts, :images?, true),
-        do: sync_images(entries, Keyword.get(opts, :force?, false))
+        do: sync_images(entries, Keyword.get(opts, :force?, false), progress)
 
     summary = %{data: data, images: images}
 
@@ -70,24 +79,23 @@ defmodule Sanctum.CardSync do
     end)
   end
 
-  defp sync_data(entries) do
-    log("Syncing card data for #{length(entries)} entries...")
+  defp sync_data(entries, progress) do
+    progress.({:data_started, %{entries: length(entries), cards: card_count(entries)}})
 
     {synced, failures} =
-      MarvelCdb.sync_entries(entries, image_url_fun: &CardImages.public_url/1)
+      MarvelCdb.sync_entries(entries,
+        image_url_fun: &CardImages.public_url/1,
+        on_progress: &progress.({:card, &1})
+      )
 
-    Enum.each(failures, fn {base_code, error} ->
-      log("  FAILED card #{base_code}: #{inspect(error)}")
-    end)
-
-    log("Card data: #{synced} cards synced, #{length(failures)} failed")
+    progress.({:data_done, %{synced: synced, failures: failures}})
     %{synced: synced, failures: failures}
   end
 
-  defp sync_images(entries, force?) do
+  defp sync_images(entries, force?, progress) do
     paths = image_paths(entries)
     total = length(paths)
-    log("Mirroring #{total} images into #{CardImages.base_url()}...")
+    progress.({:images_started, %{total: total}})
 
     {counts, failures} =
       paths
@@ -95,9 +103,10 @@ defmodule Sanctum.CardSync do
       |> Enum.reduce({%{uploaded: 0, skipped: 0}, []}, fn {path, index}, {counts, failures} ->
         result = CardImages.mirror(path, force: force?)
 
-        if rem(index, @progress_every) == 0 or index == total do
-          log("  #{index}/#{total} images processed")
-        end
+        progress.(
+          {:image,
+           %{index: index, total: total, file: Path.basename(path), result: image_outcome(result)}}
+        )
 
         case result do
           {:ok, :uploaded} ->
@@ -113,14 +122,16 @@ defmodule Sanctum.CardSync do
       end)
 
     failures = Enum.reverse(failures)
-    Enum.each(failures, &log("  FAILED image: #{inspect(&1)}"))
 
-    log(
-      "Images: #{counts.uploaded} uploaded, #{counts.skipped} skipped, #{length(failures)} failed"
+    progress.(
+      {:images_done, %{uploaded: counts.uploaded, skipped: counts.skipped, failures: failures}}
     )
 
     Map.put(counts, :failures, failures)
   end
+
+  defp image_outcome({:ok, outcome}), do: outcome
+  defp image_outcome({:error, _reason}), do: :error
 
   # Every scan referenced by the payload: side images plus the parent-only
   # front/back files (e.g. 01097.png) that no side entry mentions directly.
@@ -131,17 +142,21 @@ defmodule Sanctum.CardSync do
     |> Enum.uniq_by(&CardImages.object_key/1)
   end
 
-  defp report_dry_run(entries) do
-    cards =
-      entries
-      |> Enum.map(&MarvelCdb.extract_base_code(&1["code"]))
-      |> Enum.uniq()
-      |> length()
+  defp card_count(entries) do
+    entries
+    |> Enum.map(&MarvelCdb.extract_base_code(&1["code"]))
+    |> Enum.uniq()
+    |> length()
+  end
 
-    images = entries |> image_paths() |> length()
-
-    log(
-      "Dry run: #{length(entries)} entries -> #{cards} cards, #{images} images. Nothing written."
+  defp report_dry_run(entries, progress) do
+    progress.(
+      {:dry_run,
+       %{
+         entries: length(entries),
+         cards: card_count(entries),
+         images: entries |> image_paths() |> length()
+       }}
     )
 
     {:ok, :dry_run}
@@ -151,6 +166,34 @@ defmodule Sanctum.CardSync do
     (data != nil and data.failures != []) or (images != nil and images.failures != [])
   end
 
-  # Plain IO so progress shows for both `mix sanctum.sync_cards` and release eval.
-  defp log(message), do: IO.puts(message)
+  # Default progress handler: CLI-style output for the mix task and release
+  # eval. Plain IO so it shows in both contexts.
+  defp log_progress({:data_started, %{entries: entries}}),
+    do: IO.puts("Syncing card data for #{entries} entries...")
+
+  defp log_progress({:data_done, %{synced: synced, failures: failures}}) do
+    Enum.each(failures, fn {base_code, error} ->
+      IO.puts("  FAILED card #{base_code}: #{inspect(error)}")
+    end)
+
+    IO.puts("Card data: #{synced} cards synced, #{length(failures)} failed")
+  end
+
+  defp log_progress({:images_started, %{total: total}}),
+    do: IO.puts("Mirroring #{total} images into #{CardImages.base_url()}...")
+
+  defp log_progress({:image, %{index: index, total: total}})
+       when rem(index, 25) == 0 or index == total,
+       do: IO.puts("  #{index}/#{total} images processed")
+
+  defp log_progress({:images_done, %{uploaded: uploaded, skipped: skipped, failures: failures}}) do
+    Enum.each(failures, &IO.puts("  FAILED image: #{inspect(&1)}"))
+    IO.puts("Images: #{uploaded} uploaded, #{skipped} skipped, #{length(failures)} failed")
+  end
+
+  defp log_progress({:dry_run, %{entries: entries, cards: cards, images: images}}) do
+    IO.puts("Dry run: #{entries} entries -> #{cards} cards, #{images} images. Nothing written.")
+  end
+
+  defp log_progress(_event), do: :ok
 end

--- a/lib/sanctum/card_sync/server.ex
+++ b/lib/sanctum/card_sync/server.ex
@@ -1,0 +1,223 @@
+defmodule Sanctum.CardSync.Server do
+  @moduledoc """
+  Runs card syncs detached from any LiveView and fans progress out over
+  PubSub.
+
+  The sync itself executes in a supervised `Task`, so the admin page can
+  trigger a run and every connected client can watch it — or navigate away —
+  without touching the sync. Only one sync runs at a time; latest progress is
+  kept in state so a freshly-mounted LiveView shows a run already underway.
+  """
+
+  use GenServer
+
+  alias Sanctum.CardSync
+
+  @topic "card_sync"
+  # Card upserts emit hundreds of progress events per second — cap broadcast
+  # rate so LiveViews repaint at most ~10x/s. Phase changes always broadcast.
+  @broadcast_interval_ms 100
+  @max_failures_kept 50
+
+  @aws_env ~w(AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINT_URL_S3 BUCKET_NAME)
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  def subscribe, do: Phoenix.PubSub.subscribe(Sanctum.PubSub, @topic)
+
+  @doc """
+  Starts a sync (options as `Sanctum.CardSync.run/1`). Returns `:ok`,
+  `{:error, :already_running}`, or `{:error, {:missing_env, vars}}` when
+  image mirroring is requested without the bucket credentials.
+  """
+  def start_sync(opts \\ []), do: GenServer.call(__MODULE__, {:start_sync, opts})
+
+  @doc "Latest sync state — also what PubSub delivers as `{:card_sync, state}`."
+  def status, do: GenServer.call(__MODULE__, :status)
+
+  @impl true
+  def init(:ok) do
+    {:ok, %{task_ref: nil, last_broadcast: 0, sync: idle_sync()}}
+  end
+
+  @impl true
+  def handle_call({:start_sync, opts}, _from, %{task_ref: nil} = state) do
+    case missing_env(opts) do
+      [] ->
+        {:reply, :ok, begin_sync(state, opts)}
+
+      vars ->
+        {:reply, {:error, {:missing_env, vars}}, state}
+    end
+  end
+
+  def handle_call({:start_sync, _opts}, _from, state),
+    do: {:reply, {:error, :already_running}, state}
+
+  def handle_call(:status, _from, state), do: {:reply, state.sync, state}
+
+  @impl true
+  def handle_info({:progress, event}, state) do
+    state = %{state | sync: apply_event(state.sync, event)}
+    {:noreply, broadcast(state, broadcast_mode(event))}
+  end
+
+  def handle_info({ref, result}, %{task_ref: ref} = state) do
+    Process.demonitor(ref, [:flush])
+    sync = finish_sync(state.sync, result)
+    {:noreply, broadcast(%{state | task_ref: nil, sync: sync}, :force)}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{task_ref: ref} = state) do
+    sync = %{
+      state.sync
+      | status: :error,
+        phase: nil,
+        current: nil,
+        finished_at: DateTime.utc_now(),
+        failures: add_failure(state.sync.failures, "sync crashed: #{inspect(reason)}")
+    }
+
+    {:noreply, broadcast(%{state | task_ref: nil, sync: sync}, :force)}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  defp begin_sync(state, opts) do
+    server = self()
+
+    task =
+      Task.Supervisor.async_nolink(Sanctum.TaskSupervisor, fn ->
+        CardSync.run(Keyword.put(opts, :progress_fun, &send(server, {:progress, &1})))
+      end)
+
+    sync = %{idle_sync() | status: :running, phase: :fetching, started_at: DateTime.utc_now()}
+    broadcast(%{state | task_ref: task.ref, sync: sync}, :force)
+  end
+
+  # Uploads need the bucket credentials; a missing var would otherwise crash
+  # the task on the first image that isn't in the bucket yet.
+  defp missing_env(opts) do
+    if Keyword.get(opts, :images?, true) do
+      Enum.filter(@aws_env, &(System.get_env(&1) in [nil, ""]))
+    else
+      []
+    end
+  end
+
+  defp idle_sync do
+    %{
+      status: :idle,
+      phase: nil,
+      current: nil,
+      index: 0,
+      total: nil,
+      data: %{synced: 0, failed: 0},
+      images: %{uploaded: 0, skipped: 0, failed: 0},
+      failures: [],
+      started_at: nil,
+      finished_at: nil
+    }
+  end
+
+  defp apply_event(sync, {:data_started, %{cards: cards}}),
+    do: %{sync | phase: :data, index: 0, total: cards, current: nil}
+
+  defp apply_event(sync, {:card, %{index: index, total: total, name: name, ok?: ok?}}) do
+    data = Map.update!(sync.data, if(ok?, do: :synced, else: :failed), &(&1 + 1))
+    %{sync | index: index, total: total, current: name, data: data}
+  end
+
+  defp apply_event(sync, {:data_done, %{synced: synced, failures: failures}}) do
+    formatted =
+      Enum.map(failures, fn {base_code, error} -> "card #{base_code}: #{inspect(error)}" end)
+
+    %{
+      sync
+      | current: nil,
+        data: %{synced: synced, failed: length(failures)},
+        failures: Enum.reduce(formatted, sync.failures, &add_failure(&2, &1))
+    }
+  end
+
+  defp apply_event(sync, {:images_started, %{total: total}}),
+    do: %{sync | phase: :images, index: 0, total: total, current: nil}
+
+  defp apply_event(sync, {:image, %{index: index, total: total, file: file, result: result}}) do
+    key =
+      case result do
+        :uploaded -> :uploaded
+        :error -> :failed
+        _skipped_or_no_image -> :skipped
+      end
+
+    %{
+      sync
+      | index: index,
+        total: total,
+        current: file,
+        images: Map.update!(sync.images, key, &(&1 + 1))
+    }
+  end
+
+  defp apply_event(
+         sync,
+         {:images_done, %{uploaded: uploaded, skipped: skipped, failures: failures}}
+       ) do
+    formatted = Enum.map(failures, &"image: #{inspect(&1)}")
+
+    %{
+      sync
+      | current: nil,
+        images: %{uploaded: uploaded, skipped: skipped, failed: length(failures)},
+        failures: Enum.reduce(formatted, sync.failures, &add_failure(&2, &1))
+    }
+  end
+
+  defp apply_event(sync, {:dry_run, %{entries: entries, cards: cards, images: images}}),
+    do: %{sync | current: "dry run: #{entries} entries -> #{cards} cards, #{images} images"}
+
+  defp apply_event(sync, _event), do: sync
+
+  defp finish_sync(sync, result) do
+    status =
+      case result do
+        {:ok, _} -> :done
+        {:error, _} -> :error
+      end
+
+    failures =
+      case result do
+        # Summary failures were already collected from the *_done events
+        {:error, %{data: _}} -> sync.failures
+        {:error, reason} -> add_failure(sync.failures, "fetch failed: #{inspect(reason)}")
+        {:ok, _} -> sync.failures
+      end
+
+    %{
+      sync
+      | status: status,
+        phase: nil,
+        current: nil,
+        finished_at: DateTime.utc_now(),
+        failures: failures
+    }
+  end
+
+  defp add_failure(failures, message), do: Enum.take([message | failures], @max_failures_kept)
+
+  defp broadcast_mode({:card, _}), do: :throttled
+  defp broadcast_mode({:image, _}), do: :throttled
+  defp broadcast_mode(_event), do: :force
+
+  defp broadcast(state, mode) do
+    now = System.monotonic_time(:millisecond)
+
+    if mode == :force or now - state.last_broadcast >= @broadcast_interval_ms do
+      Phoenix.PubSub.broadcast(Sanctum.PubSub, @topic, {:card_sync, state.sync})
+      %{state | last_broadcast: now}
+    else
+      state
+    end
+  end
+end

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -135,19 +135,44 @@ defmodule Sanctum.MarvelCdb do
       stored on the side. Defaults to an absolute marvelcdb.com URL;
       `Sanctum.CardSync` passes `Sanctum.CardImages.public_url/1` to point at
       the mirrored bucket instead.
+    * `:on_progress` — called after each card group with
+      `%{index, total, base_code, name, ok?}`.
   """
   def sync_entries(entries, opts \\ []) do
-    entries
-    |> Enum.uniq_by(& &1["code"])
-    |> Enum.group_by(&extract_base_code(&1["code"]))
-    |> Enum.reduce({0, []}, fn {base_code, group}, {synced, failures} ->
-      case create_card_from_entries(group, opts) do
+    on_progress = Keyword.get(opts, :on_progress)
+
+    groups =
+      entries
+      |> Enum.uniq_by(& &1["code"])
+      |> Enum.group_by(&extract_base_code(&1["code"]))
+      |> Enum.sort_by(fn {base_code, _group} -> base_code end)
+
+    total = length(groups)
+
+    groups
+    |> Enum.with_index(1)
+    |> Enum.reduce({0, []}, fn {{base_code, group}, index}, {synced, failures} ->
+      result = create_card_from_entries(group, opts)
+
+      if on_progress do
+        on_progress.(%{
+          index: index,
+          total: total,
+          base_code: base_code,
+          name: group_name(group),
+          ok?: match?({:ok, _}, result)
+        })
+      end
+
+      case result do
         {:ok, _card} -> {synced + 1, failures}
         {:error, error} -> {synced, [{base_code, error} | failures]}
       end
     end)
     |> then(fn {synced, failures} -> {synced, Enum.reverse(failures)} end)
   end
+
+  defp group_name(group), do: Enum.find_value(group, &presence(&1["name"]))
 
   def load_card(card_id) when is_integer(card_id) do
     card_id

--- a/lib/sanctum_web/live/card_live/index.ex
+++ b/lib/sanctum_web/live/card_live/index.ex
@@ -8,6 +8,9 @@ defmodule SanctumWeb.CardLive.Index do
       <.header>
         Listing Cards
         <:actions>
+          <.button navigate={~p"/cards/sync"}>
+            <.icon name="hero-arrow-path" /> Sync
+          </.button>
           <.button variant="primary" navigate={~p"/cards/new"}>
             <.icon name="hero-plus" /> New Card
           </.button>

--- a/lib/sanctum_web/live/card_live/sync.ex
+++ b/lib/sanctum_web/live/card_live/sync.ex
@@ -1,0 +1,174 @@
+defmodule SanctumWeb.CardLive.Sync do
+  use SanctumWeb, :live_view
+
+  alias Sanctum.CardSync.Server
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.admin flash={@flash}>
+      <.header>
+        Card Sync
+        <:subtitle>
+          Pulls the card catalog from MarvelCDB and mirrors card scans into the public bucket.
+        </:subtitle>
+        <:actions>
+          <.button navigate={~p"/cards"}>
+            <.icon name="hero-arrow-left" /> Back to cards
+          </.button>
+        </:actions>
+      </.header>
+
+      <div class="space-y-6">
+        <div class="rounded-lg border border-base-300 bg-base-200 p-4 space-y-4">
+          <div class="flex items-center gap-3">
+            <span class={[
+              "inline-flex items-center rounded-full px-3 py-1 text-sm font-medium",
+              status_class(@sync.status)
+            ]}>
+              {status_label(@sync.status)}
+            </span>
+            <span :if={@sync.started_at} class="text-sm text-base-content/60">
+              started {Calendar.strftime(@sync.started_at, "%Y-%m-%d %H:%M:%S UTC")}
+            </span>
+            <span :if={@sync.finished_at} class="text-sm text-base-content/60">
+              &middot; finished {Calendar.strftime(@sync.finished_at, "%Y-%m-%d %H:%M:%S UTC")}
+            </span>
+          </div>
+
+          <div :if={@sync.status == :running} class="space-y-2">
+            <div class="flex items-baseline justify-between text-sm">
+              <span class="font-medium">{phase_label(@sync.phase)}</span>
+              <span :if={@sync.total} class="tabular-nums text-base-content/70">
+                {@sync.index} / {@sync.total}
+              </span>
+            </div>
+
+            <div class="h-3 w-full overflow-hidden rounded-full bg-base-300">
+              <div
+                class="h-full rounded-full bg-primary transition-[width] duration-150"
+                style={"width: #{percent(@sync)}%"}
+              >
+              </div>
+            </div>
+
+            <div :if={@sync.current} class="truncate text-sm text-base-content/70">
+              {@sync.current}
+            </div>
+          </div>
+
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-5 text-sm">
+            <.stat label="Cards synced" value={@sync.data.synced} />
+            <.stat label="Cards failed" value={@sync.data.failed} error?={@sync.data.failed > 0} />
+            <.stat label="Images uploaded" value={@sync.images.uploaded} />
+            <.stat label="Images skipped" value={@sync.images.skipped} />
+            <.stat
+              label="Images failed"
+              value={@sync.images.failed}
+              error?={@sync.images.failed > 0}
+            />
+          </div>
+        </div>
+
+        <form phx-submit="start" class="rounded-lg border border-base-300 bg-base-200 p-4 space-y-3">
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="skip_images" value="true" class="checkbox checkbox-sm" />
+            Skip images (card data only)
+          </label>
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" name="force" value="true" class="checkbox checkbox-sm" />
+            Force re-upload of images already in the bucket
+          </label>
+
+          <.button variant="primary" disabled={@sync.status == :running}>
+            <.icon name="hero-arrow-path" />
+            {if @sync.status == :running, do: "Sync running…", else: "Start sync"}
+          </.button>
+        </form>
+
+        <div :if={@sync.failures != []} class="rounded-lg border border-error/40 bg-base-200 p-4">
+          <h3 class="mb-2 text-sm font-semibold text-error">
+            Failures ({length(@sync.failures)} most recent)
+          </h3>
+          <ul class="space-y-1 text-xs font-mono text-base-content/80">
+            <li :for={failure <- @sync.failures} class="truncate">{failure}</li>
+          </ul>
+        </div>
+      </div>
+    </Layouts.admin>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :integer, required: true
+  attr :error?, :boolean, default: false
+
+  defp stat(assigns) do
+    ~H"""
+    <div class="rounded-md bg-base-100 p-3">
+      <div class="text-xs text-base-content/60">{@label}</div>
+      <div class={["text-lg font-semibold tabular-nums", @error? && "text-error"]}>{@value}</div>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: Server.subscribe()
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Card Sync")
+     |> assign_new(:current_user, fn -> nil end)
+     |> assign(:sync, Server.status())}
+  end
+
+  @impl true
+  def handle_event("start", params, socket) do
+    opts = [
+      images?: params["skip_images"] != "true",
+      force?: params["force"] == "true"
+    ]
+
+    case Server.start_sync(opts) do
+      :ok ->
+        {:noreply, put_flash(socket, :info, "Card sync started")}
+
+      {:error, :already_running} ->
+        {:noreply, put_flash(socket, :error, "A sync is already running")}
+
+      {:error, {:missing_env, vars}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Missing bucket credentials (#{Enum.join(vars, ", ")}) — set them or check \"Skip images\""
+         )}
+    end
+  end
+
+  @impl true
+  def handle_info({:card_sync, sync}, socket) do
+    {:noreply, assign(socket, :sync, sync)}
+  end
+
+  defp percent(%{total: total, index: index}) when is_integer(total) and total > 0,
+    do: Float.round(index / total * 100, 1)
+
+  defp percent(_sync), do: 0
+
+  defp status_label(:idle), do: "Idle"
+  defp status_label(:running), do: "Running"
+  defp status_label(:done), do: "Completed"
+  defp status_label(:error), do: "Failed"
+
+  defp status_class(:idle), do: "bg-base-300 text-base-content/70"
+  defp status_class(:running), do: "bg-info/20 text-info"
+  defp status_class(:done), do: "bg-success/20 text-success"
+  defp status_class(:error), do: "bg-error/20 text-error"
+
+  defp phase_label(:fetching), do: "Fetching card list from MarvelCDB…"
+  defp phase_label(:data), do: "Syncing card data"
+  defp phase_label(:images), do: "Mirroring images to the bucket"
+  defp phase_label(_phase), do: ""
+end

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -44,6 +44,7 @@ defmodule SanctumWeb.Router do
 
       live "/cards", CardLive.Index, :index
       live "/cards/new", CardLive.Form, :new
+      live "/cards/sync", CardLive.Sync, :index
       live "/cards/:id/edit", CardLive.Form, :edit
 
       live "/cards/:id", CardLive.Show, :show

--- a/test/sanctum/card_sync/server_test.exs
+++ b/test/sanctum/card_sync/server_test.exs
@@ -1,0 +1,94 @@
+defmodule Sanctum.CardSync.ServerTest do
+  @moduledoc false
+
+  # async: false — the server task hits the DB outside the test process (needs
+  # the shared sandbox) and the Req stub must be visible to that task too.
+  use Sanctum.DataCase, async: false
+
+  alias Sanctum.CardSync.Server
+  alias Sanctum.Games
+
+  @entries [
+    %{
+      "code" => "01050",
+      "name" => "Hulk",
+      "type_code" => "ally",
+      "faction_code" => "aggression",
+      "pack_code" => "core",
+      "imagesrc" => "/bundles/cards/01050.png"
+    },
+    %{
+      "code" => "01001a",
+      "name" => "Spider-Man",
+      "type_code" => "hero",
+      "pack_code" => "core",
+      "imagesrc" => "/bundles/cards/01001a.png"
+    },
+    %{
+      "code" => "01001b",
+      "name" => "Peter Parker",
+      "type_code" => "alter_ego",
+      "pack_code" => "core",
+      "imagesrc" => "/bundles/cards/01001b.png"
+    }
+  ]
+
+  setup do
+    # The sync task is not the test process, so route its requests through a
+    # plug fun instead of a process-owned Req.Test stub. The slow response
+    # keeps the run alive long enough to observe the :running state.
+    original = Application.get_env(:sanctum, :marvel_cdb_req_options)
+
+    Application.put_env(:sanctum, :marvel_cdb_req_options,
+      plug: fn conn ->
+        Process.sleep(100)
+        Req.Test.json(conn, @entries)
+      end
+    )
+
+    on_exit(fn -> Application.put_env(:sanctum, :marvel_cdb_req_options, original) end)
+
+    Server.subscribe()
+    :ok
+  end
+
+  test "runs a sync in a detached task and broadcasts progress" do
+    assert :ok = Server.start_sync(images?: false)
+
+    assert_receive {:card_sync, %{status: :running}}
+
+    # Only one sync at a time
+    assert {:error, :already_running} = Server.start_sync(images?: false)
+
+    assert_receive {:card_sync, %{status: :done} = final}, 2_000
+    assert final.data == %{synced: 2, failed: 0}
+    assert final.failures == []
+    assert %DateTime{} = final.finished_at
+
+    # The detached task actually wrote through Ash
+    assert Games.get_card_by_code!("01001").is_multi_sided
+
+    # Status survives for late-mounting LiveViews
+    assert %{status: :done} = Server.status()
+  end
+
+  test "refuses to mirror images without bucket credentials" do
+    vars = ~w(AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINT_URL_S3 BUCKET_NAME)
+    original = Map.new(vars, &{&1, System.get_env(&1)})
+    Enum.each(vars, &System.delete_env/1)
+
+    on_exit(fn ->
+      Enum.each(original, fn
+        {_var, nil} -> :ok
+        {var, value} -> System.put_env(var, value)
+      end)
+    end)
+
+    assert {:error, {:missing_env, missing}} = Server.start_sync([])
+    assert "AWS_ACCESS_KEY_ID" in missing
+
+    # Data-only syncs don't need credentials
+    assert :ok = Server.start_sync(images?: false)
+    assert_receive {:card_sync, %{status: :done}}, 2_000
+  end
+end

--- a/test/sanctum_web/live/card_live/sync_test.exs
+++ b/test/sanctum_web/live/card_live/sync_test.exs
@@ -1,0 +1,43 @@
+defmodule SanctumWeb.CardLive.SyncTest do
+  @moduledoc false
+
+  use SanctumWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  test "renders the sync page with a start button when no sync is running", %{conn: conn} do
+    # The singleton server may hold :idle or a previous test's :done state —
+    # either way, no sync is running and the form must be startable.
+    {:ok, _view, html} = live(conn, ~p"/cards/sync")
+
+    assert html =~ "Card Sync"
+    assert html =~ "Start sync"
+    assert html =~ "Skip images"
+  end
+
+  test "renders live progress from PubSub broadcasts", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/cards/sync")
+
+    running = %{
+      status: :running,
+      phase: :images,
+      current: "01097b.png",
+      index: 150,
+      total: 3598,
+      data: %{synced: 3887, failed: 0},
+      images: %{uploaded: 120, skipped: 30, failed: 0},
+      failures: [],
+      started_at: ~U[2026-07-13 12:00:00Z],
+      finished_at: nil
+    }
+
+    send(view.pid, {:card_sync, running})
+    html = render(view)
+
+    assert html =~ "Mirroring images to the bucket"
+    assert html =~ "01097b.png"
+    assert html =~ "150 / 3598"
+    assert html =~ "3887"
+    assert html =~ "Sync running…"
+  end
+end


### PR DESCRIPTION

## What

Adds `/cards/sync`: a page to start a catalog sync and watch its progress live — a progress bar with an `x / y` counter, the name of the card or image file currently being processed, running tallies, and a recent-failures list.

## How

- The sync runs detached in `Sanctum.CardSync.Server` (a GenServer that runs the sync in a supervised `Task`), so navigating away never kills a run, and a LiveView mounted mid-run picks up in-flight progress from server state.
- Progress fans out over `Phoenix.PubSub`, throttled to ~10 broadcasts/sec (the data phase emits hundreds of events per second).
- Starting a sync is guarded against concurrent runs and against missing bucket credentials when images are requested (friendly flash instead of a task crash).
- `CardSync.run` now emits structured progress events through a `:progress_fun`; the default handler reproduces the previous CLI output, so `mix sanctum.sync_cards` and release eval are unchanged.

## Verification

A full data sync driven from the server finished **3,887 cards in ~15s with zero failures**; a page mounted mid-run showed the phase, counter, and current card. Concurrent-start rejection and the missing-credentials guard both confirmed.

Stacked on #58 (card sync core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)