### PR TITLE
fix(ci): serialize changelog job to prevent version tag races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,14 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
+    # Serialize release runs so concurrent pushes to main don't race to create
+    # the same version tag (e.g. `fatal: tag 'v1.0.0' already exists`). Queued
+    # runs wait for the in-progress release instead of cancelling it, so each
+    # push gets its changelog/tag off an up-to-date main.
+    concurrency:
+      group: changelog-release
+      cancel-in-progress: false
+
     outputs:
       skipped: ${{ steps.changelog.outputs.skipped }}
       tag: ${{ steps.changelog.outputs.tag }}


### PR DESCRIPTION
## Problem

The \`changelog\` job runs on every push to \`main\`. When several PRs merge in quick succession (e.g. #58/#59/#60 merged within ~26s), multiple \`changelog\` jobs run **concurrently**. Each independently computes the same next version via \`TriPSs/conventional-changelog-action\` and races to create the git tag. The first wins; the rest fail with:

\`\`\`
fatal: tag 'v1.0.0' already exists
\`\`\`

This is why the last several CI runs on \`main\` failed.

## Fix

Add a job-scoped concurrency group to the \`changelog\` job:

\`\`\`yaml
concurrency:
  group: changelog-release
  cancel-in-progress: false
\`\`\`

Release runs now serialize instead of overlapping. A queued run waits for the in-progress release to finish tagging + bumping the version, then computes the next version off the tag the prior run just created (checkout uses \`fetch-depth: 0\`, so all tags are present). \`cancel-in-progress: false\` ensures a queued release waits its turn rather than clobbering one mid-flight.

Scoped to the job — not the workflow — so \`lint\` and \`build_and_test\` still run fully in parallel across branches.

## Note

There's a pre-existing divergence between \`mix.exs\` (\`0.13.0\`) and the tag sequence (jumps \`v0.9.0\` → \`v1.0.0\`), a scar from these races. Left alone to self-heal, since the action tags off the latest git tag and overwrites \`mix.exs\` on the next release regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)