### PR TITLE
fix(cards): don't duplicate card sides whose stored enum no longer loads

### DIFF
--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -560,12 +560,14 @@ defmodule Sanctum.MarvelCdb do
   defp upsert_side(card, side_attrs) do
     attrs = Map.put(side_attrs, :card_id, card.id)
 
-    find_existing_side(card, attrs)
-    |> case do
-      {:ok, existing} -> Games.update_card_side(existing, attrs, authorize?: false)
-      {:error, _not_found} -> Games.create_card_side(attrs, authorize?: false)
-    end
-    |> case do
+    result =
+      case find_existing_side(card, attrs) do
+        {:ok, existing} -> Games.update_card_side(existing, attrs, authorize?: false)
+        :not_found -> Games.create_card_side(attrs, authorize?: false)
+        {:error, _} = err -> err
+      end
+
+    case result do
       {:ok, side} ->
         create_or_find_villain(card, side)
         :ok
@@ -575,15 +577,42 @@ defmodule Sanctum.MarvelCdb do
     end
   end
 
-  # The card+identifier fallback catches rows written by older sync logic
-  # under a differently-suffixed code (e.g. "01144" where the payload now says
+  # Resolves an existing side to update, or `:not_found` to create. A lookup that
+  # fails for any reason *other* than a missing row — e.g. an existing row that
+  # can't be loaded because a stored enum value is no longer valid (a legacy
+  # `aspect`/`ownership` faction value) — returns `{:error, reason}` and must
+  # propagate. Treating such an error as "not found" is what inserts a duplicate
+  # and trips the (card_id, side_identifier) unique constraint (the ~1,600 prod
+  # sync failures).
+  #
+  # The card+identifier fallback catches rows written by older sync logic under
+  # a differently-suffixed code (e.g. "01144" where the payload now says
   # "01144a"); updating them corrects the code in place.
   defp find_existing_side(card, attrs) do
     case Games.get_card_side_by_code(attrs.code) do
-      {:ok, existing} -> {:ok, existing}
-      {:error, _} -> Games.get_card_side_by_card_and_side(card.id, attrs.side_identifier)
+      {:ok, existing} ->
+        {:ok, existing}
+
+      {:error, error} ->
+        if not_found?(error),
+          do: find_side_by_card_and_side(card, attrs),
+          else: {:error, error}
     end
   end
+
+  defp find_side_by_card_and_side(card, attrs) do
+    case Games.get_card_side_by_card_and_side(card.id, attrs.side_identifier) do
+      {:ok, existing} -> {:ok, existing}
+      {:error, error} -> if not_found?(error), do: :not_found, else: {:error, error}
+    end
+  end
+
+  defp not_found?(%Ash.Error.Query.NotFound{}), do: true
+
+  defp not_found?(%Ash.Error.Invalid{errors: errors}),
+    do: Enum.any?(errors, &match?(%Ash.Error.Query.NotFound{}, &1))
+
+  defp not_found?(_), do: false
 
   # The side's image with fallback to the double-sided parent entry, which
   # alone carries the front (`imagesrc`) and back (`backimagesrc`) scans for

--- a/priv/repo/migrations/20260714170000_reclassify_non_aspect_faction_values.exs
+++ b/priv/repo/migrations/20260714170000_reclassify_non_aspect_faction_values.exs
@@ -1,0 +1,49 @@
+defmodule Sanctum.Repo.Migrations.ReclassifyNonAspectFactionValues do
+  @moduledoc """
+  Data migration: fix `card_sides.aspect` rows still holding ownership-only
+  faction values.
+
+  The faction split (`split_card_faction`) moved MarvelCDB's overloaded
+  `faction_code` into two columns — `ownership` (which pool a card comes from)
+  and `aspect` (the player aspects only). But it only *added* the `ownership`
+  column; it never scrubbed the raw faction value out of `aspect`. Rows synced
+  before the split kept ownership-only values there — "encounter" (~1,644) and
+  "basic" (~329) — which are no longer valid `CardAspect` members.
+
+  Any such row fails to load through Ash, which breaks reads and — because the
+  catalog sync's find-existing-side lookup then errors instead of matching —
+  makes re-sync raise a duplicate-side constraint (~1,600 failures in prod).
+  This is the same failure `reclassify_pool_ownership_as_aspect` fixed, for the
+  symmetric case where the stale value sits in `aspect` rather than `ownership`.
+
+  Rewrite those rows to the classification the current MarvelCDB sync writes:
+  the pool moves to `ownership`, `aspect` becomes NULL.
+
+  Hand-written data migration (a deliberate exception to the
+  "migrations are managed by ash.codegen" rule).
+  """
+
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE card_sides
+    SET ownership = 'encounter', aspect = NULL, updated_at = now()
+    WHERE aspect = 'encounter'
+    """)
+
+    execute("""
+    UPDATE card_sides
+    SET ownership = 'basic', aspect = NULL, updated_at = now()
+    WHERE aspect = 'basic'
+    """)
+  end
+
+  def down do
+    # No-op: the corrected state (pool in `ownership`, `aspect` NULL) is exactly
+    # what a clean sync writes. Restoring the old ownership-only value into
+    # `aspect` would reintroduce the un-loadable rows this migration removes, so
+    # reverting is intentionally not done.
+    :ok
+  end
+end

--- a/test/sanctum/card_sync_test.exs
+++ b/test/sanctum/card_sync_test.exs
@@ -234,6 +234,31 @@ defmodule Sanctum.CardSyncTest do
     assert side_a.name == "Spider-Man"
   end
 
+  test "does not duplicate a side whose stored enum value no longer loads" do
+    assert {:ok, _} = CardSync.run(packs: :all, images?: false)
+
+    {:ok, card} = Games.get_card_by_code("01001")
+
+    # Corrupt an existing side the way legacy prod data is corrupt: an
+    # ownership-only faction value ("encounter") left in the aspect column,
+    # which the current CardAspect enum can no longer load.
+    Sanctum.Repo.query!("UPDATE card_sides SET aspect = 'encounter' WHERE code = '01001a'")
+
+    count_sql = "SELECT count(*) FROM card_sides WHERE card_id::text = $1"
+    before = Sanctum.Repo.query!(count_sql, [card.id]).rows
+
+    assert {:error, %{data: %{failures: failures}}} = CardSync.run(packs: :all, images?: false)
+
+    # The card group failed, but NOT with a duplicate-side constraint violation:
+    # the un-loadable row's error propagates instead of being mistaken for "not
+    # found" and re-inserted.
+    assert {"01001", error} = Enum.find(failures, fn {code, _} -> code == "01001" end)
+    refute inspect(error) =~ "has already been taken"
+
+    # No duplicate side was inserted for the card.
+    assert before == Sanctum.Repo.query!(count_sql, [card.id]).rows
+  end
+
   test "dry run writes nothing" do
     assert {:ok, :dry_run} = CardSync.run(packs: :all, dry_run?: true)
     assert {:error, _} = Games.get_card_side_by_code("01001a")


### PR DESCRIPTION
## Problem

Running the MarvelCDB card sync in **prod** produced **~1,600** errors like:

```
%Ash.Error.Invalid{... InvalidAttribute{field: :card_id,
  message: "has already been taken",
  constraint: "card_sides_unique_card_side_index" ...}}
```

## Root cause

Legacy `card_sides` rows carry ownership-only faction values — **1,644 `"encounter"` + 329 `"basic"`** — in the **`aspect`** column. These were left behind when `split_card_faction` *added* the `ownership` column without scrubbing the raw faction value out of `aspect`. The current `CardAspect` enum (`[:aggression, :protection, :leadership, :justice, :pool]`) rejects them, so Ash **fails to load** those ~1,973 rows.

The sync's `find_existing_side` treated that load error as "row not found" and fell through to `create_card_side`, colliding with the row that's already there → the unique-constraint violations. Dev never hit this because dev was wiped + re-synced during Card Model v2; prod was not.

This is the same failure `reclassify_pool_ownership_as_aspect` already fixed — the symmetric case, with the stale value in `aspect` instead of `ownership`.

## Fix

- **`marvel_cdb.ex`** — `find_existing_side` now only `create`s on a genuine `NotFound`; any other lookup error **propagates as a counted failure** instead of silently inserting a duplicate. This closes the latent defect that turned one un-loadable row into a constraint violation.
- **Data migration** `reclassify_non_aspect_faction_values` — rewrites the polluted rows to exactly what the sync writes: pool → `ownership`, `aspect` → `NULL`. Mirrors the pool precedent (hand-written data migration, the blessed exception to the ash.codegen rule).
- **Regression test** — corrupting a side's `aspect` no longer yields a duplicate/`"has already been taken"` error and inserts no duplicate row.

## Verification

- Root cause confirmed against prod via read-only diagnostic: the exact Ash read used by `find_existing_side` errors with `cannot load "encounter" as type CardAspect for field :aspect`, while the row exists.
- `mix ck` clean (format, Credo, Sobelow); sync test suite green including the new regression test.
- Migration applies cleanly.

After this merges + deploys (`/app/bin/migrate` runs the data migration), re-running the sync is idempotent again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)