### PR TITLE
feat(decks): comic-dossier deck detail page

### DIFF
--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -1,76 +1,189 @@
 defmodule SanctumWeb.DeckLive.Show do
+  @moduledoc """
+  Public deck detail — a comic-dossier "decklist" view: a cover with the hero
+  identity card + deck meta, the writeup, and the card list grouped by type.
+  """
   use SanctumWeb, :live_view
+
+  alias SanctumWeb.Components.Card, as: CardComponent
+
+  @type_order [:ally, :event, :support, :upgrade, :resource]
+  @type_plural %{
+    ally: "Allies",
+    event: "Events",
+    support: "Supports",
+    upgrade: "Upgrades",
+    resource: "Resources"
+  }
 
   @impl true
   def render(assigns) do
     ~H"""
-    <Layouts.admin flash={@flash}>
+    <Layouts.app current_user={@current_user} flash={@flash} active_tab={:decks}>
       <.header>
         {@deck.title}
         <:subtitle>
-          {@deck.hero && @deck.hero.hero_name} — {format_aspects(@deck.aspects)}
+          {@cover.hero_name}<span :if={@cover.author}> · by {@cover.author}</span>
         </:subtitle>
         <:actions>
           <.button navigate={~p"/decks"}>
-            <.icon name="hero-arrow-left" />
+            <.icon name="hero-arrow-left" /> Decks
           </.button>
         </:actions>
       </.header>
 
-      <div class="flex-1 min-h-0 overflow-y-auto pr-1">
-        <div class="mb-8 p-6 border-2 border-neutral bg-base-200 shadow-comic">
-          <h3 class="font-komika text-lg mb-4">Deck Information</h3>
-          <.list>
-            <:item title="Source">{@deck.source}</:item>
-            <:item :if={@deck.mcdb_id} title="MarvelCDB">
-              {@deck.mcdb_type}/{@deck.mcdb_id}
-            </:item>
-            <:item :if={@deck.mcdb_user} title="Author (MarvelCDB user)">
-              #{@deck.mcdb_user.mcdb_user_id}
-            </:item>
-            <:item title="Aspects">{format_aspects(@deck.aspects)}</:item>
-            <:item :if={@deck.tags} title="Tags">{@deck.tags}</:item>
-            <:item :if={@deck.version} title="Version">{@deck.version}</:item>
-            <:item title="Cards">
-              {@total_cards} ({length(@deck.deck_cards)} unique)
-            </:item>
-            <:item :if={@deck.meta && @deck.meta != %{}} title="Raw meta">
-              <code class="text-xs bg-base-300 px-2 py-1">{inspect(@deck.meta)}</code>
-            </:item>
-          </.list>
-        </div>
+      <div class="space-y-5">
+        <!-- cover -->
+        <.panel class="relative flex flex-col gap-5 overflow-hidden p-4 sm:flex-row sm:items-start">
+          <div
+            class="h-[330px] w-[236px] flex-none self-center border-2 border-neutral shadow-comic sm:self-start"
+            style="transform:rotate(-1.5deg);"
+          >
+            <.mc_card
+              name={@cover.hero_name}
+              aspect={:hero}
+              image_url={@cover.identity_image}
+              gradient_from={@cover.gradient_from}
+              gradient_to={@cover.gradient_to}
+              size="lg"
+              show_cost={false}
+            />
+          </div>
 
-        <div
-          :if={@deck.description_md}
-          class="mb-8 p-6 border-2 border-neutral bg-base-200 shadow-comic"
-        >
-          <h3 class="font-komika text-lg mb-2">Description</h3>
-          <div class="font-barlow text-[15px] leading-relaxed text-base-content/90 whitespace-pre-wrap">
-            {@deck.description_md}
+          <div class="flex min-w-0 flex-1 flex-col">
+            <div class="font-ibm-mono text-[11px] uppercase tracking-[0.25em] text-primary">
+              {@cover.source_label} · {@cover.hero_name}
+            </div>
+            <h1 class="mt-1.5 font-anton text-[46px] uppercase leading-[0.88] [text-wrap:balance]">
+              {@deck.title}
+            </h1>
+
+            <div class="mt-3 flex flex-wrap items-center gap-1.5">
+              <span
+                :for={a <- @cover.aspects}
+                class={[
+                  "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
+                  a.text,
+                  a.border
+                ]}
+              >
+                {a.label}
+              </span>
+            </div>
+
+            <div class="mt-4 flex items-end gap-6">
+              <div>
+                <div class="font-anton text-[30px] leading-none">{@cover.total_cards}</div>
+                <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                  Cards
+                </div>
+              </div>
+              <div>
+                <div class="font-anton text-[30px] leading-none">{@cover.unique_cards}</div>
+                <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                  Unique
+                </div>
+              </div>
+              <div :if={@cover.author} class="flex items-center gap-2 self-center">
+                <span class="flex size-[28px] items-center justify-center rounded-full border-2 border-neutral bg-primary font-bangers text-sm text-primary-content">
+                  {@cover.author_initial}
+                </span>
+                <span class="font-barlow-condensed text-[13px] font-bold text-primary">
+                  {@cover.author}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div class="absolute inset-x-0 bottom-0 h-1.5" style={"background:#{@cover.gradient_to};"}>
+          </div>
+        </.panel>
+
+        <!-- body: writeup + card list -->
+        <div class="grid items-start gap-5 lg:grid-cols-[1.4fr_1fr]">
+          <.panel class="p-5">
+            <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+              Deck Notes
+            </div>
+            <div
+              :if={@paragraphs != []}
+              class="font-barlow text-[15px] leading-[1.7] text-base-content/85"
+            >
+              <p :for={p <- @paragraphs} class="mb-4 whitespace-pre-line">{p}</p>
+            </div>
+            <div :if={@paragraphs == []} class="font-barlow text-[14px] italic text-base-content/45">
+              No writeup for this deck.
+            </div>
+          </.panel>
+
+          <div class="space-y-5">
+            <.panel class="p-4">
+              <div class="mb-3 flex items-baseline gap-2 border-b-2 border-neutral pb-2">
+                <div class="font-anton text-[17px] uppercase tracking-[0.05em]">In This Deck</div>
+                <div class="ml-auto font-ibm-mono text-[11px] text-base-content/45">
+                  {@cover.total_cards} cards
+                </div>
+              </div>
+
+              <div :for={g <- @groups} class="mb-4 last:mb-0">
+                <div class="mb-2 font-anton text-[12px] uppercase tracking-[0.06em] text-primary">
+                  {g.name} · {g.count}
+                </div>
+                <div class="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
+                  <.link
+                    :for={c <- g.cards}
+                    navigate={~p"/cards/#{c.card_id}"}
+                    class="h-[101px] border-2 border-neutral shadow-comic-sm"
+                  >
+                    <.mc_card
+                      name={c.name}
+                      cost={c.cost}
+                      aspect={c.aspect_key}
+                      image_url={c.image_url}
+                      gradient_from={c.gradient_from}
+                      gradient_to={c.gradient_to}
+                      qty={c.qty}
+                      size="sm"
+                      show_cost={false}
+                    />
+                  </.link>
+                </div>
+              </div>
+            </.panel>
+
+            <!-- details -->
+            <.panel class="p-4">
+              <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+                Details
+              </div>
+              <div class="grid grid-cols-2 gap-x-6 gap-y-3">
+                <.meta label="Source" value={@cover.source_label} />
+                <.meta
+                  :if={@deck.mcdb_id}
+                  label="MarvelCDB"
+                  value={"#{@deck.mcdb_type}/#{@deck.mcdb_id}"}
+                />
+                <.meta :if={@deck.version} label="Version" value={@deck.version} />
+                <.meta :if={@deck.tags} label="Tags" value={@deck.tags} />
+              </div>
+            </.panel>
           </div>
         </div>
-
-        <div class="w-full overflow-auto">
-          <.table
-            id="deck-cards"
-            rows={@deck_cards}
-            row_click={fn dc -> JS.navigate(~p"/cards/#{dc.card}") end}
-          >
-            <:col :let={dc} label="Qty">{dc.quantity}</:col>
-            <:col :let={dc} label="Name">{dc.card.primary_side && dc.card.primary_side.name}</:col>
-            <:col :let={dc} label="Type">{dc.card.primary_side && dc.card.primary_side.type}</:col>
-            <:col :let={dc} label="Aspect">
-              {dc.card.primary_side && dc.card.primary_side.aspect}
-            </:col>
-            <:col :let={dc} label="Cost">{dc.card.primary_side && dc.card.primary_side.cost}</:col>
-            <:col :let={dc} label="Base Code">{dc.card.base_code}</:col>
-            <:col :let={dc} label="Ignore Limit">
-              <span :if={dc.ignore_deck_limit}>yes</span>
-            </:col>
-          </.table>
-        </div>
       </div>
-    </Layouts.admin>
+    </Layouts.app>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :any, required: true
+
+  defp meta(assigns) do
+    ~H"""
+    <div :if={@value not in [nil, ""]}>
+      <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+        {@label}
+      </div>
+      <div class="mt-0.5 font-barlow-condensed text-[15px] font-semibold">{@value}</div>
+    </div>
     """
   end
 
@@ -79,24 +192,133 @@ defmodule SanctumWeb.DeckLive.Show do
     deck =
       Sanctum.Decks.get_deck!(id,
         actor: socket.assigns[:current_user],
-        load: [:hero, :mcdb_user, deck_cards: [card: [:primary_side]]]
+        load: [
+          :card_row_count,
+          :total_card_count,
+          :mcdb_user,
+          :owner,
+          hero: [:hero_side, card: [:primary_side]],
+          deck_cards: [card: [:primary_side]]
+        ]
       )
 
-    deck_cards =
-      Enum.sort_by(deck.deck_cards, fn dc ->
-        {to_string(dc.card.primary_side && dc.card.primary_side.type), dc.card.base_code}
-      end)
+    hero_gradient = hero_gradient(deck.hero)
 
-    total_cards = Enum.sum(Enum.map(deck.deck_cards, & &1.quantity))
+    groups =
+      deck.deck_cards
+      |> Enum.map(&card_view(&1, hero_gradient))
+      |> Enum.group_by(& &1.type)
+      |> Enum.map(fn {type, cards} ->
+        %{
+          type: type,
+          name: type_plural(type),
+          count: Enum.sum(Enum.map(cards, & &1.qty)),
+          cards: Enum.sort_by(cards, &{&1.cost || 99, &1.name})
+        }
+      end)
+      |> Enum.sort_by(&type_rank(&1.type))
 
     {:ok,
      socket
      |> assign(:page_title, "Deck - #{deck.title}")
      |> assign(:deck, deck)
-     |> assign(:deck_cards, deck_cards)
-     |> assign(:total_cards, total_cards)}
+     |> assign(:cover, cover_view(deck, hero_gradient))
+     |> assign(:groups, groups)
+     |> assign(:paragraphs, paragraphs(deck.description_md))}
   end
 
-  defp format_aspects([]), do: "basic"
-  defp format_aspects(aspects), do: Enum.map_join(aspects, ", ", &to_string/1)
+  defp cover_view(deck, {gradient_from, gradient_to}) do
+    hero = deck.hero
+    author = author(deck)
+
+    %{
+      hero_name: hero.hero_name,
+      identity_image: identity_image(hero),
+      gradient_from: gradient_from,
+      gradient_to: gradient_to,
+      aspects: aspect_badges(deck.aspects),
+      source_label: source_label(deck.source),
+      total_cards: deck.total_card_count || 0,
+      unique_cards: deck.card_row_count || 0,
+      author: author,
+      author_initial: author_initial(author)
+    }
+  end
+
+  defp card_view(dc, hero_gradient) do
+    side = dc.card.primary_side
+    aspect_key = display_aspect(side)
+    {gf, gt} = if aspect_key == :hero, do: hero_gradient, else: {nil, nil}
+
+    %{
+      card_id: dc.card.id,
+      qty: dc.quantity,
+      name: side.name,
+      cost: side.cost,
+      type: side.type,
+      aspect_key: aspect_key,
+      image_url: side.image_url,
+      gradient_from: gf,
+      gradient_to: gt
+    }
+  end
+
+  defp hero_gradient(%{primary_color: from, secondary_color: to, set: set}) do
+    {fallback_from, fallback_to} = CardComponent.fallback_gradient(set)
+    {from || fallback_from, to || fallback_to}
+  end
+
+  defp identity_image(%{hero_side: %{image_url: url}}) when is_binary(url), do: url
+  defp identity_image(%{card: %{primary_side: %{image_url: url}}}) when is_binary(url), do: url
+  defp identity_image(_), do: nil
+
+  # Player-card aspect display key (aspect cards use their aspect; hero/basic/
+  # pool ownership pools use their ownership).
+  defp display_aspect(%{ownership: :player, aspect: aspect}) when not is_nil(aspect), do: aspect
+  defp display_aspect(%{ownership: :hero}), do: :hero
+  defp display_aspect(%{ownership: :basic}), do: :basic
+  defp display_aspect(%{ownership: :pool}), do: :pool
+  defp display_aspect(%{aspect: aspect}) when not is_nil(aspect), do: aspect
+  defp display_aspect(_), do: :basic
+
+  defp aspect_badges([]), do: [aspect_badge(:basic, "Basic")]
+
+  defp aspect_badges(aspects),
+    do: Enum.map(aspects, &aspect_badge(&1, &1 |> to_string() |> String.capitalize()))
+
+  defp aspect_badge(aspect, label) do
+    ac = CardComponent.aspect_classes(aspect)
+    %{label: label, text: ac.text, border: ac.border}
+  end
+
+  defp source_label(:marvelcdb), do: "MarvelCDB"
+  defp source_label(:native), do: "Native"
+  defp source_label(other), do: other |> to_string() |> String.capitalize()
+
+  defp author(%{mcdb_user: %{username: username}}) when is_binary(username) and username != "",
+    do: "@" <> username
+
+  defp author(%{mcdb_user: %{mcdb_user_id: id}}) when not is_nil(id), do: "mcdb ##{id}"
+  defp author(%{owner: %{email: email}}) when is_binary(email), do: email
+  defp author(_), do: nil
+
+  defp author_initial(nil), do: "?"
+
+  defp author_initial(author),
+    do: author |> String.trim_leading("@") |> String.first() |> String.upcase()
+
+  defp paragraphs(md) when is_binary(md) and md != "",
+    do: md |> String.split(~r/\n\s*\n/, trim: true) |> Enum.map(&String.trim/1)
+
+  defp paragraphs(_), do: []
+
+  defp type_plural(type),
+    do: Map.get(@type_plural, type, type |> to_string() |> String.capitalize())
+
+  defp type_rank(type) do
+    case Enum.find_index(@type_order, &(&1 == type)) do
+      nil -> length(@type_order)
+      i -> i
+    end
+  end
 end

--- a/test/sanctum_web/live/deck_live/show_test.exs
+++ b/test/sanctum_web/live/deck_live/show_test.exs
@@ -1,0 +1,88 @@
+defmodule SanctumWeb.DeckLive.ShowTest do
+  @moduledoc false
+
+  use SanctumWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Sanctum.Factory
+
+  defp make_deck_with_card do
+    hero_card =
+      create(Sanctum.Games.Card, attrs: %{base_code: "90050", code: "90050a", set: "spider_man"})
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: hero_card.id,
+        name: "Spider-Man",
+        type: :hero,
+        code: "90050a",
+        side_identifier: "A",
+        is_primary_side: true
+      }
+    )
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: hero_card.id,
+        name: "Peter Parker",
+        type: :alter_ego,
+        code: "90050b",
+        side_identifier: "B",
+        is_primary_side: false
+      }
+    )
+
+    {:ok, hero} =
+      Sanctum.Heroes.find_or_create_hero(%{
+        hero_name: "Spider-Man",
+        alter_ego_name: "Peter Parker",
+        set: "spider_man",
+        base_code: "90050",
+        card_id: hero_card.id
+      })
+
+    {:ok, deck} =
+      Sanctum.Decks.Deck
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Web Warrior",
+        hero_id: hero.id,
+        aspects: [:justice],
+        source: :native,
+        description_md: "Thwart twice, apologise never."
+      })
+      |> Ash.create()
+
+    ally = create(Sanctum.Games.Card, attrs: %{base_code: "90051", code: "90051a"})
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: ally.id,
+        name: "Beat Cop",
+        type: :ally,
+        aspect: :justice,
+        cost: 3,
+        code: "90051a",
+        side_identifier: "A",
+        is_primary_side: true
+      }
+    )
+
+    Sanctum.Decks.DeckCard
+    |> Ash.Changeset.for_create(:create, %{deck_id: deck.id, card_id: ally.id, quantity: 2})
+    |> Ash.create!(authorize?: false)
+
+    deck
+  end
+
+  test "an anonymous visitor can view a deck's cover, notes, and card list", %{conn: conn} do
+    deck = make_deck_with_card()
+
+    {:ok, _view, html} = live(conn, ~p"/decks/#{deck.id}")
+
+    assert html =~ "Web Warrior"
+    assert html =~ "Spider-Man"
+    assert html =~ "In This Deck"
+    assert html =~ "Allies"
+    assert html =~ "Thwart twice"
+  end
+end


### PR DESCRIPTION
## What

Rebuild `DeckLive.Show` (`/decks/:id`) in the design-system style, replacing the old `Layouts.admin` table. This is the promised follow-up to the public Deck Browser (#89) — the page rows already link here; now it looks the part.

## Layout (public "decklist" view)

- **Cover panel** — the hero identity `mc_card` (`lg`, with the hero's stored MarvelCDB gradient, tilted slightly) beside the deck title (Anton), aspect badges, `cards` / `unique` stat pair, and the author; a hero-colored accent bar along the bottom.
- **Deck Notes** — the `description_md` writeup rendered as editorial paragraphs (plain text for now).
- **In This Deck** — the card list grouped by type (Allies / Events / Supports / Upgrades / Resources), each a grid of `mc_card` minis with quantity badges, linking to the card detail.
- **Details** — a compact meta grid (source, MarvelCDB id, version, tags).

Uses the `total_card_count` / `card_row_count` aggregates and mirrors the `CardLive.Show` conventions (panels, badges, meta grid, `display_aspect`/gradient reuse).

## Verification

- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo` all clean.
- `mix test` — 146 tests, 0 failures (added a `DeckLive.Show` test: anonymous visitor sees the cover, notes, and grouped card list).
- Live on `:4150`: `/decks/:id` renders the cover, writeup, and 38 grouped card minis for a sample deck.

## Follow-ups

- Shared **card-text / writeup markup renderer** (`<b>`, `*italic*`, `[energy]`, `[Card](/card/…)` chips) — the design's deck view had inline card-hover chips; the writeup currently renders as plain paragraphs. Still pending across Pool / card detail / deck notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)