### PR TITLE
fix(ci): retry migrations on cold Neon compute and fix changelog PR quoting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,16 @@ jobs:
 
       - name: Create Changelog PR
         if: steps.changelog.outputs.skipped == 'false'
+        # Pass the title/body through env vars rather than inlining them into the
+        # command. The changelog body can contain quotes and other shell
+        # metacharacters (an apostrophe once broke `--body '...'` quoting), which
+        # is both a correctness bug and a command-injection risk.
         run: |
-          gh pr create --base main --head ${{ env.PR_BRANCH }} --title 'chore(release): ${{ steps.changelog.outputs.tag }} [skip-ci]' --body '${{ steps.changelog.outputs.clean_changelog }}'
+          gh pr create --base main --head "$PR_BRANCH" --title "$PR_TITLE" --body "$PR_BODY"
         env:
           GH_TOKEN: ${{ secrets.github_token }}
+          PR_TITLE: "chore(release): ${{ steps.changelog.outputs.tag }} [skip-ci]"
+          PR_BODY: ${{ steps.changelog.outputs.clean_changelog }}
 
       - name: Merge Changelog PR
         if: steps.changelog.outputs.skipped == 'false'

--- a/lib/sanctum/release.ex
+++ b/lib/sanctum/release.ex
@@ -9,8 +9,30 @@ defmodule Sanctum.Release do
     load_app()
 
     for repo <- repos() do
-      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+      migrate_repo(repo)
     end
+  end
+
+  # Neon scales its compute to zero when the app is idle. On deploy this release
+  # command runs on a fresh machine, and its first connection often lands before
+  # the Neon endpoint has finished waking, so the initial migration attempt fails
+  # with a connection/timeout error. Retry with a short backoff to give the
+  # compute time to come online before aborting the deploy.
+  defp migrate_repo(repo, attempts \\ 5) do
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+  rescue
+    error ->
+      if attempts > 1 do
+        IO.puts(
+          "Migration attempt failed (#{Exception.message(error)}); " <>
+            "the database may still be waking. Retrying in 3s (#{attempts - 1} left)..."
+        )
+
+        Process.sleep(3_000)
+        migrate_repo(repo, attempts - 1)
+      else
+        reraise error, __STACKTRACE__
+      end
   end
 
   def rollback(repo, version) do


### PR DESCRIPTION
## Summary

Fixes two failures in the deploy pipeline observed on recent `main` pushes.

### 1. Migration fails against a cold Neon compute
Neon scales its compute to zero when the app is idle. Fly's `release_command` (`/app/bin/migrate`) runs on a fresh machine, and its first DB connection often lands *before* the Neon endpoint has finished waking — so the initial migration attempt fails and aborts the whole deploy.

Observed in [this run](https://github.com/jwstover/sanctum/actions/runs/29264561618/job/86866312294):
```
Could not create schema migrations table. ... The database does not exist
** (exit) exited in: GenServer.stop(Sanctum.Repo, :normal, 5000) ** (EXIT) time out
    (ecto_sql 3.14.0) lib/ecto/migrator.ex:171: Ecto.Migrator.with_repo/3
    (sanctum 0.13.0) lib/sanctum/release.ex:12
```

`Ecto.Migrator.with_repo/3` runs immediately with no retry, so a single cold-start miss fails the deploy. `Sanctum.Release.migrate/0` now retries `with_repo` up to 5 times with a 3s backoff so the retry hits a warm compute. The `rescue` handles both failure shapes (the `{:ok, _, _} =` match error on an error tuple, and exceptions raised when the query hits a not-yet-awake endpoint, including the `GenServer.stop` timeout). The original error is re-raised after the final attempt so genuine migration bugs still fail the deploy.

### 2. Changelog PR creation breaks on quotes in the body
The changelog body was inlined into `gh pr create --body '...'` via `${{ steps.changelog.outputs.clean_changelog }}`. A changelog entry containing an apostrophe (`button component's :global include list`) closed the shell quote, turning the rest into stray args.

Observed in [this run](https://github.com/jwstover/sanctum/actions/runs/29264717090/job/86867791319):
```
unknown arguments [":global" "include" "list." "Its" "updated" "HEEx" "formatter" "also"]
```

The title and body now pass through `PR_TITLE` / `PR_BODY` env vars referenced with double quotes, so quotes and other shell metacharacters in the changelog can't break arg parsing — this also closes the command-injection vector.

## Test plan
- `mix compile --warnings-as-errors` passes; `mix format` clean.
- Migration retry can't be fully exercised without a real cold Neon endpoint; the retry path re-raises on final failure so genuine errors still surface.
- Changelog quoting fix will be validated on the next `main` push through the changelog job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)