### PR TITLE
feat(cards): show a printed dash on stat badges with no value

### DIFF
--- a/lib/sanctum_web/components/stat_badge.ex
+++ b/lib/sanctum_web/components/stat_badge.ex
@@ -42,7 +42,11 @@ defmodule SanctumWeb.Components.StatBadge do
       <.stat_badge stat={:def} value="*" bright="#49b52b" dark="#256714" label="DEF" />
   """
   attr :stat, :any, default: :thw, doc: "stat key (:thw :atk :def :sch :hp :rec) or custom string"
-  attr :value, :any, default: nil, doc: "number/marker shown in the star"
+
+  attr :value, :any,
+    default: nil,
+    doc: "number/marker shown in the star; nil renders the printed-dash bar (distinct from 0)"
+
   attr :size, :integer, default: 88, doc: "rendered width in px"
   attr :label, :string, default: nil, doc: "override the plate label"
   attr :bright, :string, default: nil, doc: "override the bright fill color"
@@ -102,7 +106,7 @@ defmodule SanctumWeb.Components.StatBadge do
       height={@height}
       viewBox={"-30 0 260 #{@vb_height}"}
       role="img"
-      aria-label={"#{@label} #{@value}"}
+      aria-label={"#{@label} #{if is_nil(@value), do: "—", else: @value}"}
       style="overflow:visible"
       {@rest}
     >
@@ -141,7 +145,21 @@ defmodule SanctumWeb.Components.StatBadge do
       </g>
 
       <path d={@plate} fill="#141418" stroke="#fbfbfb" stroke-width="4" stroke-linejoin="round" />
+      <rect
+        :if={is_nil(@value)}
+        x="64"
+        y="100"
+        width="72"
+        height="22"
+        rx="8"
+        fill="#fff"
+        stroke="#101014"
+        stroke-width="7.2"
+        style="paint-order:stroke"
+        filter={"url(#shadow-#{@uid})"}
+      />
       <text
+        :if={not is_nil(@value)}
         x={if @star, do: "104", else: "100"}
         y="111"
         text-anchor="middle"


### PR DESCRIPTION
## Summary

Allies like Hulk have no printed THW stat — the card shows a dash. Our starburst stat badge rendered an empty star in that case. The badge now draws the card frame's thick outlined dash bar when the stat value is `nil`.

- `nil` value → dash bar (matching the physical card art), with the same outline and drop shadow as the numerals
- Printed `0` still renders as `0` — no-stat and zero-stat stay distinct
- `aria-label` reads "THW —" instead of trailing off empty

No call-site changes needed: the pool tile already passed `nil` through; the badge just had nothing to show for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)