### PR TITLE
fix(ci): build changelog off tip of main to stop version tag races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,9 +160,18 @@ jobs:
       PR_BRANCH: release-ci-${{ github.sha }}
 
     steps:
+      # Check out the tip of main, NOT the triggering commit. The changelog
+      # action derives the next version by bumping the version in mix.exs, so it
+      # must read the latest mix.exs — the one that already includes the version
+      # bump merged by the previous release run. Building off the (stale)
+      # triggering SHA makes every push that predates the last release-bump
+      # recompute the same version and collide on the tag
+      # (`fatal: tag 'vX.Y.Z' already exists`). The concurrency group above
+      # guarantees the previous run's bump has landed on main before this runs.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: main
 
       - name: Create Branch
         run: |


### PR DESCRIPTION
## Follow-up to #62

#62 added a concurrency group to serialize release runs. That was necessary but **not sufficient** — [run 29286973557](https://github.com/jwstover/sanctum/actions/runs/29286973557/job/86941975593) still died with:

\`\`\`
fatal: tag 'v1.1.0' already exists
\`\`\`

## Root cause (the part #62 missed)

The changelog action derives the next version by **bumping the version in \`mix.exs\`**, not by reading git tags. The job's checkout was pulling the **triggering commit's** \`mix.exs\`, which is stale for any push that landed *before* the previous release run merged its version bump.

In that failed run the log shows it — \`v1.1.0\` was already fetched as an existing tag, yet the action read a \`1.0.x\` \`mix.exs\` from the stale checkout and computed \`New version: 1.1.0\` anyway, then collided on the tag.

Concurrency serialized the runs correctly (the tag existed at fetch time, proving the runs no longer overlap), but a serialized run building off a stale \`mix.exs\` still recomputes the same version.

## Fix

Check out \`ref: main\` in the changelog job so it reads the **latest** \`mix.exs\` — the one already bumped by the previous release run. The concurrency group guarantees that bump has merged before this run starts, so:

- fresh version baseline in → next sequential version out → no collision.

## Together, #62 + this PR

- **Concurrency group** → release runs never overlap; the bump always lands before the next run starts.
- **\`ref: main\` checkout** → each run reads the post-bump \`mix.exs\`, so it computes the next version instead of re-deriving a taken one.

Both are needed: without serialization, two runs check out the same pre-bump \`main\` and race; without \`ref: main\`, a serialized run still reads a stale version file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)