### PR TITLE
fix(ui): restore prod styles blocked by CSP and move colors to Tailwind tokens

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -59,6 +59,34 @@
   --noise: 0;
 }
 
+/* ── Semantic color tokens ────────────────────────────────────────────
+   Registered with Tailwind's @theme so they generate utilities
+   (text-aspect-hero, bg-aspect-justice, text-res-energy, …). This is the
+   single source of truth for aspect + resource colors; the legacy
+   aspect/res var names below alias these for any remaining var() use.
+   Aspect greys/surfaces reuse daisyUI's base-100/200/300 tokens rather
+   than one-off hexes. */
+@theme {
+  --color-aspect-hero: #ce1b2e;
+  --color-aspect-aggression: #b12020;
+  --color-aspect-justice: #dbcb36;
+  --color-aspect-leadership: #2ea7b8;
+  --color-aspect-protection: #46991b;
+  --color-aspect-pool: #d074ac;
+  --color-aspect-basic: #87868f;
+
+  /* DEF stat has no aspect; the other combat stats reuse aspect hues. */
+  --color-stat-defense: #2456a6;
+
+  --color-res-energy: oklch(0.8 0.16 65);
+  --color-res-mental: oklch(0.72 0.15 255);
+  --color-res-physical: oklch(0.67 0.22 25);
+  --color-res-wild: oklch(0.68 0.13 165);
+
+  /* Mid grey used for input/search borders. */
+  --color-line: #2a2a30;
+}
+
 /* Set root font size to 16 */
 :root, html {
   font-size: 16px;
@@ -479,20 +507,20 @@ main, #game-board {
   --sanctum-panel: #15151a;
   --sanctum-border: #08080a;
 
-  /* Aspect accents */
-  --aspect-hero: #ce1b2e;
-  --aspect-aggression: #b12020;
-  --aspect-justice: #dbcb36;
-  --aspect-leadership: #2ea7b8;
-  --aspect-protection: #46991b;
-  --aspect-pool: #d074ac;
-  --aspect-basic: #87868f;
+  /* Aspect accents — alias the @theme tokens (single source of truth). */
+  --aspect-hero: var(--color-aspect-hero);
+  --aspect-aggression: var(--color-aspect-aggression);
+  --aspect-justice: var(--color-aspect-justice);
+  --aspect-leadership: var(--color-aspect-leadership);
+  --aspect-protection: var(--color-aspect-protection);
+  --aspect-pool: var(--color-aspect-pool);
+  --aspect-basic: var(--color-aspect-basic);
 
   /* Resource-pip colors (ChampionsIcons glyphs) */
-  --res-energy: oklch(0.8 0.16 65);
-  --res-mental: oklch(0.72 0.15 255);
-  --res-physical: oklch(0.67 0.22 25);
-  --res-wild: oklch(0.68 0.13 165);
+  --res-energy: var(--color-res-energy);
+  --res-mental: var(--color-res-mental);
+  --res-physical: var(--color-res-physical);
+  --res-wild: var(--color-res-wild);
 }
 
 @layer base {
@@ -548,6 +576,11 @@ textarea::placeholder {
   .bg-halftone {
     background-image: radial-gradient(circle, rgba(255, 255, 255, 0.04) 1.1px, transparent 1.5px);
     background-size: 15px 15px;
+  }
+
+  /* Diagonal-hatch placeholder shown behind card faces with no art */
+  .bg-card-hatch {
+    background: repeating-linear-gradient(135deg, #1b1b21 0 7px, #23232c 7px 14px);
   }
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -49,6 +49,15 @@ liveSocket.connect()
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
 
+// Register the service worker. Kept here (not as an inline <script> in the
+// root layout) so the prod CSP can leave script-src at 'self' with no
+// 'unsafe-inline'.
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/sw.js")
+    .then(() => console.log("Service Worker registered"))
+    .catch((error) => console.log("Service Worker registration failed:", error))
+}
+
 // The lines below enable quality of life phoenix_live_reload
 // development features:
 //

--- a/lib/sanctum_web/components/card.ex
+++ b/lib/sanctum_web/components/card.ex
@@ -13,21 +13,40 @@ defmodule SanctumWeb.Components.Card do
   """
   use Phoenix.Component
 
-  @aspect %{
-    "hero" => "#ce1b2e",
-    "aggression" => "#b12020",
-    "justice" => "#dbcb36",
-    "leadership" => "#2ea7b8",
-    "protection" => "#46991b",
-    "pool" => "#d074ac",
-    "basic" => "#87868f"
+  # Tailwind color-class trio per aspect (backed by the --color-aspect-*
+  # tokens in app.css). Full literal class names so Tailwind's source
+  # scanner detects them; do not build these by interpolation.
+  @aspect_classes %{
+    "hero" => %{text: "text-aspect-hero", bg: "bg-aspect-hero", border: "border-aspect-hero"},
+    "aggression" => %{
+      text: "text-aspect-aggression",
+      bg: "bg-aspect-aggression",
+      border: "border-aspect-aggression"
+    },
+    "justice" => %{
+      text: "text-aspect-justice",
+      bg: "bg-aspect-justice",
+      border: "border-aspect-justice"
+    },
+    "leadership" => %{
+      text: "text-aspect-leadership",
+      bg: "bg-aspect-leadership",
+      border: "border-aspect-leadership"
+    },
+    "protection" => %{
+      text: "text-aspect-protection",
+      bg: "bg-aspect-protection",
+      border: "border-aspect-protection"
+    },
+    "pool" => %{text: "text-aspect-pool", bg: "bg-aspect-pool", border: "border-aspect-pool"},
+    "basic" => %{text: "text-aspect-basic", bg: "bg-aspect-basic", border: "border-aspect-basic"}
   }
 
   @res %{
-    "energy" => {"var(--res-energy)", "E"},
-    "mental" => {"var(--res-mental)", "M"},
-    "physical" => {"var(--res-physical)", "P"},
-    "wild" => {"var(--res-wild)", "W"}
+    "energy" => {"text-res-energy", "E"},
+    "mental" => {"text-res-mental", "M"},
+    "physical" => {"text-res-physical", "P"},
+    "wild" => {"text-res-wild", "W"}
   }
 
   @dims %{
@@ -71,7 +90,7 @@ defmodule SanctumWeb.Components.Card do
     aspect = to_s(assigns.aspect)
     type = to_s(assigns.type)
     hero? = aspect == "hero"
-    aspect_color = Map.get(@aspect, aspect, @aspect["basic"])
+    aspect_classes = aspect_classes(aspect)
     dims = Map.get(@dims, assigns.size, @dims["md"])
 
     pips =
@@ -82,26 +101,30 @@ defmodule SanctumWeb.Components.Card do
 
     has_cost? = assigns.show_cost and assigns.cost not in [nil, ""] and type != "resource"
 
-    card_bg =
+    # Hero cards get a MarvelCDB gradient border painted via border-box, so
+    # that background stays inline (dynamic colors). Other aspects use the
+    # solid `bg-base-200` utility and a `border-aspect-*` class instead.
+    card_style =
       if hero? do
         {default_from, default_to} = @default_gradient
         from = assigns.gradient_from || default_from
         to = assigns.gradient_to || default_to
 
-        "linear-gradient(#15151a,#15151a) padding-box, " <>
-          "linear-gradient(135deg, #{from}, #{to}) border-box"
+        "background:linear-gradient(var(--color-base-200),var(--color-base-200)) padding-box," <>
+          "linear-gradient(135deg,#{from},#{to}) border-box;"
       else
-        "#15151a"
+        ""
       end
 
     assigns =
       assign(assigns,
-        aspect_color: aspect_color,
+        aspect_classes: aspect_classes,
+        hero?: hero?,
         dims: dims,
         pips: pips,
         has_cost?: has_cost?,
-        card_bg: card_bg,
-        border_color: if(hero?, do: "transparent", else: aspect_color),
+        card_style: card_style,
+        border_class: if(hero?, do: "border-transparent", else: aspect_classes.border),
         type_label: type_label(type),
         show_res?: assigns.size != "sm" and pips != [] and assigns.qty == 0,
         show_qty?: assigns.qty > 0,
@@ -111,29 +134,27 @@ defmodule SanctumWeb.Components.Card do
     ~H"""
     <div
       class={[
-        "relative h-full w-full overflow-hidden rounded-[7px] font-barlow-condensed text-white",
+        "relative h-full w-full overflow-hidden rounded-[7px] border-2 font-barlow-condensed text-white",
+        @border_class,
+        !@hero? && "bg-base-200",
         @class
       ]}
-      style={"background:#{@card_bg};border:2px solid #{@border_color};box-shadow:0 4px 14px rgba(0,0,0,.5);"}
+      style={"#{@card_style}box-shadow:0 4px 14px rgba(0,0,0,.5);"}
       {@rest}
     >
       <!-- diagonal-hatch art placeholder -->
-      <div
-        class="absolute inset-0"
-        style="background:repeating-linear-gradient(135deg,#1b1b21 0 7px,#23232c 7px 14px);"
-      >
-      </div>
+      <div class="bg-card-hatch absolute inset-0"></div>
       <div class="absolute inset-x-0 top-[38%] flex items-center justify-center">
         <span
-          class="font-ibm-mono uppercase tracking-[0.2em]"
-          style={"font-size:#{@dims.label}px;color:rgba(255,255,255,.32);"}
+          class="font-ibm-mono uppercase tracking-[0.2em] text-white/[0.32]"
+          style={"font-size:#{@dims.label}px;"}
         >
           card&nbsp;art
         </span>
       </div>
 
       <!-- aspect stripe -->
-      <div class="absolute inset-y-0 left-0 w-[5px]" style={"background:#{@aspect_color};"}></div>
+      <div class={["absolute inset-y-0 left-0 w-[5px]", @aspect_classes.bg]}></div>
 
       <!-- card image -->
       <img
@@ -146,8 +167,11 @@ defmodule SanctumWeb.Components.Card do
       <!-- cost bubble -->
       <div
         :if={@has_cost?}
-        class="font-elektra absolute left-[9px] top-[6px] z-[3] flex items-center justify-center rounded-full"
-        style={"width:#{@dims.cost}px;height:#{@dims.cost}px;background:#0c0c0f;border:2px solid #{@aspect_color};font-size:#{@dims.sub}px;box-shadow:0 2px 5px rgba(0,0,0,.5);"}
+        class={[
+          "font-elektra absolute left-[9px] top-[6px] z-[3] flex items-center justify-center rounded-full border-2 bg-base-100",
+          @aspect_classes.border
+        ]}
+        style={"width:#{@dims.cost}px;height:#{@dims.cost}px;font-size:#{@dims.sub}px;box-shadow:0 2px 5px rgba(0,0,0,.5);"}
       >
         {@cost}
       </div>
@@ -155,9 +179,9 @@ defmodule SanctumWeb.Components.Card do
       <!-- resource pips -->
       <div :if={@show_res?} class="absolute right-[6px] top-[6px] z-[3] flex gap-[3px]">
         <span
-          :for={{color, glyph} <- @pips}
-          class="font-champions leading-none"
-          style={"font-size:#{@dims.res}px;color:#{color};text-shadow:0 1px 2px rgba(0,0,0,.95),0 0 3px rgba(0,0,0,.8);"}
+          :for={{color_class, glyph} <- @pips}
+          class={["font-champions leading-none", color_class]}
+          style={"font-size:#{@dims.res}px;text-shadow:0 1px 2px rgba(0,0,0,.95),0 0 3px rgba(0,0,0,.8);"}
         >
           {glyph}
         </span>
@@ -166,7 +190,7 @@ defmodule SanctumWeb.Components.Card do
       <!-- quantity badge -->
       <div
         :if={@show_qty?}
-        class="absolute right-[6px] top-[6px] z-[3] flex items-center justify-center rounded-[5px] bg-white font-anton text-[#0c0c0f]"
+        class="absolute right-[6px] top-[6px] z-[3] flex items-center justify-center rounded-[5px] bg-white font-anton text-base-100"
         style={"min-width:#{@dims.badge}px;height:#{@dims.badge}px;padding:0 5px;font-size:#{@dims.sub}px;box-shadow:0 2px 6px rgba(0,0,0,.6);"}
       >
         ×{@qty}
@@ -184,7 +208,7 @@ defmodule SanctumWeb.Components.Card do
           {@name}
         </div>
         <div class="mt-1 flex items-center gap-[5px]">
-          <span class="rounded-[1px]" style={"width:7px;height:7px;background:#{@aspect_color};"}></span>
+          <span class={["size-[7px] rounded-[1px]", @aspect_classes.bg]}></span>
           <span
             class="font-semibold uppercase tracking-[0.16em] text-white/60"
             style={"font-size:#{@dims.label}px;"}
@@ -198,15 +222,26 @@ defmodule SanctumWeb.Components.Card do
   end
 
   @doc """
-  Maps a list of resource atoms/strings to `{css_color, glyph}` tuples for
-  rendering ChampionsIcons pips outside a card face (e.g. a detail row).
-  Unknown resources are dropped.
+  Maps a list of resource atoms/strings to `{text_color_class, glyph}` tuples
+  for rendering ChampionsIcons pips outside a card face (e.g. a detail row).
+  The class (e.g. `"text-res-energy"`) goes on the element's `class`, not an
+  inline style. Unknown resources are dropped.
   """
   def resource_pips(resources) do
     resources
     |> Enum.map(&to_s/1)
     |> Enum.map(&Map.get(@res, &1))
     |> Enum.reject(&is_nil/1)
+  end
+
+  @doc """
+  Tailwind color classes for an aspect as `%{text:, bg:, border:}` (backed by
+  the `--color-aspect-*` theme tokens). Unknown aspects fall back to `basic`.
+  Use these classes instead of inline color styles so the prod CSP can keep
+  `style-src` free of inline color rules.
+  """
+  def aspect_classes(aspect) do
+    Map.get(@aspect_classes, to_s(aspect), @aspect_classes["basic"])
   end
 
   @doc """

--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -135,12 +135,16 @@ defmodule SanctumWeb.CoreComponents do
 
   ## Examples
 
-      <.filter_pill active={@aspect == :hero} dot="var(--aspect-hero)" phx-click="filter">
+      <.filter_pill active={@aspect == :hero} dot_class="bg-aspect-hero" phx-click="filter">
         Hero
       </.filter_pill>
   """
   attr :active, :boolean, default: false
-  attr :dot, :string, default: nil, doc: "optional CSS color for a leading square swatch"
+
+  attr :dot_class, :string,
+    default: nil,
+    doc: "optional Tailwind bg-* class for a leading square swatch (e.g. bg-aspect-hero)"
+
   attr :class, :string, default: ""
   attr :rest, :global, include: ~w(href navigate patch phx-click phx-value-key value name)
   slot :inner_block, required: true
@@ -158,9 +162,8 @@ defmodule SanctumWeb.CoreComponents do
       {@rest}
     >
       <span
-        :if={@dot}
-        class="size-2 rounded-[2px]"
-        style={"background:#{if @active, do: "var(--color-primary-content)", else: @dot};"}
+        :if={@dot_class}
+        class={["size-2 rounded-[2px]", (@active && "bg-primary-content") || @dot_class]}
       />
       {render_slot(@inner_block)}
     </button>

--- a/lib/sanctum_web/components/layouts/root.html.heex
+++ b/lib/sanctum_web/components/layouts/root.html.heex
@@ -20,13 +20,6 @@
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
     </script>
-    <script>
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('/sw.js')
-          .then(() => console.log('Service Worker registered'))
-          .catch((error) => console.log('Service Worker registration failed:', error));
-      }
-    </script>
   </head>
   <body>
     {@inner_content}

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -17,13 +17,13 @@ defmodule SanctumWeb.CardLive.Pool do
 
   @aspects [
     {"all", "All", nil},
-    {"hero", "Hero", "var(--aspect-hero)"},
-    {"aggression", "Aggression", "var(--aspect-aggression)"},
-    {"justice", "Justice", "var(--aspect-justice)"},
-    {"leadership", "Leadership", "var(--aspect-leadership)"},
-    {"protection", "Protection", "var(--aspect-protection)"},
-    {"pool", "Pool", "var(--aspect-pool)"},
-    {"basic", "Basic", "var(--aspect-basic)"}
+    {"hero", "Hero", "bg-aspect-hero"},
+    {"aggression", "Aggression", "bg-aspect-aggression"},
+    {"justice", "Justice", "bg-aspect-justice"},
+    {"leadership", "Leadership", "bg-aspect-leadership"},
+    {"protection", "Protection", "bg-aspect-protection"},
+    {"pool", "Pool", "bg-aspect-pool"},
+    {"basic", "Basic", "bg-aspect-basic"}
   ]
 
   @types [
@@ -59,7 +59,7 @@ defmodule SanctumWeb.CardLive.Pool do
             phx-debounce="200"
             autocomplete="off"
             placeholder="Search cards by name…"
-            class="w-full border-[2.5px] border-[#2a2a30] bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-[15px] text-base-content outline-none focus:border-primary"
+            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-[15px] text-base-content outline-none focus:border-primary"
           />
         </form>
         <div class="whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
@@ -70,9 +70,9 @@ defmodule SanctumWeb.CardLive.Pool do
       <!-- aspect filters -->
       <div class="mb-2.5 flex flex-wrap gap-1.5">
         <.filter_pill
-          :for={{key, label, dot} <- @aspect_options}
+          :for={{key, label, dot_class} <- @aspect_options}
           active={@aspect == key}
-          dot={dot}
+          dot_class={dot_class}
           phx-click="filter_aspect"
           phx-value-key={key}
         >
@@ -126,10 +126,10 @@ defmodule SanctumWeb.CardLive.Pool do
                 {card.cost}
               </div>
               <div class="min-w-0 flex-1">
-                <div
-                  class="font-ibm-mono text-[9px] uppercase tracking-[0.2em]"
-                  style={"color:#{card.aspect_color};"}
-                >
+                <div class={[
+                  "font-ibm-mono text-[9px] uppercase tracking-[0.2em]",
+                  card.aspect_text_class
+                ]}>
                   {card.type_name} · {card.aspect_name}
                 </div>
                 <div class="mt-[3px] font-anton text-[22px] uppercase leading-[0.94]">
@@ -170,9 +170,8 @@ defmodule SanctumWeb.CardLive.Pool do
 
             <div :if={card.pips != []} class="mt-2.5 flex items-center gap-1">
               <span
-                :for={{color, glyph} <- card.pips}
-                class="font-champions text-2xl leading-none"
-                style={"color:#{color};"}
+                :for={{color_class, glyph} <- card.pips}
+                class={["font-champions text-2xl leading-none", color_class]}
               >
                 {glyph}
               </span>
@@ -311,7 +310,7 @@ defmodule SanctumWeb.CardLive.Pool do
       gradient_from: gradient_from,
       gradient_to: gradient_to,
       type_name: type_name(side.type),
-      aspect_color: "var(--aspect-#{aspect_key})",
+      aspect_text_class: CardComponent.aspect_classes(aspect_key).text,
       resources: resources,
       pips: CardComponent.resource_pips(resources),
       traits: format_traits(side.traits),

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -66,14 +66,14 @@ defmodule SanctumWeb.CardLive.Show do
 
           <div class="flex min-w-0 flex-1 flex-col">
             <div class="flex flex-wrap items-center gap-2">
-              <.badge :if={side.is_primary_side} color="var(--aspect-protection)">Primary</.badge>
+              <.badge :if={side.is_primary_side} aspect="protection">Primary</.badge>
               <.badge>Side {side.side_identifier}</.badge>
             </div>
 
-            <div
-              class="mt-2 font-ibm-mono text-[10px] uppercase tracking-[0.2em]"
-              style={"color:#{side.aspect_color};"}
-            >
+            <div class={[
+              "mt-2 font-ibm-mono text-[10px] uppercase tracking-[0.2em]",
+              side.aspect_text_class
+            ]}>
               {side.type_name}<span :if={side.aspect_name}> · {side.aspect_name}</span>
             </div>
             <h2 class="mt-1 font-anton text-[30px] uppercase leading-[0.92]">{side.name}</h2>
@@ -84,9 +84,8 @@ defmodule SanctumWeb.CardLive.Show do
             <!-- resource pips -->
             <div :if={side.pips != []} class="mt-3 flex items-center gap-1.5">
               <span
-                :for={{color, glyph} <- side.pips}
-                class="font-champions text-[18px] leading-none"
-                style={"color:#{color};"}
+                :for={{color_class, glyph} <- side.pips}
+                class={["font-champions text-[18px] leading-none", color_class]}
               >
                 {glyph}
               </span>
@@ -112,7 +111,7 @@ defmodule SanctumWeb.CardLive.Show do
 
             <!-- keyword icons -->
             <div :if={side.icons != []} class="mt-4 flex flex-wrap gap-1.5">
-              <.badge :for={icon <- side.icons} color="var(--aspect-hero)">{icon}</.badge>
+              <.badge :for={icon <- side.icons} aspect="hero">{icon}</.badge>
             </div>
 
             <!-- other typed stats -->
@@ -169,7 +168,7 @@ defmodule SanctumWeb.CardLive.Show do
   defp stat_box(assigns) do
     ~H"""
     <div
-      class="border-2 border-neutral bg-[#0c0c0f] px-0.5 py-1.5 text-center"
+      class="border-2 border-neutral bg-base-100 px-0.5 py-1.5 text-center"
       style={"border-top:3px solid #{@color};"}
     >
       <div class="font-anton text-[20px] leading-[0.9]">{@value}</div>
@@ -180,20 +179,19 @@ defmodule SanctumWeb.CardLive.Show do
     """
   end
 
-  attr :color, :string, default: nil
+  attr :aspect, :any, default: nil, doc: "aspect key for accent color; nil = neutral badge"
   slot :inner_block, required: true
 
   defp badge(assigns) do
+    classes = assigns.aspect && CardComponent.aspect_classes(assigns.aspect)
+    assigns = assign(assigns, :badge_classes, classes)
+
     ~H"""
-    <span
-      class="border-2 px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]"
-      style={
-        if(@color,
-          do: "border-color:#{@color};color:#{@color};background:#000;",
-          else: "border-color:var(--color-neutral);color:rgba(244,241,234,.8);background:#000;"
-        )
-      }
-    >
+    <span class={[
+      "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
+      (@badge_classes && [@badge_classes.text, @badge_classes.border]) ||
+        "border-neutral text-base-content/80"
+    ]}>
       {render_slot(@inner_block)}
     </span>
     """
@@ -258,7 +256,8 @@ defmodule SanctumWeb.CardLive.Show do
       type_name: type_name(side.type),
       aspect_key: if(hero_face?, do: :hero, else: side.aspect || :basic),
       aspect_name: side.aspect && aspect_name(side.aspect),
-      aspect_color: aspect_color(if(hero_face?, do: :hero, else: side.aspect)),
+      aspect_text_class:
+        CardComponent.aspect_classes(if(hero_face?, do: :hero, else: side.aspect)).text,
       resources: resources,
       pips: CardComponent.resource_pips(resources),
       traits: format_traits(side.traits),
@@ -274,10 +273,10 @@ defmodule SanctumWeb.CardLive.Show do
 
   defp combat_stats(side) do
     [
-      {"THW", side.thwart, "#2ea7b8"},
-      {"ATK", side.attack, "#ce1b2e"},
-      {"DEF", side.defense, "#2456a6"},
-      {"HP", side.health, "#46991b"}
+      {"THW", side.thwart, "var(--color-aspect-leadership)"},
+      {"ATK", side.attack, "var(--color-aspect-hero)"},
+      {"DEF", side.defense, "var(--color-stat-defense)"},
+      {"HP", side.health, "var(--color-aspect-protection)"}
     ]
     |> Enum.filter(fn {_l, stat, _c} -> stat_value(stat) != nil end)
     |> Enum.map(fn {label, stat, color} ->
@@ -358,9 +357,6 @@ defmodule SanctumWeb.CardLive.Show do
 
   defp aspect_name(:hero), do: "Hero"
   defp aspect_name(aspect), do: aspect |> to_string() |> String.capitalize()
-
-  defp aspect_color(nil), do: "var(--aspect-basic)"
-  defp aspect_color(aspect), do: "var(--aspect-#{aspect})"
 
   defp type_name(nil), do: "Card"
   defp type_name(type), do: type |> to_string() |> String.replace("_", " ") |> String.capitalize()

--- a/lib/sanctum_web/live/dev_live/stat_badges.ex
+++ b/lib/sanctum_web/live/dev_live/stat_badges.ex
@@ -82,10 +82,7 @@ defmodule SanctumWeb.DevLive.StatBadges do
         <h2 class="text-sm uppercase tracking-widest font-black border-b-2 border-current pb-1">
           On dark
         </h2>
-        <div
-          class="flex flex-wrap items-start gap-8 rounded-xl p-8"
-          style="background:#14141b;background-image:radial-gradient(rgba(255,255,255,.05) 1.4px,transparent 1.5px);background-size:16px 16px"
-        >
+        <div class="bg-base-200 bg-halftone flex flex-wrap items-start gap-8 rounded-xl p-8">
           <div :for={stat <- @stats} class="flex flex-col items-center gap-2">
             <.stat_badge
               stat={stat}
@@ -119,10 +116,7 @@ defmodule SanctumWeb.DevLive.StatBadges do
         <h2 class="text-sm uppercase tracking-widest font-black border-b-2 border-current pb-1">
           Health badge
         </h2>
-        <div
-          class="flex flex-wrap items-center gap-8 rounded-xl p-8"
-          style="background:#14141b;background-image:radial-gradient(rgba(255,255,255,.05) 1.4px,transparent 1.5px);background-size:16px 16px"
-        >
+        <div class="bg-base-200 bg-halftone flex flex-wrap items-center gap-8 rounded-xl p-8">
           <div class="flex flex-col items-center gap-2">
             <.health_badge value={@value} size={@size} />
             <span class="text-[11px] uppercase tracking-widest text-white/50 font-bold">hp</span>
@@ -146,10 +140,7 @@ defmodule SanctumWeb.DevLive.StatBadges do
         <h2 class="text-sm uppercase tracking-widest font-black border-b-2 border-current pb-1">
           Custom colors (bright + dark overrides)
         </h2>
-        <div
-          class="flex flex-wrap items-start gap-8 rounded-xl p-8"
-          style="background:#14141b"
-        >
+        <div class="bg-base-200 flex flex-wrap items-start gap-8 rounded-xl p-8">
           <.stat_badge value={@value} size={@size} label="POW" bright="#ff7a00" dark="#a33c00" />
           <.stat_badge value={@value} size={@size} label="ARM" bright="#8a8f98" dark="#3a3d44" />
           <.stat_badge value={@value} size={@size} label="SPD" bright="#12b886" dark="#0a6b4f" />

--- a/lib/sanctum_web/plugs/content_security_policy.ex
+++ b/lib/sanctum_web/plugs/content_security_policy.ex
@@ -22,7 +22,12 @@ defmodule SanctumWeb.Plugs.ContentSecurityPolicy do
 
     case Application.get_env(:sanctum, :env) do
       :prod ->
+        # LiveView applies inline style="" attributes at runtime (aspect colors,
+        # resource pips, stat/health badges), which can't be hashed or nonced —
+        # so style-src must allow 'unsafe-inline'. Without an explicit style-src,
+        # it falls back to default-src 'self' and every inline style is blocked.
         "default-src 'self';" <>
+          "style-src 'self' 'unsafe-inline';" <>
           "connect-src wss://#{host} https://#{host}:*;" <>
           "img-src 'self' blob: data: #{img_src_hosts()};" <>
           "font-src 'self' data:;"


### PR DESCRIPTION
## Problem

On production, all inline `style=` colors were being stripped — aspect filter chips, resource pips, card cost-bubble borders, and detail-page badges all rendered colorless. The release image was fine; the culprit was the **prod Content Security Policy**.

`lib/sanctum_web/plugs/content_security_policy.ex` set `default-src 'self'` with **no `style-src`**, so inline styles fell back to a policy lacking `'unsafe-inline'` and were blocked. Confirmed on live prod: **196 identical CSP violations** (`Applying inline style violates … 'style-src' was not explicitly set`). Dev was unaffected because its `default-src` includes `'unsafe-inline'`.

## Changes

1. **CSP fix** — add `style-src 'self' 'unsafe-inline'` to the prod branch. LiveView re-applies inline styles at runtime, so they can't be hashed/nonced; `'unsafe-inline'` for `style-src` is the standard approach. Also moved the service-worker registration out of an inline `<script>` into `app.js` so `script-src` stays tight.

2. **Colors → Tailwind classes + tokens** — converted the enumerable aspect/resource colors from inline `style=` to Tailwind utility classes (`text-/bg-/border-aspect-*`, `text-res-*`) backed by new `@theme` tokens (`--color-aspect-*`, `--color-res-*`, `--color-stat-defense`, `--color-line`). Legacy `--aspect-*`/`--res-*` vars now alias these (single source of truth). Colors now render independently of CSP.

3. **Grey consolidation** — merged near-identical greys onto daisyUI `base-100/200/300`, `#2a2a30` → `border-line`, combat-stat hexes → tokens (reusing aspect hues), and added a `.bg-card-hatch` utility. Dynamic inline styles (card dims, progress width, hero gradient, shadows) intentionally remain and rely on the CSP fix.

## Verification

- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --min-priority=normal`, `mix sobelow`, `mix deps.unlock --check-unused` — all clean.
- `card_live` tests: 19 passing.
- Verified locally: generated CSS contains all new utilities; `/cards` renders with colors restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)