### PR TITLE
feat(cards): paginate /cards listing with infinite scroll

### DIFF
--- a/lib/sanctum/games/card.ex
+++ b/lib/sanctum/games/card.ex
@@ -15,7 +15,12 @@ defmodule Sanctum.Games.Card do
   end
 
   actions do
-    defaults [:read, :destroy]
+    defaults [:destroy]
+
+    read :read do
+      primary? true
+      pagination offset?: true, default_limit: 50, required?: false
+    end
 
     create :create do
       primary? true

--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -333,6 +333,8 @@ defmodule SanctumWeb.CoreComponents do
 
   slot :action, doc: "the slot for showing user actions in the last table column"
 
+  attr :rest, :global, include: ~w(phx-viewport-top phx-viewport-bottom)
+
   def table(assigns) do
     assigns =
       with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
@@ -349,7 +351,7 @@ defmodule SanctumWeb.CoreComponents do
           </th>
         </tr>
       </thead>
-      <tbody id={@id} phx-update={is_struct(@rows, Phoenix.LiveView.LiveStream) && "stream"}>
+      <tbody id={@id} phx-update={is_struct(@rows, Phoenix.LiveView.LiveStream) && "stream"} {@rest}>
         <tr :for={row <- @rows} id={@row_id && @row_id.(row)}>
           <td
             :for={col <- @col}

--- a/lib/sanctum_web/live/card_live/index.ex
+++ b/lib/sanctum_web/live/card_live/index.ex
@@ -22,6 +22,7 @@ defmodule SanctumWeb.CardLive.Index do
           id="cards"
           rows={@streams.cards}
           row_click={fn {_id, card} -> JS.navigate(~p"/cards/#{card}") end}
+          phx-viewport-bottom={!@end_of_timeline? && "next-page"}
         >
           <:col :let={{_id, card}} label="Image">
             <img
@@ -87,26 +88,46 @@ defmodule SanctumWeb.CardLive.Index do
     """
   end
 
+  @page_size 50
+
   @impl true
   def mount(_params, _session, socket) do
-    cards =
-      Sanctum.Games.list_cards!(
-        actor: socket.assigns[:current_user],
-        load: [:primary_side, :card_sides],
-        query: [sort: [base_code: :asc]]
-      )
-
     {:ok,
      socket
      |> assign(:page_title, "Listing Cards")
-     |> stream(:cards, cards)}
+     |> assign(:offset, 0)
+     |> assign(:end_of_timeline?, false)
+     |> paginate_cards(0)}
   end
 
   @impl true
+  def handle_event("next-page", _params, socket) do
+    if socket.assigns.end_of_timeline? do
+      {:noreply, socket}
+    else
+      {:noreply, paginate_cards(socket, socket.assigns.offset + @page_size)}
+    end
+  end
+
   def handle_event("delete", %{"id" => id}, socket) do
     card = Ash.get!(Sanctum.Games.Card, id, actor: socket.assigns.current_user)
     Ash.destroy!(card, actor: socket.assigns.current_user)
 
     {:noreply, stream_delete(socket, :cards, card)}
+  end
+
+  defp paginate_cards(socket, offset) do
+    page =
+      Sanctum.Games.list_cards!(
+        actor: socket.assigns[:current_user],
+        load: [:primary_side, :card_sides],
+        query: [sort: [base_code: :asc]],
+        page: [limit: @page_size, offset: offset]
+      )
+
+    socket
+    |> assign(:offset, offset)
+    |> assign(:end_of_timeline?, !page.more?)
+    |> stream(:cards, page.results, at: -1)
   end
 end


### PR DESCRIPTION
## Problem

The admin card listing at `/cards` loaded the **entire ~3,900-card catalog** in a single query at mount — each row eager-loading its `primary_side` and full `card_sides` association — then rendered thousands of `<tr>`/`<img>` up front. Slow to mount, heavy on the DB, and wasteful since only the first screenful is visible.

## Change

Load **50 cards per page** and append the next page as the user scrolls to the bottom (automatic infinite scroll), using Ash offset pagination + the existing LiveView stream + Phoenix's built-in `phx-viewport-bottom` binding — no custom JS hook.

- **`Card`** — split the defaulted `:read` into an explicit primary read action with `pagination offset?: true, default_limit: 50, required?: false`. `required?: false` keeps non-paginated callers (sync, deck import, `get_card_by_code`) unchanged.
- **`CardLive.Index`** — `mount` loads page 0; a `next-page` handler fetches the next page and appends via `stream(:cards, results, at: -1)`; `end_of_timeline?` tracks the page's `more?` flag so the viewport binding stops firing at the end of the catalog.
- **`core_components`** — `<.table>` gains a `:global` rest passthrough (incl. `phx-viewport-*`) applied to its `<tbody>`; additive and backward-compatible with every existing caller.

## Verification

- `mix compile` clean; `mix ash.codegen --check` exit 0 (no migration needed — pagination is action config only).
- `mix format` + `mix credo` clean on the changed files.
- Verified against the dev DB (3,887 cards): proper `Ash.Page.Offset`, 50 rows/page, correct offsets with no overlap (page 0 → `01001`, page 1 → `01051`), and the final page (offset 3850, 37 rows) returns `more?: false` → `end_of_timeline?` flips true and the viewport binding stops firing.

Note: the pagination query and end-of-timeline logic were verified directly against the running app's DB; the in-browser scroll wasn't driven because `/cards` is admin-gated. The render delta is a single passthrough attribute on an already-working stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)