### PR TITLE
feat(decks): add basic deck list and view pages

### DIFF
--- a/lib/sanctum/decks/deck.ex
+++ b/lib/sanctum/decks/deck.ex
@@ -120,6 +120,11 @@ defmodule Sanctum.Decks.Deck do
     end
   end
 
+  aggregates do
+    count :card_row_count, :deck_cards
+    sum :total_card_count, :deck_cards, :quantity
+  end
+
   identities do
     identity :unique_mcdb_deck, [:mcdb_type, :mcdb_id]
   end

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -1,0 +1,65 @@
+defmodule SanctumWeb.DeckLive.Index do
+  use SanctumWeb, :live_view
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.admin flash={@flash}>
+      <.header>
+        Listing Decks
+        <:subtitle>{length(@decks)} deck(s) — mostly synced from MarvelCDB</:subtitle>
+      </.header>
+
+      <div class="w-full flex-1 min-h-0 overflow-auto">
+        <.table
+          id="decks"
+          rows={@decks}
+          row_click={fn deck -> JS.navigate(~p"/decks/#{deck}") end}
+        >
+          <:col :let={deck} label="Title">
+            <div class="font-medium">{deck.title}</div>
+          </:col>
+          <:col :let={deck} label="Hero">{deck.hero && deck.hero.hero_name}</:col>
+          <:col :let={deck} label="Aspects">{format_aspects(deck.aspects)}</:col>
+          <:col :let={deck} label="Cards">
+            {deck.total_card_count || 0} ({deck.card_row_count} unique)
+          </:col>
+          <:col :let={deck} label="Source">{deck.source}</:col>
+          <:col :let={deck} label="MarvelCDB">
+            <span :if={deck.mcdb_id}>{deck.mcdb_type}/{deck.mcdb_id}</span>
+          </:col>
+          <:col :let={deck} label="Author">
+            <span :if={deck.mcdb_user}>#{deck.mcdb_user.mcdb_user_id}</span>
+          </:col>
+
+          <:action :let={deck}>
+            <.link navigate={~p"/decks/#{deck}"}>Show</.link>
+          </:action>
+        </.table>
+      </div>
+    </Layouts.admin>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Listing Decks")
+     |> assign_decks()}
+  end
+
+  defp assign_decks(socket) do
+    decks =
+      Sanctum.Decks.list_decks!(
+        actor: socket.assigns[:current_user],
+        load: [:hero, :mcdb_user, :card_row_count, :total_card_count],
+        query: [sort: [inserted_at: :desc]]
+      )
+
+    assign(socket, :decks, decks)
+  end
+
+  defp format_aspects([]), do: "basic"
+  defp format_aspects(aspects), do: Enum.map_join(aspects, ", ", &to_string/1)
+end

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -1,0 +1,102 @@
+defmodule SanctumWeb.DeckLive.Show do
+  use SanctumWeb, :live_view
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.admin flash={@flash}>
+      <.header>
+        {@deck.title}
+        <:subtitle>
+          {@deck.hero && @deck.hero.hero_name} — {format_aspects(@deck.aspects)}
+        </:subtitle>
+        <:actions>
+          <.button navigate={~p"/decks"}>
+            <.icon name="hero-arrow-left" />
+          </.button>
+        </:actions>
+      </.header>
+
+      <div class="flex-1 min-h-0 overflow-y-auto pr-1">
+        <div class="mb-8 p-6 border-2 border-neutral bg-base-200 shadow-comic">
+          <h3 class="font-komika text-lg mb-4">Deck Information</h3>
+          <.list>
+            <:item title="Source">{@deck.source}</:item>
+            <:item :if={@deck.mcdb_id} title="MarvelCDB">
+              {@deck.mcdb_type}/{@deck.mcdb_id}
+            </:item>
+            <:item :if={@deck.mcdb_user} title="Author (MarvelCDB user)">
+              #{@deck.mcdb_user.mcdb_user_id}
+            </:item>
+            <:item title="Aspects">{format_aspects(@deck.aspects)}</:item>
+            <:item :if={@deck.tags} title="Tags">{@deck.tags}</:item>
+            <:item :if={@deck.version} title="Version">{@deck.version}</:item>
+            <:item title="Cards">
+              {@total_cards} ({length(@deck.deck_cards)} unique)
+            </:item>
+            <:item :if={@deck.meta && @deck.meta != %{}} title="Raw meta">
+              <code class="text-xs bg-base-300 px-2 py-1">{inspect(@deck.meta)}</code>
+            </:item>
+          </.list>
+        </div>
+
+        <div
+          :if={@deck.description_md}
+          class="mb-8 p-6 border-2 border-neutral bg-base-200 shadow-comic"
+        >
+          <h3 class="font-komika text-lg mb-2">Description</h3>
+          <div class="font-barlow text-[15px] leading-relaxed text-base-content/90 whitespace-pre-wrap">
+            {@deck.description_md}
+          </div>
+        </div>
+
+        <div class="w-full overflow-auto">
+          <.table
+            id="deck-cards"
+            rows={@deck_cards}
+            row_click={fn dc -> JS.navigate(~p"/cards/#{dc.card}") end}
+          >
+            <:col :let={dc} label="Qty">{dc.quantity}</:col>
+            <:col :let={dc} label="Name">{dc.card.primary_side && dc.card.primary_side.name}</:col>
+            <:col :let={dc} label="Type">{dc.card.primary_side && dc.card.primary_side.type}</:col>
+            <:col :let={dc} label="Aspect">
+              {dc.card.primary_side && dc.card.primary_side.aspect}
+            </:col>
+            <:col :let={dc} label="Cost">{dc.card.primary_side && dc.card.primary_side.cost}</:col>
+            <:col :let={dc} label="Base Code">{dc.card.base_code}</:col>
+            <:col :let={dc} label="Ignore Limit">
+              <span :if={dc.ignore_deck_limit}>yes</span>
+            </:col>
+          </.table>
+        </div>
+      </div>
+    </Layouts.admin>
+    """
+  end
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    deck =
+      Sanctum.Decks.get_deck!(id,
+        actor: socket.assigns[:current_user],
+        load: [:hero, :mcdb_user, deck_cards: [card: [:primary_side]]]
+      )
+
+    deck_cards =
+      Enum.sort_by(deck.deck_cards, fn dc ->
+        {to_string(dc.card.primary_side && dc.card.primary_side.type), dc.card.base_code}
+      end)
+
+    total_cards = Enum.sum(Enum.map(deck.deck_cards, & &1.quantity))
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Deck - #{deck.title}")
+     |> assign(:deck, deck)
+     |> assign(:deck_cards, deck_cards)
+     |> assign(:total_cards, total_cards)}
+  end
+
+  defp format_aspects([]), do: "basic"
+  defp format_aspects(aspects), do: Enum.map_join(aspects, ", ", &to_string/1)
+end

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -52,6 +52,9 @@ defmodule SanctumWeb.Router do
 
       live "/cards/:id", CardLive.Show, :show
       live "/cards/:id/show/edit", CardLive.Show, :edit
+
+      live "/decks", DeckLive.Index, :index
+      live "/decks/:id", DeckLive.Show, :show
     end
   end
 


### PR DESCRIPTION
Stacked on #66 (`feat/marvelcdb-deck-sync`) — review/merge that first.

## Why

Adds minimal admin pages to inspect the decks we're syncing from MarvelCDB, so the sync output can be eyeballed without dropping into IEx or AshAdmin.

## What

- **`/decks`** — lists every deck with title, hero, aspects (or "basic"), card counts (total + unique), source, MarvelCDB `type/id`, and author (MarvelCDB user id). Sorted newest-first.
- **`/decks/:id`** — deck metadata (source, aspects, tags, version, raw `meta`, description) plus the full card list with quantities, type, aspect, cost, and an "ignore limit" marker. Rows link to the existing card show page.

Both live under the existing admin-only route scope, mirroring `CardLive`. Adds `card_row_count` / `total_card_count` aggregates to `Deck` for the counts.

## Verification

- Index and show data-load paths verified against the synced decks (aggregates compute, relationships + card sides load).
- `mix ck` clean (Credo + Sobelow); **126 tests pass**; compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)