### PR TITLE
chore(ci): bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/actions/elixir-setup/action.yml
+++ b/.github/actions/elixir-setup/action.yml
@@ -64,7 +64,7 @@ runs:
         otp-version: ${{ inputs.otp-version }}
 
     - name: Get deps cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: deps/
         key: deps-${{ inputs.cache-key }}-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
@@ -72,7 +72,7 @@ runs:
           deps-${{ inputs.cache-key }}-${{ runner.os }}-
 
     - name: Get build cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: build-cache
       with:
         path: _build/${{env.MIX_ENV}}/
@@ -81,7 +81,7 @@ runs:
           build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-
 
     - name: Get Hex cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: hex-cache
       with:
         path: ~/.hex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Elixir Project
         uses: ./.github/actions/elixir-setup
@@ -40,7 +40,7 @@ jobs:
       # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
       # Cache key based on Elixir & Erlang version (also useful when running in matrix)
       - name: Restore PLT cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: plt_cache
         with:
           key: plt-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}-${{ hashFiles('**/*.ex') }}
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Elixir Project
         uses: ./.github/actions/elixir-setup
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Elixir Project
         uses: ./.github/actions/elixir-setup
@@ -160,7 +160,7 @@ jobs:
       PR_BRANCH: release-ci-${{ github.sha }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -169,7 +169,7 @@ jobs:
           git checkout -b ${{ env.PR_BRANCH }}
 
       - name: Create Changelog
-        uses: TriPSs/conventional-changelog-action@v5
+        uses: TriPSs/conventional-changelog-action@v6
         id: changelog
         with:
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: deploy-group    # optional: ensure only one action runs at a time
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:


### PR DESCRIPTION
## Summary

GitHub is [deprecating the Node.js 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for Actions. Recent CI runs surfaced deprecation warnings because several actions still target Node 20 and are being force-run on Node 24. This bumps them to the latest majors, all of which natively target Node 24:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/cache` | v4 | v6 |
| `TriPSs/conventional-changelog-action` | v5 | v6 |

Touched files: `.github/workflows/ci.yml`, `.github/workflows/fly-deploy.yml`, `.github/actions/elixir-setup/action.yml`.

`superfly/flyctl-actions/setup-flyctl@master` and `erlef/setup-beam@v1` were not flagged and are left as-is.

## Breaking changes reviewed — none relevant
- **checkout v7** only adds blocking of fork-PR checkouts for `pull_request_target` / `workflow_run` (neither trigger is used here) plus an internal ESM migration.
- **cache v5/v6** are the Node 24 bump + ESM migration; no config changes.
- **conventional-changelog v6**'s sole breaking change is prerelease type derivation from `releaseType`, which this repo doesn't configure.

## Test plan
- CI on this PR exercises the bumped `checkout` and `cache` actions directly (lint + build/test jobs).
- The `conventional-changelog` bump runs only on `main` (changelog job skips on PRs), so it will be validated on the post-merge run — which is being watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)