### PR TITLE
feat(decks): comic-dossier public Deck Browser

### DIFF
--- a/lib/sanctum/decks/deck.ex
+++ b/lib/sanctum/decks/deck.ex
@@ -17,6 +17,68 @@ defmodule Sanctum.Decks.Deck do
   actions do
     defaults [:read, :destroy, create: :*]
 
+    # Public deck-browser search: filter by title/hero name, aspect, and hero,
+    # with sorting and offset pagination. Backs SanctumWeb.DeckLive.Index.
+    read :browse do
+      argument :query, :string, allow_nil?: true
+      argument :aspect, :string, allow_nil?: true
+      argument :hero_id, :string, allow_nil?: true
+      argument :sort, :string, allow_nil?: true
+
+      pagination offset?: true, default_limit: 24, countable: true, required?: false
+
+      prepare fn query, _context ->
+        require Ash.Query
+
+        search = Ash.Query.get_argument(query, :query)
+        aspect = Ash.Query.get_argument(query, :aspect)
+        hero_id = Ash.Query.get_argument(query, :hero_id)
+        sort = Ash.Query.get_argument(query, :sort)
+
+        query =
+          Ash.Query.load(query, [
+            :card_row_count,
+            :total_card_count,
+            :mcdb_user,
+            :owner,
+            hero: [:hero_side, card: [:primary_side]]
+          ])
+
+        query =
+          if is_binary(search) and String.trim(search) != "" do
+            pattern = "%" <> String.trim(search) <> "%"
+            Ash.Query.filter(query, ilike(title, ^pattern) or ilike(hero.hero_name, ^pattern))
+          else
+            query
+          end
+
+        query =
+          cond do
+            not is_binary(aspect) or aspect in ["", "all"] ->
+              query
+
+            # An empty aspect list is a basic deck.
+            aspect == "basic" ->
+              Ash.Query.filter(query, fragment("cardinality(?) = 0", aspects))
+
+            true ->
+              Ash.Query.filter(query, ^to_enum(aspect) in aspects)
+          end
+
+        query =
+          if is_binary(hero_id) and hero_id not in ["", "all"] do
+            Ash.Query.filter(query, hero_id == ^hero_id)
+          else
+            query
+          end
+
+        case sort do
+          "title" -> Ash.Query.sort(query, title: :asc)
+          _ -> Ash.Query.sort(query, updated_at: :desc)
+        end
+      end
+    end
+
     update :update do
       primary? true
       accept [:*]
@@ -127,5 +189,13 @@ defmodule Sanctum.Decks.Deck do
 
   identities do
     identity :unique_mcdb_deck, [:mcdb_type, :mcdb_id]
+  end
+
+  # Safely convert an incoming filter string to an existing atom; unknown
+  # values fall back to a sentinel that matches nothing.
+  defp to_enum(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> :__invalid__
   end
 end

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -53,13 +53,8 @@ defmodule SanctumWeb.Layouts do
           </a>
           <nav class="flex h-[34px] items-end gap-5">
             <.nav_tab navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.nav_tab>
+            <.nav_tab navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.nav_tab>
             <.nav_tab navigate={~p"/guess"} active={@active_tab == :guess}>Flavor Town</.nav_tab>
-            <span
-              class="cursor-default pb-[3px] text-[13px] font-bold uppercase tracking-[0.13em] text-base-content/25"
-              title="Coming soon"
-            >
-              Decks
-            </span>
           </nav>
           <div class="ml-auto flex items-center gap-4">
             <span class="font-ibm-mono text-xs text-base-content/40">

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -1,65 +1,362 @@
 defmodule SanctumWeb.DeckLive.Index do
+  @moduledoc """
+  Public "Deck Browser" — a feed of decks filterable by name/hero, aspect, and
+  hero, with Newest / A–Z sorting. The comic-dossier counterpart to the admin
+  deck table.
+  """
   use SanctumWeb, :live_view
+
+  require Ash.Query
+
+  alias SanctumWeb.Components.Card, as: CardComponent
+
+  @page_size 24
+
+  @aspects [
+    {"all", "All", nil},
+    {"aggression", "Aggression", "bg-aspect-aggression"},
+    {"justice", "Justice", "bg-aspect-justice"},
+    {"leadership", "Leadership", "bg-aspect-leadership"},
+    {"protection", "Protection", "bg-aspect-protection"},
+    {"pool", "Pool", "bg-aspect-pool"},
+    {"basic", "Basic", "bg-aspect-basic"}
+  ]
+
+  @sorts [{"new", "Newest"}, {"title", "A–Z"}]
 
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.admin flash={@flash}>
+    <Layouts.app current_user={@current_user} flash={@flash} active_tab={:decks}>
       <.header>
-        Listing Decks
-        <:subtitle>{length(@decks)} deck(s) — mostly synced from MarvelCDB</:subtitle>
+        Browse Decks
+        <:subtitle>
+          Every deck in the vault. Filter by hero or aspect, then open one for the full list.
+        </:subtitle>
       </.header>
 
-      <div class="w-full flex-1 min-h-0 overflow-auto">
-        <.table
-          id="decks"
-          rows={@decks}
-          row_click={fn deck -> JS.navigate(~p"/decks/#{deck}") end}
-        >
-          <:col :let={deck} label="Title">
-            <div class="font-medium">{deck.title}</div>
-          </:col>
-          <:col :let={deck} label="Hero">{deck.hero && deck.hero.hero_name}</:col>
-          <:col :let={deck} label="Aspects">{format_aspects(deck.aspects)}</:col>
-          <:col :let={deck} label="Cards">
-            {deck.total_card_count || 0} ({deck.card_row_count} unique)
-          </:col>
-          <:col :let={deck} label="Source">{deck.source}</:col>
-          <:col :let={deck} label="MarvelCDB">
-            <span :if={deck.mcdb_id}>{deck.mcdb_type}/{deck.mcdb_id}</span>
-          </:col>
-          <:col :let={deck} label="Author">
-            <span :if={deck.mcdb_user}>#{deck.mcdb_user.mcdb_user_id}</span>
-          </:col>
-
-          <:action :let={deck}>
-            <.link navigate={~p"/decks/#{deck}"}>Show</.link>
-          </:action>
-        </.table>
+      <!-- search + count -->
+      <div class="mb-3 flex flex-wrap items-center gap-2.5">
+        <form id="deck-search" phx-change="search" class="relative min-w-[260px] flex-1">
+          <span class="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-[17px] text-base-content/40">
+            ⌕
+          </span>
+          <input
+            type="text"
+            name="query"
+            value={@query}
+            phx-debounce="200"
+            autocomplete="off"
+            placeholder="Search decks or heroes…"
+            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-[15px] text-base-content outline-none focus:border-primary"
+          />
+        </form>
+        <div class="whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
+          {@count} <span class="text-base-content/45">/ {@total} decks</span>
+        </div>
       </div>
-    </Layouts.admin>
+
+      <!-- sort + hero -->
+      <div class="mb-2.5 flex flex-wrap items-center gap-2.5">
+        <div class="flex gap-1.5">
+          <.filter_pill
+            :for={{key, label} <- @sort_options}
+            active={@sort == key}
+            phx-click="sort"
+            phx-value-key={key}
+          >
+            {label}
+          </.filter_pill>
+        </div>
+        <form id="deck-hero-filter" phx-change="filter_hero" class="ml-auto min-w-[200px]">
+          <select
+            name="hero_id"
+            class="w-full border-[2.5px] border-line bg-black px-3 py-2 font-barlow-condensed text-[14px] font-bold uppercase tracking-[0.04em] text-base-content outline-none focus:border-primary"
+          >
+            <option value="all" selected={@hero_id == "all"}>All heroes</option>
+            <option :for={{id, name} <- @hero_options} value={id} selected={@hero_id == id}>
+              {name}
+            </option>
+          </select>
+        </form>
+      </div>
+
+      <!-- aspect filters -->
+      <div class="mb-6 flex flex-wrap gap-1.5">
+        <.filter_pill
+          :for={{key, label, dot_class} <- @aspect_options}
+          active={@aspect == key}
+          dot_class={dot_class}
+          phx-click="filter_aspect"
+          phx-value-key={key}
+        >
+          {label}
+        </.filter_pill>
+      </div>
+
+      <!-- feed -->
+      <div
+        id="deck-feed"
+        phx-update="stream"
+        phx-viewport-bottom={!@end_of_timeline? && "next-page"}
+        class="grid grid-cols-[repeat(auto-fill,minmax(520px,1fr))] items-start gap-3"
+      >
+        <.link
+          :for={{dom_id, deck} <- @streams.decks}
+          id={dom_id}
+          navigate={~p"/decks/#{deck.id}"}
+          class="mc-tile flex items-stretch gap-4 border-2 border-neutral bg-base-200 p-3.5 shadow-comic"
+        >
+          <div class="h-[151px] w-[108px] flex-none border-2 border-neutral shadow-comic-sm">
+            <.mc_card
+              name={deck.hero_name}
+              aspect={:hero}
+              image_url={deck.identity_image}
+              gradient_from={deck.gradient_from}
+              gradient_to={deck.gradient_to}
+              size="md"
+              show_cost={false}
+            />
+          </div>
+
+          <div class="flex min-w-0 flex-1 flex-col">
+            <div class="flex flex-wrap items-center gap-1.5">
+              <span
+                :for={a <- deck.aspects}
+                class={[
+                  "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
+                  a.text,
+                  a.border
+                ]}
+              >
+                {a.label}
+              </span>
+              <span class="border-2 border-neutral bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em] text-base-content/70">
+                {deck.source_label}
+              </span>
+            </div>
+
+            <div class="mt-2 font-anton text-[26px] uppercase leading-[0.95]">{deck.title}</div>
+
+            <div
+              :if={deck.tagline}
+              class="mt-1.5 font-barlow text-[14px] leading-[1.42] text-base-content/60"
+            >
+              {deck.tagline}
+            </div>
+
+            <div :if={deck.author} class="mt-auto flex items-center gap-2 pt-3">
+              <span class="flex size-[26px] items-center justify-center rounded-full border-2 border-neutral bg-primary font-bangers text-sm text-primary-content">
+                {deck.author_initial}
+              </span>
+              <span class="font-barlow-condensed text-[13px] font-bold text-primary">
+                {deck.author}
+              </span>
+            </div>
+          </div>
+
+          <div class="flex flex-none flex-col justify-center gap-2 border-l-2 border-neutral pl-4">
+            <div>
+              <div class="font-anton text-[26px] leading-none">{deck.total_card_count}</div>
+              <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                Cards
+              </div>
+            </div>
+            <div class="font-barlow text-[13px] text-base-content/55">
+              {deck.card_row_count} unique
+            </div>
+            <div class="font-ibm-mono text-[11px] leading-[1.5] text-base-content/40">
+              {deck.updated}
+            </div>
+          </div>
+        </.link>
+      </div>
+
+      <!-- empty state -->
+      <.panel
+        :if={@count == 0}
+        class="mt-2 border-dashed !border-[#2a2a30] px-6 py-12 text-center !shadow-none"
+      >
+        <div class="font-bangers text-[30px] tracking-[0.02em] text-primary">No decks found</div>
+        <div class="mt-1.5 font-barlow text-[14px] text-base-content/55">
+          Try a different search or clear your filters.
+        </div>
+        <.button variant="primary" phx-click="clear" class="mt-4">Clear filters</.button>
+      </.panel>
+    </Layouts.app>
     """
   end
 
   @impl true
   def mount(_params, _session, socket) do
+    total = count_decks(socket, %{})
+
     {:ok,
      socket
-     |> assign(:page_title, "Listing Decks")
-     |> assign_decks()}
+     |> assign(:page_title, "Browse Decks")
+     |> assign(:query, "")
+     |> assign(:sort, "new")
+     |> assign(:aspect, "all")
+     |> assign(:hero_id, "all")
+     |> assign(:total, total)
+     |> assign(:count, total)
+     |> assign(:aspect_options, @aspects)
+     |> assign(:sort_options, @sorts)
+     |> assign(:hero_options, load_hero_options())
+     |> assign(:offset, 0)
+     |> assign(:end_of_timeline?, false)
+     |> stream(:decks, [])
+     |> load_page(0, reset: true)}
   end
 
-  defp assign_decks(socket) do
-    decks =
-      Sanctum.Decks.list_decks!(
-        actor: socket.assigns[:current_user],
-        load: [:hero, :mcdb_user, :card_row_count, :total_card_count],
-        query: [sort: [inserted_at: :desc]]
+  # {id, hero_name} for every hero that has at least one deck, sorted by name.
+  # TODO: optimize with a distinct query if the deck count grows large.
+  defp load_hero_options do
+    Sanctum.Decks.Deck
+    |> Ash.Query.load(:hero)
+    |> Ash.read!()
+    |> Enum.map(& &1.hero)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq_by(& &1.id)
+    |> Enum.sort_by(& &1.hero_name)
+    |> Enum.map(&{&1.id, &1.hero_name})
+  end
+
+  @impl true
+  def handle_event("search", %{"query" => query}, socket) do
+    {:noreply, socket |> assign(:query, query) |> reset_and_load()}
+  end
+
+  def handle_event("sort", %{"key" => key}, socket) do
+    {:noreply, socket |> assign(:sort, key) |> reset_and_load()}
+  end
+
+  def handle_event("filter_aspect", %{"key" => key}, socket) do
+    {:noreply, socket |> assign(:aspect, key) |> reset_and_load()}
+  end
+
+  def handle_event("filter_hero", %{"hero_id" => hero_id}, socket) do
+    {:noreply, socket |> assign(:hero_id, hero_id) |> reset_and_load()}
+  end
+
+  def handle_event("clear", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(query: "", aspect: "all", hero_id: "all", sort: "new")
+     |> reset_and_load()}
+  end
+
+  def handle_event("next-page", _params, socket) do
+    if socket.assigns.end_of_timeline? do
+      {:noreply, socket}
+    else
+      {:noreply, load_page(socket, socket.assigns.offset + @page_size)}
+    end
+  end
+
+  defp reset_and_load(socket), do: load_page(socket, 0, reset: true)
+
+  defp load_page(socket, offset, opts \\ []) do
+    reset? = Keyword.get(opts, :reset, false)
+
+    page =
+      Sanctum.Decks.Deck
+      |> Ash.Query.for_read(:browse, filters(socket.assigns),
+        actor: socket.assigns[:current_user]
       )
+      |> Ash.read!(page: [limit: @page_size, offset: offset, count: reset?])
 
-    assign(socket, :decks, decks)
+    socket
+    |> assign(:offset, offset)
+    |> assign(:end_of_timeline?, !page.more?)
+    |> then(fn s -> if reset?, do: assign(s, :count, page.count), else: s end)
+    |> stream(:decks, Enum.map(page.results, &deck_view/1), reset: reset?)
   end
 
-  defp format_aspects([]), do: "basic"
-  defp format_aspects(aspects), do: Enum.map_join(aspects, ", ", &to_string/1)
+  defp count_decks(socket, extra) do
+    Sanctum.Decks.Deck
+    |> Ash.Query.for_read(:browse, Map.merge(%{sort: "new"}, extra),
+      actor: socket.assigns[:current_user]
+    )
+    |> Ash.read!(page: [limit: 1, offset: 0, count: true])
+    |> Map.get(:count)
+  end
+
+  defp filters(a) do
+    %{query: a.query, aspect: a.aspect, hero_id: a.hero_id, sort: a.sort}
+  end
+
+  # Builds the row display map from a loaded Deck.
+  defp deck_view(deck) do
+    hero = deck.hero
+    author = author(deck)
+
+    %{
+      id: deck.id,
+      title: deck.title,
+      hero_name: hero.hero_name,
+      identity_image: identity_image(hero),
+      gradient_from: hero.primary_color || elem(CardComponent.fallback_gradient(hero.set), 0),
+      gradient_to: hero.secondary_color || elem(CardComponent.fallback_gradient(hero.set), 1),
+      aspects: aspect_badges(deck.aspects),
+      source_label: source_label(deck.source),
+      tagline: excerpt(deck.description_md),
+      author: author,
+      author_initial: author_initial(author),
+      total_card_count: deck.total_card_count || 0,
+      card_row_count: deck.card_row_count || 0,
+      updated: format_date(deck.updated_at)
+    }
+  end
+
+  defp identity_image(%{hero_side: %{image_url: url}}) when is_binary(url), do: url
+  defp identity_image(%{card: %{primary_side: %{image_url: url}}}) when is_binary(url), do: url
+  defp identity_image(_), do: nil
+
+  defp aspect_badges([]), do: [aspect_badge(:basic, "Basic")]
+
+  defp aspect_badges(aspects),
+    do: Enum.map(aspects, &aspect_badge(&1, &1 |> to_string() |> String.capitalize()))
+
+  defp aspect_badge(aspect, label) do
+    ac = CardComponent.aspect_classes(aspect)
+    %{label: label, text: ac.text, border: ac.border}
+  end
+
+  defp source_label(:marvelcdb), do: "MarvelCDB"
+  defp source_label(:native), do: "Native"
+  defp source_label(other), do: other |> to_string() |> String.capitalize()
+
+  defp author(%{mcdb_user: %{username: username}}) when is_binary(username) and username != "",
+    do: "@" <> username
+
+  defp author(%{mcdb_user: %{mcdb_user_id: id}}) when not is_nil(id), do: "mcdb ##{id}"
+  defp author(%{owner: %{email: email}}) when is_binary(email), do: email
+  defp author(_), do: nil
+
+  defp author_initial(nil), do: "?"
+
+  defp author_initial(author),
+    do: author |> String.trim_leading("@") |> String.first() |> String.upcase()
+
+  # Turn description markdown into a short plain-text teaser.
+  defp excerpt(md) when is_binary(md) and md != "" do
+    text =
+      md
+      |> String.replace(~r/\[([^\]]+)\]\([^)]*\)/, "\\1")
+      |> String.replace(~r/[#>*_`~]/, "")
+      |> String.replace(~r/\s+/, " ")
+      |> String.trim()
+
+    cond do
+      text == "" -> nil
+      String.length(text) > 140 -> String.slice(text, 0, 140) <> "…"
+      true -> text
+    end
+  end
+
+  defp excerpt(_), do: nil
+
+  defp format_date(%DateTime{} = dt), do: Calendar.strftime(dt, "%b %-d, %Y")
+  defp format_date(_), do: ""
 end

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -45,6 +45,10 @@ defmodule SanctumWeb.Router do
       # Public card pool (catalog reads are unauthenticated).
       live "/cards", CardLive.Pool, :index
 
+      # Public deck browser + detail (deck reads are unauthenticated).
+      live "/decks", DeckLive.Index, :index
+      live "/decks/:id", DeckLive.Show, :show
+
       # Public "Name That Card" flavor-text guessing mini-game.
       live "/guess", GuessLive.Play, :index
 
@@ -62,9 +66,6 @@ defmodule SanctumWeb.Router do
 
       live "/cards/:id", CardLive.Show, :show
       live "/cards/:id/show/edit", CardLive.Show, :edit
-
-      live "/decks", DeckLive.Index, :index
-      live "/decks/:id", DeckLive.Show, :show
     end
   end
 

--- a/test/sanctum_web/live/deck_live/index_test.exs
+++ b/test/sanctum_web/live/deck_live/index_test.exs
@@ -1,0 +1,83 @@
+defmodule SanctumWeb.DeckLive.IndexTest do
+  @moduledoc false
+
+  use SanctumWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Sanctum.Factory
+
+  # Builds a valid deck (hero with both hero + alter-ego sides on one card).
+  defp make_deck(title, set, base_code, hero_name, aspects) do
+    card =
+      create(Sanctum.Games.Card, attrs: %{base_code: base_code, code: base_code <> "a", set: set})
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: card.id,
+        name: hero_name,
+        type: :hero,
+        code: base_code <> "a",
+        side_identifier: "A",
+        is_primary_side: true
+      }
+    )
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: card.id,
+        name: hero_name <> " (alter-ego)",
+        type: :alter_ego,
+        code: base_code <> "b",
+        side_identifier: "B",
+        is_primary_side: false
+      }
+    )
+
+    {:ok, hero} =
+      Sanctum.Heroes.find_or_create_hero(%{
+        hero_name: hero_name,
+        alter_ego_name: hero_name <> " (alter-ego)",
+        set: set,
+        base_code: base_code,
+        card_id: card.id
+      })
+
+    {:ok, deck} =
+      Sanctum.Decks.Deck
+      |> Ash.Changeset.for_create(:create, %{
+        title: title,
+        hero_id: hero.id,
+        aspects: aspects,
+        source: :native
+      })
+      |> Ash.create()
+
+    deck
+  end
+
+  test "an anonymous visitor can browse decks", %{conn: conn} do
+    make_deck("Web Warrior", "spider_man", "90001", "Spider-Man", [:justice])
+    make_deck("Cosmic Blast", "captain_marvel", "90002", "Captain Marvel", [:aggression])
+
+    {:ok, _view, html} = live(conn, ~p"/decks")
+
+    assert html =~ "Browse Decks"
+    assert html =~ "Web Warrior"
+    assert html =~ "Cosmic Blast"
+  end
+
+  test "search narrows the feed", %{conn: conn} do
+    make_deck("Web Warrior", "spider_man", "90001", "Spider-Man", [:justice])
+    make_deck("Cosmic Blast", "captain_marvel", "90002", "Captain Marvel", [:aggression])
+
+    {:ok, view, _html} = live(conn, ~p"/decks")
+
+    html =
+      view
+      |> form("form[phx-change=search]", %{query: "cosmic"})
+      |> render_change()
+
+    assert html =~ "Cosmic Blast"
+    refute html =~ "Web Warrior"
+  end
+end


### PR DESCRIPTION
## What

Rebuild `/decks` as the public **"Browse Decks"** feed from the design system, replacing the admin data table. Mirrors the Card Pool architecture.

The mockup's rows lean on MarvelCDB community metrics (likes, comments, rating, difficulty, archetype) that **we don't store**, so the row is adapted to our real `Deck` fields.

## Changes

- **`:browse` read action** on `Decks.Deck`: search (title / hero name via `ilike`), aspect filter (`= ANY`, with empty-array = basic), hero filter, Newest / A–Z sort, offset pagination + counts. No migration (read action only).
- **Public routing:** moved `/decks` and `/decks/:id` from the admin scope into the public scope (deck reads are already `authorize_if always()`), and lit up the dormant **"Decks" nav tab**.
- **`DeckLive.Index` rewrite:** `Layouts.app` + streamed feed — search, sort toggle, aspect filter pills, hero `<select>`, and deck rows: hero identity `mc_card` (with the hero's stored MarvelCDB gradient), aspect + source badges, Anton title, description excerpt, author handle, and a card-count / last-updated stats column. Infinite scroll + empty state.
- **`DeckLive.Index` test:** anonymous visitor can browse (guards the public-route move) + search narrows the feed.

## Verification

- `mix compile --warnings-as-errors` clean; `mix format --check-formatted` clean; `mix credo` clean.
- `mix test` — 143 tests, 0 failures (added 2 deck tests).
- Exercised the action via Tidewave (all=36, justice=7, basic=1, title-sort + search correct).
- Live on `:4150`: `/decks` returns **200 anonymously** (was 302→sign-in), the Decks tab is active, and the feed shows distinct per-hero gradient borders. `/decks/:id` also 200 anonymously.

## Follow-ups

- **Deck detail page** (`DeckLive.Show`) dossier restyle — now publicly reachable but still the old `Layouts.admin` table; the immediate next PR.
- Optional source filter + richer author once `McdbUser.username` is backfilled.
- Shared card-text markup renderer (`<b>`, `[energy]`) — still pending across Pool/detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)