### PR TITLE
feat(cards): show hero combat stats and hand size in the card pool

### DIFF
--- a/lib/sanctum_web/components/hand_size_badge.ex
+++ b/lib/sanctum_web/components/hand_size_badge.ex
@@ -1,0 +1,61 @@
+defmodule SanctumWeb.Components.HandSizeBadge do
+  @moduledoc """
+  A hero's hand-size indicator — a small "fanned cards" glyph followed by the
+  hand-size number, styled to match the white-rimmed comic card frames.
+
+  Three rounded-rect cards fan out from a shared bottom hinge, each with a white
+  fill and a dark stroke. Drawn back-to-front, the front cards' strokes read as
+  the gaps between the fanned cards — so no masking is needed.
+  """
+  use Phoenix.Component
+
+  # One card face (rounded rect, width 24), centered on the bottom hinge (50,82).
+  # The three copies are tilted around that hinge with `rotate(...)`.
+  @card "M 42.5 37 L 57.5 37 A 4.5 4.5 0 0 1 62 41.5 L 62 75.5 A 4.5 4.5 0 0 1 57.5 80 L 42.5 80 A 4.5 4.5 0 0 1 38 75.5 L 38 41.5 A 4.5 4.5 0 0 1 42.5 37 Z"
+
+  @doc """
+  Renders the hand-size icon + number.
+
+  ## Examples
+
+      <.hand_size_badge value={5} />
+      <.hand_size_badge value={6} class="text-base-content/80" />
+  """
+  attr :value, :any, default: nil, doc: "hand size shown to the right of the glyph"
+  attr :size, :integer, default: 24, doc: "glyph height in px"
+  attr :class, :string, default: nil
+  attr :rest, :global
+
+  def hand_size_badge(assigns) do
+    assigns = assign(assigns, card: @card, width: round(assigns.size * 72 / 52))
+
+    ~H"""
+    <span class={["inline-flex items-center gap-1.5 leading-none", @class]} {@rest}>
+      <svg width={@width} height={@size} viewBox="14 34 72 52" role="img" aria-label="Hand size">
+        <!-- drawn back-to-front left→right, so each card stacks over the one to its left.
+             a small rotation + outward shift keeps the fan gentle but well spaced -->
+        <path
+          d={@card}
+          transform="translate(-9 0) rotate(-15 50 82)"
+          fill="currentColor"
+          stroke="#141418"
+          stroke-width="3"
+          stroke-linejoin="round"
+        />
+        <path d={@card} fill="currentColor" stroke="#141418" stroke-width="3" stroke-linejoin="round" />
+        <path
+          d={@card}
+          transform="translate(9 0) rotate(15 50 82)"
+          fill="currentColor"
+          stroke="#141418"
+          stroke-width="3"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <span :if={not is_nil(@value)} class="font-elektra-med text-2xl/tight h-6">
+        {@value}
+      </span>
+    </span>
+    """
+  end
+end

--- a/lib/sanctum_web/components/stat_badge.ex
+++ b/lib/sanctum_web/components/stat_badge.ex
@@ -48,6 +48,7 @@ defmodule SanctumWeb.Components.StatBadge do
   attr :bright, :string, default: nil, doc: "override the bright fill color"
   attr :dark, :string, default: nil, doc: "override the dark rim/dot color"
   attr :tilt, :integer, default: @tilt, doc: "star tilt in degrees (plate/text stay flat)"
+  attr :hero, :boolean, default: false, doc: "Whether or not this stat is for a hero card"
 
   attr :consequential, :integer,
     default: 0,
@@ -74,7 +75,7 @@ defmodule SanctumWeb.Components.StatBadge do
     conseq = max(assigns.consequential || 0, 0)
     # Plate grows a row taller when it carries consequential stars; sides keep the
     # same lean so the short and tall variants read as the same shape.
-    plate_bottom = 264
+    plate_bottom = if assigns.hero, do: 224, else: 264
     dy = plate_bottom - 162
     bottom_l = Float.round(16 + -16 / 102 * dy, 1)
     bottom_r = Float.round(196 + -16 / 102 * dy, 1)

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -8,6 +8,7 @@ defmodule SanctumWeb.CardLive.Pool do
 
   require Ash.Query
 
+  import SanctumWeb.Components.HandSizeBadge
   import SanctumWeb.Components.HealthBadge
   import SanctumWeb.Components.StatBadge
 
@@ -118,7 +119,7 @@ defmodule SanctumWeb.CardLive.Pool do
           </div>
 
           <div class="flex min-w-0 flex-1 flex-col">
-            <div class="flex items-start gap-3">
+            <div class="h-12 flex items-start gap-3">
               <div
                 :if={card.show_cost}
                 class="flex flex-none items-center justify-center rounded-full font-elektra-med text-4xl/normal"
@@ -158,6 +159,17 @@ defmodule SanctumWeb.CardLive.Pool do
               </div>
             </div>
 
+            <div :if={card.is_hero} class="flex items-start gap-2 w-full">
+              <div class="flex flex-grow items-start justify-start">
+                <.stat_badge stat={:thw} value={card.thwart} size={64} hero={true} />
+                <.stat_badge stat={:atk} value={card.attack} size={64} hero={true} />
+                <.stat_badge stat={:def} value={card.defense} size={64} hero={true} />
+              </div>
+              <div class="flex items-start justify-end">
+                <.health_badge value={card.health} size={52} />
+              </div>
+            </div>
+
             <div class="my-2 h-px bg-neutral"></div>
 
             <div
@@ -178,13 +190,21 @@ defmodule SanctumWeb.CardLive.Pool do
               {Sanctum.CardText.to_html(card.flavor)}
             </div>
 
-            <div :if={card.pips != []} class="mt-2.5 flex items-center gap-1">
+            <div
+              :if={card.pips != [] or (card.is_hero and card.hand_size)}
+              class="mt-2.5 flex items-center gap-1"
+            >
               <span
                 :for={{color_class, glyph} <- card.pips}
                 class={["font-champions text-2xl leading-none", color_class]}
               >
                 {glyph}
               </span>
+              <.hand_size_badge
+                :if={card.is_hero and card.hand_size}
+                value={card.hand_size}
+                class="ml-auto text-base-content/75"
+              />
             </div>
           </div>
         </div>
@@ -327,10 +347,13 @@ defmodule SanctumWeb.CardLive.Pool do
       text: side.text || "",
       flavor: Map.get(side, :flavor, ""),
       is_ally: side.type == :ally,
+      is_hero: side.type == :hero,
+      hand_size: side.hand_size,
       attack: stat_value(side.attack),
       attack_consequential: stat_consequential(side.attack),
       thwart: stat_value(side.thwart),
       thwart_consequential: stat_consequential(side.thwart),
+      defense: stat_value(side.defense),
       health: stat_value(side.health),
       image_url: side.image_url
     }


### PR DESCRIPTION
## Summary

Hero cards in the Card Pool now render their combat stats the way ally cards do, plus a new hand-size indicator.

- **Card Pool** — render THW / ATK / DEF starburst badges and the HP health badge for hero cards. Heroes have a defense stat allies lack, and no consequential damage. Adds `is_hero` / `defense` / `hand_size` to the card view.
- **HandSizeBadge** (new component) — a "fanned cards" glyph followed by the hand-size number, shown in the resource-pip row aligned right. Three rounded-rect cards fan from a shared bottom hinge (gentle tilt + a small outward shift), stacked left→right so each overlaps the one to its left. Fill and number inherit the traits text color; a dark stroke separates the cards.
- **StatBadge** — supports a `hero` variant (shorter nameplate) used by the hero stat row.

## Testing

- `mix compile --warnings-as-errors` passes clean.
- Glyph geometry verified by rendering the exact SVG headlessly at inline (24px), 40px, and detail (96px) sizes, and against the panel background with the traits color applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)