### PR TITLE
feat(guess): Flavor Town card-guessing mini-game

### DIFF
--- a/lib/sanctum/games/card.ex
+++ b/lib/sanctum/games/card.ex
@@ -112,6 +112,16 @@ defmodule Sanctum.Games.Card do
       prepare build(load: [:card_sides, :primary_side])
     end
 
+    # Random-pickable pool for the "Name That Card" guessing game: any card
+    # whose primary side has flavor text. Backs SanctumWeb.GuessLive.Play.
+    read :guessable do
+      prepare build(load: [:primary_side])
+
+      filter expr(not is_nil(primary_side.flavor) and primary_side.flavor != "")
+
+      pagination offset?: true, default_limit: 1, countable: true, required?: false
+    end
+
     read :by_set do
       argument :set, :string, allow_nil?: false
       filter expr(set == ^arg(:set))

--- a/lib/sanctum/games/card_guess.ex
+++ b/lib/sanctum/games/card_guess.ex
@@ -1,0 +1,252 @@
+defmodule Sanctum.Games.CardGuess do
+  @moduledoc """
+  Logic for the "Name That Card" guessing game (inspired by the *Stunned &
+  Confused* podcast segment): the player is shown a card's flavor text and tries
+  to name the card.
+
+  This module is otherwise pure: it picks a random card that has flavor text
+  (`random_guessable_card/0`, the only DB call), builds an ordered ladder of
+  hints that narrow from broad ("it's a player card") to specific ("it comes
+  from the Spider-Man pack") via `build_hints/1`, and decides whether a typed
+  guess names the card via `correct?/2` (exact-normalized or a close Jaro match,
+  so typos still count).
+  """
+
+  require Ash.Query
+
+  alias Sanctum.Games.{Card, Stat}
+
+  # A normalized guess this similar (0..1, via String.jaro_distance/2) to any
+  # candidate name counts as correct — forgiving of typos/pluralization. Single
+  # knob, tune after playtesting.
+  @match_threshold 0.9
+
+  @player_ownerships [:player, :basic, :pool, :hero]
+  @encounter_ownerships [:encounter, :campaign]
+  @character_types [:hero, :alter_ego, :ally, :minion, :villain]
+  @scheme_types [:main_scheme, :side_scheme]
+
+  @doc """
+  Fetches a random card that has flavor text, with its primary side loaded.
+  Returns `nil` when no guessable cards exist.
+  """
+  def random_guessable_card do
+    count =
+      Card
+      |> Ash.Query.for_read(:guessable)
+      |> Ash.read!(page: [limit: 1, offset: 0, count: true])
+      |> Map.get(:count)
+
+    if is_integer(count) and count > 0 do
+      offset = :rand.uniform(count) - 1
+
+      Card
+      |> Ash.Query.for_read(:guessable)
+      |> Ash.read!(page: [limit: 1, offset: offset])
+      |> Map.get(:results)
+      |> List.first()
+    end
+  end
+
+  @doc """
+  Whether `guess` names the card — a case/punctuation-insensitive exact match
+  or a Jaro similarity at/above `#{@match_threshold}` against the name,
+  subname, or "name subname".
+  """
+  def correct?(guess, %Card{primary_side: side}) do
+    normalized = normalize(guess)
+
+    normalized != "" and
+      side
+      |> candidates()
+      |> Enum.map(&normalize/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.any?(fn candidate ->
+        candidate == normalized or String.jaro_distance(normalized, candidate) >= @match_threshold
+      end)
+  end
+
+  defp candidates(%{name: name, subname: subname}), do: [name, subname, join_name(name, subname)]
+
+  defp join_name(name, subname)
+       when is_binary(name) and is_binary(subname) and subname != "",
+       do: name <> " " <> subname
+
+  defp join_name(_, _), do: nil
+
+  @doc """
+  Lowercases, strips a leading "the ", drops punctuation, and collapses
+  whitespace so "The Vision!" and "vision" compare equal.
+  """
+  def normalize(nil), do: ""
+
+  def normalize(str) when is_binary(str) do
+    str
+    |> String.downcase()
+    |> String.trim()
+    |> String.replace_prefix("the ", "")
+    |> String.replace(~r/[^\p{L}\p{N}\s]/u, "")
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+  end
+
+  @doc """
+  Ordered list of `%{key: atom, text: String.t()}` hints for the card, broadest
+  first. Rungs that don't apply to the card are skipped, so a player card and an
+  encounter card each get a sensible ~10-hint ladder.
+  """
+  def build_hints(%Card{primary_side: side} = card) do
+    [
+      allegiance_hint(side),
+      nature_hint(side),
+      aspect_hint(side),
+      type_hint(side),
+      traits_hint(side),
+      cost_hint(side),
+      resources_hint(side),
+      stats_hint(side),
+      uniqueness_hint(card),
+      set_hint(card),
+      name_shape_hint(side)
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # 1. Allegiance — player vs encounter.
+  defp allegiance_hint(%{ownership: ownership}) when ownership in @player_ownerships,
+    do: hint(:allegiance, "This is a player card.")
+
+  defp allegiance_hint(%{ownership: ownership}) when ownership in @encounter_ownerships,
+    do: hint(:allegiance, "This is an encounter card.")
+
+  defp allegiance_hint(_), do: nil
+
+  # 2. Broad nature — character / scheme / support-style.
+  defp nature_hint(%{type: type}) when type in @character_types,
+    do: hint(:nature, "It's a character card — something with hit points.")
+
+  defp nature_hint(%{type: type}) when type in @scheme_types,
+    do: hint(:nature, "It's a scheme.")
+
+  defp nature_hint(%{type: type}) when not is_nil(type),
+    do: hint(:nature, "It's not a character or a scheme — more of a support-style card.")
+
+  defp nature_hint(_), do: nil
+
+  # 3. Aspect / origin.
+  defp aspect_hint(%{aspect: aspect}) when not is_nil(aspect),
+    do: hint(:aspect, "Its aspect is #{aspect_label(aspect)}.")
+
+  defp aspect_hint(%{ownership: :hero}), do: hint(:aspect, "It's a hero signature card.")
+
+  defp aspect_hint(%{ownership: :basic}),
+    do: hint(:aspect, "It's a Basic card — any deck can include it.")
+
+  defp aspect_hint(%{ownership: :pool}), do: hint(:aspect, "It comes from the general card pool.")
+
+  defp aspect_hint(_), do: nil
+
+  # 4. Exact card type.
+  defp type_hint(%{type: type}) when not is_nil(type) do
+    label = type_label(type)
+    hint(:type, "It's #{article(label)} #{label}.")
+  end
+
+  defp type_hint(_), do: nil
+
+  # 5. Traits.
+  defp traits_hint(%{traits: traits}) when is_list(traits) and traits != [],
+    do: hint(:traits, "Traits: #{Enum.join(traits, ", ")}.")
+
+  defp traits_hint(_), do: nil
+
+  # 6. Resource cost.
+  defp cost_hint(%{cost: cost}) when is_integer(cost),
+    do: hint(:cost, "Its resource cost is #{cost}.")
+
+  defp cost_hint(_), do: nil
+
+  # 7. Resource icons it provides.
+  defp resources_hint(side) do
+    [
+      {"energy", side.resource_energy_count},
+      {"physical", side.resource_physical_count},
+      {"mental", side.resource_mental_count},
+      {"wild", side.resource_wild_count}
+    ]
+    |> Enum.flat_map(fn {label, n} ->
+      if is_integer(n) and n > 0, do: ["#{n} #{label}"], else: []
+    end)
+    |> case do
+      [] -> nil
+      list -> hint(:resources, "Resource icons it provides: #{Enum.join(list, ", ")}.")
+    end
+  end
+
+  # 8. Stats (character combat stats or scheme threat).
+  defp stats_hint(side) do
+    [
+      {"ATK", side.attack},
+      {"THW", side.thwart},
+      {"DEF", side.defense},
+      {"HP", side.health},
+      {"REC", side.recover},
+      {"Starting threat", side.base_threat},
+      {"Max threat", side.max_threat}
+    ]
+    |> Enum.flat_map(&stat_pair/1)
+    |> case do
+      [] -> nil
+      list -> hint(:stats, "Stats — #{Enum.join(list, ", ")}.")
+    end
+  end
+
+  defp stat_pair({label, %Stat{value: value}}) when is_integer(value), do: ["#{label} #{value}"]
+  defp stat_pair(_), do: []
+
+  # 9. Uniqueness / deck limit.
+  defp uniqueness_hint(%{unique: true}), do: hint(:uniqueness, "This card is unique.")
+
+  defp uniqueness_hint(%{deck_limit: limit}) when is_integer(limit) and limit > 0,
+    do: hint(:uniqueness, "It's not unique — a deck can include up to #{limit} #{copies(limit)}.")
+
+  defp uniqueness_hint(_), do: nil
+
+  # 10. Set / pack it comes from.
+  defp set_hint(%{set: set}) when is_binary(set) and set != "",
+    do: hint(:set, "It comes from the “#{humanize_slug(set)}” set.")
+
+  defp set_hint(%{pack: pack}) when is_binary(pack) and pack != "",
+    do: hint(:set, "It comes from the “#{humanize_slug(pack)}” pack.")
+
+  defp set_hint(_), do: nil
+
+  # 11. Name shape — the last-resort giveaway.
+  defp name_shape_hint(%{name: name}) when is_binary(name) and name != "" do
+    words = name |> String.split(~r/\s+/, trim: true) |> length()
+    first = name |> String.trim() |> String.first() |> String.upcase()
+    hint(:name_shape, "The name has #{words} #{word_word(words)} and starts with “#{first}”.")
+  end
+
+  defp name_shape_hint(_), do: nil
+
+  defp hint(key, text), do: %{key: key, text: text}
+
+  defp type_label(type),
+    do: type |> to_string() |> String.split("_") |> Enum.map_join(" ", &String.capitalize/1)
+
+  defp aspect_label(aspect), do: aspect |> to_string() |> String.capitalize()
+
+  defp humanize_slug(slug),
+    do: slug |> String.split(~r/[_\s]+/, trim: true) |> Enum.map_join(" ", &String.capitalize/1)
+
+  defp article(word) do
+    if String.downcase(String.first(word)) in ~w(a e i o u), do: "an", else: "a"
+  end
+
+  defp copies(1), do: "copy"
+  defp copies(_), do: "copies"
+
+  defp word_word(1), do: "word"
+  defp word_word(_), do: "words"
+end

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -35,7 +35,7 @@ defmodule SanctumWeb.Layouts do
 
   attr :active_tab, :atom,
     default: nil,
-    values: [nil, :cards, :decks],
+    values: [nil, :cards, :guess, :decks],
     doc: "which top-nav tab to highlight"
 
   slot :inner_block, required: true
@@ -53,6 +53,7 @@ defmodule SanctumWeb.Layouts do
           </a>
           <nav class="flex h-[34px] items-end gap-5">
             <.nav_tab navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.nav_tab>
+            <.nav_tab navigate={~p"/guess"} active={@active_tab == :guess}>Flavor Town</.nav_tab>
             <span
               class="cursor-default pb-[3px] text-[13px] font-bold uppercase tracking-[0.13em] text-base-content/25"
               title="Coming soon"

--- a/lib/sanctum_web/live/guess_live/play.ex
+++ b/lib/sanctum_web/live/guess_live/play.ex
@@ -1,0 +1,224 @@
+defmodule SanctumWeb.GuessLive.Play do
+  @moduledoc """
+  "Flavor Town" — a flavor-text guessing game inspired by the *Stunned &
+  Confused* podcast segment. The player is shown a card's flavor text and tries
+  to name it. Each wrong guess reveals the next narrowing hint; once the hints
+  run out, the next wrong guess ends the round and reveals the card.
+
+  Session-only: round state lives in socket assigns, nothing is persisted.
+  """
+  use SanctumWeb, :live_view
+
+  alias Sanctum.Games.CardGuess
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app current_user={@current_user} flash={@flash} active_tab={:guess}>
+      <.header>
+        Flavor Town
+        <:subtitle>
+          Read the flavor text and name the card. Inspired by the <em>Stunned &amp; Confused</em>
+          podcast — every wrong guess earns you a hint that narrows it down.
+        </:subtitle>
+      </.header>
+
+      <.panel :if={@status == :empty} class="px-6 py-12 text-center">
+        <div class="font-bangers text-[30px] tracking-[0.02em] text-primary">No cards to guess</div>
+        <div class="mt-1.5 font-barlow text-[14px] text-base-content/55">
+          No cards with flavor text are loaded yet. Sync the catalog and come back.
+        </div>
+      </.panel>
+
+      <div :if={@status != :empty} class="mx-auto max-w-[720px]">
+        <!-- flavor prompt -->
+        <.panel class="px-6 py-8">
+          <div class="font-ibm-mono text-[10px] uppercase tracking-[0.25em] text-base-content/45">
+            Flavor text
+          </div>
+          <blockquote class="mt-3 font-barlow text-[20px] italic leading-[1.5] text-base-content/90">
+            “{@card.primary_side.flavor}”
+          </blockquote>
+        </.panel>
+
+        <!-- guess form -->
+        <form :if={@status == :playing} phx-submit="guess" class="mt-5 flex gap-2.5">
+          <input
+            type="text"
+            name="guess"
+            value=""
+            autocomplete="off"
+            phx-mounted={JS.focus()}
+            placeholder="Name the card…"
+            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 font-barlow text-[15px] text-base-content outline-none focus:border-primary placeholder:text-base-content/40"
+          />
+          <.button variant="primary" type="submit">Guess</.button>
+        </form>
+
+        <div :if={@status == :playing} class="mt-2.5 text-right">
+          <button
+            type="button"
+            phx-click="give-up"
+            class="font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/40 hover:text-base-content/70"
+          >
+            Give up
+          </button>
+        </div>
+
+        <!-- revealed hints -->
+        <div :if={@revealed_count > 0} class="mt-6">
+          <div class="font-ibm-mono text-[10px] uppercase tracking-[0.25em] text-base-content/45">
+            Hints
+          </div>
+          <ol class="mt-2.5 flex flex-col gap-2">
+            <li
+              :for={{hint, i} <- Enum.with_index(Enum.take(@hints, @revealed_count), 1)}
+              class="flex gap-3 border-2 border-neutral bg-base-200 px-3.5 py-2.5 shadow-comic-sm"
+            >
+              <span class="font-anton text-[15px] text-primary">{i}.</span>
+              <span class="font-barlow text-[15px] text-base-content/90">{hint.text}</span>
+            </li>
+          </ol>
+          <div
+            :if={@status == :playing}
+            class="mt-2 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/40"
+          >
+            {hints_remaining_label(@hints, @revealed_count)}
+          </div>
+        </div>
+
+        <!-- missed guesses -->
+        <div
+          :if={@guesses != []}
+          class="mt-4 font-barlow text-[13px] text-base-content/50"
+        >
+          Missed guesses: {Enum.join(@guesses, ", ")}
+        </div>
+
+        <!-- result + reveal -->
+        <.panel :if={@status in [:won, :lost]} class="mt-6 px-6 py-6 text-center">
+          <div class={[
+            "font-bangers text-[34px] tracking-[0.02em]",
+            (@status == :won && "text-success") || "text-error"
+          ]}>
+            {(@status == :won && "You got it!") || "Out of guesses!"}
+          </div>
+          <div class="mt-1.5 font-barlow text-[14px] text-base-content/55">
+            {(@status == :won && win_label(@revealed_count)) || "The answer was:"}
+          </div>
+
+          <div class="mt-5 flex flex-col items-center gap-3">
+            <div class="h-[280px] w-[200px] border-2 border-neutral shadow-comic">
+              <.mc_card
+                name={@card.primary_side.name}
+                aspect={reveal_aspect(@card)}
+                type={@card.primary_side.type}
+                cost={@card.primary_side.cost}
+                image_url={@card.primary_side.image_url}
+                size="lg"
+                show_cost={false}
+              />
+            </div>
+            <div>
+              <div class="font-anton text-[26px] uppercase leading-[0.95]">
+                {@card.primary_side.name}
+              </div>
+              <div
+                :if={@card.primary_side.subname not in [nil, ""]}
+                class="font-barlow italic text-[14px] text-base-content/60"
+              >
+                {@card.primary_side.subname}
+              </div>
+            </div>
+          </div>
+
+          <.button variant="primary" phx-click="new-game" class="mt-6">Play again</.button>
+        </.panel>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket |> assign(:page_title, "Flavor Town") |> start_round()}
+  end
+
+  @impl true
+  def handle_event("guess", %{"guess" => guess}, socket) do
+    trimmed = String.trim(guess)
+
+    cond do
+      socket.assigns.status != :playing or trimmed == "" ->
+        {:noreply, socket}
+
+      CardGuess.correct?(trimmed, socket.assigns.card) ->
+        {:noreply, assign(socket, :status, :won)}
+
+      true ->
+        {:noreply, register_miss(socket, trimmed)}
+    end
+  end
+
+  def handle_event("give-up", _params, socket) do
+    {:noreply, assign(socket, :status, :lost)}
+  end
+
+  def handle_event("new-game", _params, socket) do
+    {:noreply, start_round(socket)}
+  end
+
+  # Reveals the next hint on a miss; once every hint is out, the miss loses.
+  defp register_miss(socket, guess) do
+    %{revealed_count: revealed, hints: hints} = socket.assigns
+    socket = update(socket, :guesses, &(&1 ++ [guess]))
+
+    if revealed < length(hints) do
+      assign(socket, :revealed_count, revealed + 1)
+    else
+      assign(socket, :status, :lost)
+    end
+  end
+
+  defp start_round(socket) do
+    case CardGuess.random_guessable_card() do
+      nil ->
+        socket
+        |> assign(:card, nil)
+        |> assign(:hints, [])
+        |> assign(:revealed_count, 0)
+        |> assign(:guesses, [])
+        |> assign(:status, :empty)
+
+      card ->
+        socket
+        |> assign(:card, card)
+        |> assign(:hints, CardGuess.build_hints(card))
+        |> assign(:revealed_count, 0)
+        |> assign(:guesses, [])
+        |> assign(:status, :playing)
+    end
+  end
+
+  defp hints_remaining_label(hints, revealed) do
+    case length(hints) - revealed do
+      0 -> "No more hints — the next wrong guess ends the round."
+      1 -> "1 hint remaining."
+      n -> "#{n} hints remaining."
+    end
+  end
+
+  defp win_label(0), do: "Nailed it with no hints!"
+  defp win_label(1), do: "Solved after 1 hint."
+  defp win_label(n), do: "Solved after #{n} hints."
+
+  # mc_card wants an aspect string; fall back to the ownership pool (and the
+  # component itself falls back to "basic" styling for encounter/campaign).
+  defp reveal_aspect(%{primary_side: %{aspect: aspect}}) when not is_nil(aspect),
+    do: to_string(aspect)
+
+  defp reveal_aspect(%{primary_side: %{ownership: ownership}}) when not is_nil(ownership),
+    do: to_string(ownership)
+
+  defp reveal_aspect(_), do: "basic"
+end

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -45,6 +45,9 @@ defmodule SanctumWeb.Router do
       # Public card pool (catalog reads are unauthenticated).
       live "/cards", CardLive.Pool, :index
 
+      # Public "Name That Card" flavor-text guessing mini-game.
+      live "/guess", GuessLive.Play, :index
+
       # Dev playground for refining the comic stat badges.
       live "/dev/stat-badges", DevLive.StatBadges, :index
     end

--- a/test/sanctum/games/card_guess_test.exs
+++ b/test/sanctum/games/card_guess_test.exs
@@ -1,0 +1,138 @@
+defmodule Sanctum.Games.CardGuessTest do
+  @moduledoc false
+
+  use Sanctum.DataCase, async: true
+
+  import Sanctum.Factory
+
+  alias Sanctum.Games.{Card, CardGuess, CardSide, Stat}
+
+  describe "normalize/1" do
+    test "lowercases, strips a leading 'the', and drops punctuation" do
+      assert CardGuess.normalize("The Vision!") == "vision"
+      assert CardGuess.normalize("  Spider-Man  ") == "spiderman"
+      assert CardGuess.normalize("M'Baku") == "mbaku"
+      assert CardGuess.normalize(nil) == ""
+    end
+  end
+
+  describe "correct?/2" do
+    setup do
+      card = %Card{primary_side: %CardSide{name: "Black Widow", subname: "Natasha Romanoff"}}
+      {:ok, card: card}
+    end
+
+    test "exact (normalized) match wins", %{card: card} do
+      assert CardGuess.correct?("black widow", card)
+      assert CardGuess.correct?("Black Widow!", card)
+    end
+
+    test "a close typo wins via Jaro similarity", %{card: card} do
+      assert CardGuess.correct?("Black Widdow", card)
+    end
+
+    test "the subname also matches", %{card: card} do
+      assert CardGuess.correct?("Natasha Romanoff", card)
+    end
+
+    test "a far-off or empty guess fails", %{card: card} do
+      refute CardGuess.correct?("Iron Man", card)
+      refute CardGuess.correct?("", card)
+      refute CardGuess.correct?("   ", card)
+    end
+  end
+
+  describe "build_hints/1" do
+    test "a player card yields the full ordered ladder" do
+      side = %CardSide{
+        name: "The Vision",
+        subname: "Victor Shade",
+        type: :ally,
+        ownership: :player,
+        aspect: :leadership,
+        traits: ["Android", "Avenger"],
+        cost: 4,
+        resource_mental_count: 1,
+        attack: %Stat{value: 3},
+        thwart: %Stat{value: 2},
+        health: %Stat{value: 4}
+      }
+
+      card = %Card{unique: true, deck_limit: 3, set: "core", pack: "core", primary_side: side}
+      hints = CardGuess.build_hints(card)
+
+      assert Enum.map(hints, & &1.key) ==
+               [
+                 :allegiance,
+                 :nature,
+                 :aspect,
+                 :type,
+                 :traits,
+                 :cost,
+                 :resources,
+                 :stats,
+                 :uniqueness,
+                 :set,
+                 :name_shape
+               ]
+
+      assert hd(hints).text =~ "player card"
+      assert Enum.find(hints, &(&1.key == :aspect)).text =~ "Leadership"
+      assert Enum.find(hints, &(&1.key == :type)).text =~ "Ally"
+      assert Enum.find(hints, &(&1.key == :stats)).text =~ "ATK 3"
+    end
+
+    test "an encounter card skips the aspect/cost/resource/stat rungs" do
+      side = %CardSide{
+        name: "Shadow of the Past",
+        type: :treachery,
+        ownership: :encounter,
+        traits: []
+      }
+
+      card = %Card{unique: false, deck_limit: nil, set: "rhino", pack: "core", primary_side: side}
+      hints = CardGuess.build_hints(card)
+      keys = Enum.map(hints, & &1.key)
+
+      assert hd(hints).text =~ "encounter card"
+      assert :allegiance in keys
+      assert :set in keys
+      assert :name_shape in keys
+      refute :aspect in keys
+      refute :cost in keys
+      refute :resources in keys
+      refute :stats in keys
+      refute :uniqueness in keys
+    end
+  end
+
+  describe "random_guessable_card/0" do
+    test "returns a flavor-bearing card with its primary side loaded" do
+      card = create(Card, attrs: %{base_code: "90001", code: "90001"})
+
+      create(CardSide,
+        attrs: %{
+          card_id: card.id,
+          code: "90001a",
+          is_primary_side: true,
+          flavor: "With great power comes great responsibility."
+        }
+      )
+
+      result = CardGuess.random_guessable_card()
+
+      assert result.id == card.id
+      assert result.primary_side.flavor == "With great power comes great responsibility."
+    end
+
+    test "returns nil when no card has flavor text" do
+      card = create(Card, attrs: %{base_code: "90002", code: "90002"})
+
+      create(CardSide,
+        attrs: %{card_id: card.id, code: "90002a", is_primary_side: true, flavor: nil}
+      )
+
+      assert CardGuess.random_guessable_card() == nil
+    end
+  end
+end

--- a/test/sanctum_web/live/guess_live/play_test.exs
+++ b/test/sanctum_web/live/guess_live/play_test.exs
@@ -1,0 +1,74 @@
+defmodule SanctumWeb.GuessLive.PlayTest do
+  @moduledoc false
+
+  use SanctumWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Sanctum.Factory
+
+  # The cards table is empty under `mix test`, so a single seeded flavor card is
+  # the only guessable card and gets picked deterministically.
+  defp seed_card(name, flavor) do
+    card =
+      create(Sanctum.Games.Card,
+        attrs: %{base_code: "95001", code: "95001", unique: true, deck_limit: 1}
+      )
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: card.id,
+        code: "95001a",
+        side_identifier: "A",
+        is_primary_side: true,
+        name: name,
+        type: :ally,
+        ownership: :player,
+        aspect: :leadership,
+        flavor: flavor,
+        traits: ["Avenger"]
+      }
+    )
+
+    card
+  end
+
+  test "shows the flavor text and no answer up front", %{conn: conn} do
+    seed_card("Nick Fury", "The ultimate spy.")
+
+    {:ok, _view, html} = live(conn, ~p"/guess")
+
+    assert html =~ "Flavor Town"
+    assert html =~ "The ultimate spy."
+    refute html =~ "You got it!"
+  end
+
+  test "a wrong guess reveals the first hint", %{conn: conn} do
+    seed_card("Nick Fury", "The ultimate spy.")
+
+    {:ok, view, _html} = live(conn, ~p"/guess")
+
+    html = view |> form("form", %{guess: "Definitely Wrong"}) |> render_submit()
+
+    assert html =~ "Hints"
+    assert html =~ "This is a player card."
+    assert html =~ "Missed guesses: Definitely Wrong"
+  end
+
+  test "a correct guess wins and reveals the card", %{conn: conn} do
+    seed_card("Nick Fury", "The ultimate spy.")
+
+    {:ok, view, _html} = live(conn, ~p"/guess")
+
+    html = view |> form("form", %{guess: "nick fury"}) |> render_submit()
+
+    assert html =~ "You got it!"
+    assert html =~ "Nick Fury"
+    assert html =~ "Play again"
+  end
+
+  test "is reachable by a logged-out visitor", %{conn: conn} do
+    seed_card("Nick Fury", "The ultimate spy.")
+
+    assert {:ok, _view, _html} = live(conn, ~p"/guess")
+  end
+end


### PR DESCRIPTION
## What

Adds **Flavor Town**, a public `/guess` mini-game inspired by the *Stunned & Confused* Marvel Champions podcast segment: the player is shown a card's **flavor text** and tries to name the card. Each wrong guess reveals the next narrowing **hint**; once the ~10-hint ladder is exhausted, the next wrong guess ends the round and reveals the card.

## How it works

- **Card pool:** any card with non-empty flavor text (players, villains, minions, schemes, treacheries…). Hints adapt per card — inapplicable rungs are skipped.
- **Matching:** built-in `String.jaro_distance/2` (no new dependency) against the normalized name / `name subname` / subname, threshold `0.9` — forgiving of typos and punctuation.
- **Hint ladder** (broad → specific): allegiance → nature → aspect/origin → card type → traits → cost → resource icons → stats → uniqueness → set/pack → name shape.
- **Access:** public route `/guess` with a new top-nav tab; no login required. Session-only, nothing persisted.

## Changes

- `lib/sanctum/games/card.ex` — new `:guessable` read action (flavor-bearing cards, primary side loaded).
- `lib/sanctum/games/card_guess.ex` *(new)* — pure logic: random pick, hint ladder, `normalize/1`, `correct?/2`.
- `lib/sanctum_web/live/guess_live/play.ex` *(new)* — the LiveView (inline `~H`, reuses `Layouts.app`, `header`, `panel`, `button`, `mc_card`).
- `lib/sanctum_web/router.ex` — public `live "/guess"`.
- `lib/sanctum_web/components/layouts.ex` — "Flavor Town" nav tab + `:guess` in `active_tab` values.
- Tests: `test/sanctum/games/card_guess_test.exs`, `test/sanctum_web/live/guess_live/play_test.exs`.

## Verification

- New tests pass (13): normalize, exact/typo/subname matching, hint ordering + adaptive skipping (player vs encounter card), random selection, and the full LiveView flow (flavor shown → wrong guess reveals hint → correct guess wins & reveals card → logged-out access).
- `mix ck` clean (format, Credo, Sobelow).
- Manually driven against the real server: `/guess` renders live flavor text, the guess form, hints, and the active nav tab.

## Follow-ups (out of scope)

- Friendly pack/set display names (currently humanized codes).
- Per-user scores/streaks (would need persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)