### PR TITLE
feat(cards): format MarvelCDB card text into safe HTML

### DIFF
--- a/lib/sanctum/card_text.ex
+++ b/lib/sanctum/card_text.ex
@@ -1,0 +1,112 @@
+defmodule Sanctum.CardText do
+  @moduledoc """
+  Renders MarvelCDB card markup (`text`, `flavor`, `back_text`) into safe HTML.
+
+  MarvelCDB carries one markup format across every text-bearing field:
+
+    * inline emphasis tags — only `<b>`, `<i>` and `<em>` ever appear;
+    * `<hr />` section dividers;
+    * `\\n` line breaks;
+    * `[token]` icon codes (e.g. `[energy]`, `[per_hero]`, `[star]`);
+    * `[[Trait]]` double-bracket trait references (e.g. `[[X-MEN]]`, `[[Aerial]]`).
+
+  `to_html/1` whitelists the three emphasis tags, turns newlines into `<br>`,
+  swaps icon tokens for ChampionsIcons glyphs, and renders traits in the Komika
+  face. Everything else is HTML-escaped, so raw MarvelCDB HTML can never inject
+  markup into the page.
+
+  Tokens without a glyph in our ChampionsIcons font (`attack`/`thwart`/`defense`
+  and the trait icons) fall back to their name in small caps rather than the raw
+  `[bracketed]` code.
+  """
+  import Phoenix.HTML, only: [html_escape: 1, safe_to_string: 1]
+
+  # token => {glyph, resource-color class | nil}. The glyph letters are the
+  # ChampionsIcons cmap, verified against MarvelCDB's own icon CSS.
+  @icons %{
+    "energy" => {"E", "text-res-energy"},
+    "mental" => {"M", "text-res-mental"},
+    "physical" => {"P", "text-res-physical"},
+    "wild" => {"W", "text-res-wild"},
+    "cost" => {"D", nil},
+    "star" => {"S", nil},
+    "boost" => {"B", nil},
+    "crisis" => {"C", nil},
+    "hazard" => {"H", nil},
+    "acceleration" => {"A", nil},
+    "amplify" => {"F", nil},
+    "per_hero" => {"G", nil},
+    "per_group" => {"T", nil},
+    "unique" => {"U", nil}
+  }
+
+  # Splits a line into whitelisted tags (`<b>`/`<i>`/`<em>` emphasis and the
+  # `<hr />` divider), `[[Trait]]` references, icon tokens, and the plain text
+  # between them (kept as captures so nothing is dropped). The double-bracket
+  # alternative precedes the single-bracket one so `[[Trait]]` never gets
+  # mis-split as two icon tokens. Tag matching tolerates whitespace and stray
+  # self-closing forms (e.g. an empty `<b/>`).
+  @segment ~r{(</?(?:b|i|em)\s*/?>|<hr\s*/?>|\[\[[^\]]+\]\]|\[[a-z_]+\])}i
+
+  @hr ~r{^<hr}i
+  @self_closing_emphasis ~r{^<(?:b|i|em)\s*/>$}i
+  @emphasis ~r{^</?(?:b|i|em)>$}i
+  @token ~r/^\[[a-z_]+\]$/
+  @trait ~r/^\[\[(.+)\]\]$/
+
+  @doc """
+  Convert a MarvelCDB markup string into `{:safe, iodata}` for direct use in
+  HEEx. Returns an empty safe value for `nil` or `""`.
+  """
+  def to_html(text) when text in [nil, ""], do: {:safe, []}
+
+  def to_html(text) when is_binary(text) do
+    iodata =
+      text
+      |> String.replace("\r\n", "\n")
+      |> String.split("\n")
+      |> Enum.map(&render_line/1)
+      |> Enum.intersperse("<br>")
+
+    {:safe, iodata}
+  end
+
+  defp render_line(line) do
+    @segment
+    |> Regex.split(line, include_captures: true, trim: true)
+    |> Enum.map(&render_segment/1)
+  end
+
+  defp render_segment(segment) do
+    cond do
+      Regex.match?(@hr, segment) -> ~s(<hr class="my-2 border-neutral/60">)
+      Regex.match?(@self_closing_emphasis, segment) -> ""
+      Regex.match?(@emphasis, segment) -> String.downcase(segment)
+      match = Regex.run(@trait, segment) -> render_trait(Enum.at(match, 1))
+      Regex.match?(@token, segment) -> render_icon(String.slice(segment, 1..-2//1))
+      true -> escape(segment)
+    end
+  end
+
+  defp render_trait(name) do
+    ~s(<span class="font-komika">#{escape(name)}</span>)
+  end
+
+  defp render_icon(name) do
+    case Map.fetch(@icons, name) do
+      {:ok, {glyph, nil}} ->
+        ~s(<span class="font-champions leading-none">#{glyph}</span>)
+
+      {:ok, {glyph, color}} ->
+        ~s(<span class="font-champions leading-none #{color}">#{glyph}</span>)
+
+      :error ->
+        # No glyph in ChampionsIcons for this token — show the name in small
+        # caps rather than the raw `[bracket]` code.
+        label = name |> String.replace("_", " ") |> escape()
+        ~s(<span class="font-semibold uppercase tracking-wide">#{label}</span>)
+    end
+  end
+
+  defp escape(text), do: text |> html_escape() |> safe_to_string()
+end

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -168,14 +168,14 @@ defmodule SanctumWeb.CardLive.Pool do
             </div>
 
             <div class="text-center font-barlow text-[13.5px] leading-[1.5] text-base-content/85">
-              {card.text}
+              {Sanctum.CardText.to_html(card.text)}
             </div>
 
             <div
               :if={card.flavor}
               class="text-center font-barlow italic text-xs text-base-content/65 my-2"
             >
-              {card.flavor}
+              {Sanctum.CardText.to_html(card.flavor)}
             </div>
 
             <div :if={card.pips != []} class="mt-2.5 flex items-center gap-1">

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -101,7 +101,7 @@ defmodule SanctumWeb.CardLive.Show do
             <div class="my-3 h-px bg-neutral"></div>
 
             <div :if={side.text} class="font-barlow text-[14px] leading-[1.55] text-base-content/85">
-              {side.text}
+              {Sanctum.CardText.to_html(side.text)}
             </div>
 
             <!-- combat stats -->

--- a/test/sanctum/card_text_test.exs
+++ b/test/sanctum/card_text_test.exs
@@ -1,0 +1,90 @@
+defmodule Sanctum.CardTextTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.HTML, only: [safe_to_string: 1]
+
+  alias Sanctum.CardText
+
+  defp render(text), do: text |> CardText.to_html() |> safe_to_string()
+
+  describe "to_html/1" do
+    test "returns empty safe value for nil and empty string" do
+      assert CardText.to_html(nil) == {:safe, []}
+      assert CardText.to_html("") == {:safe, []}
+    end
+
+    test "passes through whitelisted emphasis tags" do
+      assert render("<b>Interrupt</b>: draw a card") ==
+               "<b>Interrupt</b>: draw a card"
+
+      assert render("<i>quiet</i> and <em>loud</em>") ==
+               "<i>quiet</i> and <em>loud</em>"
+    end
+
+    test "escapes stray HTML and ampersands so nothing is injected" do
+      assert render(~s(1 < 2 & "three" <script>x</script>)) ==
+               "1 &lt; 2 &amp; &quot;three&quot; &lt;script&gt;x&lt;/script&gt;"
+    end
+
+    test "converts newlines to <br>" do
+      assert render("line one\nline two") == "line one<br>line two"
+      assert render("a\r\nb") == "a<br>b"
+    end
+
+    test "renders resource tokens as colored ChampionsIcons glyphs" do
+      assert render("[energy]") ==
+               ~s(<span class="font-champions leading-none text-res-energy">E</span>)
+
+      assert render("[physical]") ==
+               ~s(<span class="font-champions leading-none text-res-physical">P</span>)
+    end
+
+    test "renders non-resource tokens as uncolored glyphs" do
+      assert render("[star]") ==
+               ~s(<span class="font-champions leading-none">S</span>)
+
+      assert render("[per_hero]") ==
+               ~s(<span class="font-champions leading-none">G</span>)
+    end
+
+    test "falls back to small-caps name for tokens without a glyph" do
+      assert render("[attack]") ==
+               ~s(<span class="font-semibold uppercase tracking-wide">attack</span>)
+
+      assert render("[per_group_missing]") =~ "per group missing"
+      refute render("[guardian]") =~ "["
+    end
+
+    test "renders <hr /> dividers and drops stray empty emphasis tags" do
+      assert render("above\n<hr />\nbelow") ==
+               ~s(above<br><hr class="my-2 border-neutral/60"><br>below)
+
+      assert render("a<b/>b") == "ab"
+    end
+
+    test "renders [[Trait]] double-bracket references in the Komika face" do
+      assert render("[[X-MEN]]") == ~s(<span class="font-komika">X-MEN</span>)
+
+      assert render("[[S.H.I.E.L.D.]] and [[Board Member]]") ==
+               ~s(<span class="font-komika">S.H.I.E.L.D.</span> and ) <>
+                 ~s(<span class="font-komika">Board Member</span>)
+    end
+
+    test "does not confuse a [[Trait]] with single-bracket icon tokens" do
+      html = render("[[Attack]] then [attack]")
+
+      assert html ==
+               ~s(<span class="font-komika">Attack</span> then ) <>
+                 ~s(<span class="font-semibold uppercase tracking-wide">attack</span>)
+    end
+
+    test "handles a realistic mixed line" do
+      html = render("<b>Forced Response</b>: discard the top card.\n[physical] - Deal 2 damage.")
+
+      assert html ==
+               "<b>Forced Response</b>: discard the top card.<br>" <>
+                 ~s(<span class="font-champions leading-none text-res-physical">P</span>) <>
+                 " - Deal 2 damage."
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Card text was rendered with `{side.text}`, so HEEx escaped the raw MarvelCDB markup and it showed as literal source — `<b>Interrupt</b>`, `[energy]`, `[[Aerial]]`, collapsed newlines.

## What changed

New `Sanctum.CardText.to_html/1` converts MarvelCDB markup into safe HEEx (`{:safe, iodata}`):

- **HTML whitelist** — only `<b>`, `<i>`, `<em>` pass through; everything else is HTML-escaped. No `raw/1` on external content (XSS-safe, CSP-friendly).
- **`\n` → `<br>`** for multi-line effects.
- **`[token]` icon codes** → ChampionsIcons glyphs. All 14 tokens with a real glyph are mapped (verified against MarvelCDB's own icon CSS): `energy/mental/physical/wild` (with resource pip colors), `cost/star/boost/crisis/hazard/acceleration/amplify/per_hero/per_group/unique`. Tokens with no glyph (`attack/thwart/defense`, trait icons) fall back to small-caps text instead of raw `[brackets]`.
- **`[[Trait]]` double-bracket references** → rendered in the Komika face (1,411 across the corpus: `[[X-MEN]]`, `[[S.H.I.E.L.D.]]`, `[[Aerial]]`…).

Wired into the card detail (`show`) and pool (`text` + `flavor`) views.

**No schema/migration/sync changes** — `text`/`real_text` are byte-identical across all 4,307 cards, and `boost_text` is unused (boost effects live inline via `[boost]`).

## Testing

- 10 unit tests in `test/sanctum/card_text_test.exs` — all passing.
- Verified end-to-end on real DB rows through the running app: Spider-Man `<b>`, Hulk `[physical]/[energy]/[mental]/[wild]` + newlines, Klaw `[star]`, Surveillance Team `<i>`, Crisis Interdiction `[[Aerial]]`→komika, apostrophes escaped to `&#39;`.
- `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)