### PR TITLE
feat(cards): show every card side in the pool, search by any side title

### DIFF
--- a/lib/sanctum/games/card.ex
+++ b/lib/sanctum/games/card.ex
@@ -14,71 +14,12 @@ defmodule Sanctum.Games.Card do
     end
   end
 
-  # Ownership pools and types that belong in the player card pool (deck-buildable
-  # cards). Encounter/villain/identity/scheme cards are excluded. Hero signature
-  # cards are the `:hero` pool and surface under the "hero" filter. Pool cards are
-  # ordinary `:player` cards carrying the `:pool` aspect.
-  @player_ownerships [:player, :basic, :hero]
-  @player_types [:hero, :alter_ego, :ally, :event, :support, :upgrade, :resource]
-
   actions do
     defaults [:destroy]
 
     read :read do
       primary? true
       pagination offset?: true, default_limit: 50, required?: false
-    end
-
-    # Public card pool browsing: player cards filtered by name/aspect/type,
-    # matched against the primary side. Backs SanctumWeb.CardLive.Pool.
-    read :browse do
-      argument :query, :string, allow_nil?: true
-      argument :aspect, :string, allow_nil?: true
-      argument :type, :string, allow_nil?: true
-
-      pagination offset?: true, default_limit: 24, countable: true, required?: false
-
-      prepare fn query, _context ->
-        require Ash.Query
-
-        search = Ash.Query.get_argument(query, :query)
-        aspect = Ash.Query.get_argument(query, :aspect)
-        type = Ash.Query.get_argument(query, :type)
-
-        query =
-          query
-          |> Ash.Query.load([:primary_side])
-          |> Ash.Query.filter(primary_side.type in ^@player_types)
-          |> Ash.Query.filter(primary_side.ownership in ^@player_ownerships)
-          |> Ash.Query.sort(base_code: :asc)
-
-        query =
-          if is_binary(search) and String.trim(search) != "" do
-            pattern = "%" <> String.trim(search) <> "%"
-            Ash.Query.filter(query, ilike(primary_side.name, ^pattern))
-          else
-            query
-          end
-
-        query =
-          cond do
-            not is_binary(aspect) or aspect in ["", "all"] ->
-              query
-
-            # "hero"/"basic" are ownership pools, not aspects.
-            aspect in ["hero", "basic"] ->
-              Ash.Query.filter(query, primary_side.ownership == ^to_enum(aspect))
-
-            true ->
-              Ash.Query.filter(query, primary_side.aspect == ^to_enum(aspect))
-          end
-
-        if is_binary(type) and type not in ["", "all"] do
-          Ash.Query.filter(query, primary_side.type == ^to_enum(type))
-        else
-          query
-        end
-      end
     end
 
     create :create do
@@ -203,13 +144,5 @@ defmodule Sanctum.Games.Card do
   identities do
     identity :unique_marvelcdb_code, [:code]
     identity :unique_marvelcdb_base_code, [:base_code]
-  end
-
-  # Safely convert an incoming filter string to an existing atom; unknown
-  # values fall back to a sentinel that matches nothing.
-  defp to_enum(value) do
-    String.to_existing_atom(value)
-  rescue
-    ArgumentError -> :__invalid__
   end
 end

--- a/lib/sanctum/games/card_side.ex
+++ b/lib/sanctum/games/card_side.ex
@@ -10,8 +10,71 @@ defmodule Sanctum.Games.CardSide do
     repo Sanctum.Repo
   end
 
+  # Ownership pools and types that belong in the player card pool (deck-buildable
+  # cards). Encounter/villain/identity/scheme faces are excluded. Hero signature
+  # cards are the `:hero` pool; pool cards are ordinary `:player` cards carrying
+  # the `:pool` aspect.
+  @player_ownerships [:player, :basic, :hero]
+  @player_types [:hero, :alter_ego, :ally, :event, :support, :upgrade, :resource]
+
   actions do
     defaults [:read, :destroy]
+
+    # Public card pool browsing: player card faces filtered by name/aspect/type.
+    # Each side is its own row so multi-sided cards surface every face, and
+    # searching an alternate title (e.g. "Peter Parker") ranks that face first.
+    # Backs SanctumWeb.CardLive.Pool.
+    read :browse do
+      argument :query, :string, allow_nil?: true
+      argument :aspect, :string, allow_nil?: true
+      argument :type, :string, allow_nil?: true
+
+      pagination offset?: true, default_limit: 24, countable: true, required?: false
+
+      prepare fn query, _context ->
+        require Ash.Query
+
+        search = Ash.Query.get_argument(query, :query)
+        aspect = Ash.Query.get_argument(query, :aspect)
+        type = Ash.Query.get_argument(query, :type)
+
+        query =
+          query
+          |> Ash.Query.load(:card)
+          |> Ash.Query.filter(type in ^@player_types)
+          |> Ash.Query.filter(ownership in ^@player_ownerships)
+          # Side `code` sorts by base_code across cards and primary-first within
+          # a card (the primary side always holds the smallest code).
+          |> Ash.Query.sort(code: :asc)
+
+        query =
+          if is_binary(search) and String.trim(search) != "" do
+            pattern = "%" <> String.trim(search) <> "%"
+            Ash.Query.filter(query, ilike(name, ^pattern))
+          else
+            query
+          end
+
+        query =
+          cond do
+            not is_binary(aspect) or aspect in ["", "all"] ->
+              query
+
+            # "hero"/"basic" are ownership pools, not aspects.
+            aspect in ["hero", "basic"] ->
+              Ash.Query.filter(query, ownership == ^to_enum(aspect))
+
+            true ->
+              Ash.Query.filter(query, aspect == ^to_enum(aspect))
+          end
+
+        if is_binary(type) and type not in ["", "all"] do
+          Ash.Query.filter(query, type == ^to_enum(type))
+        else
+          query
+        end
+      end
+    end
 
     create :create do
       primary? true
@@ -128,5 +191,13 @@ defmodule Sanctum.Games.CardSide do
   identities do
     identity :unique_card_side, [:card_id, :side_identifier]
     identity :unique_code, [:code]
+  end
+
+  # Safely convert an incoming filter string to an existing atom; unknown
+  # values fall back to a sentinel that matches nothing.
+  defp to_enum(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> :__invalid__
   end
 end

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -101,18 +101,18 @@ defmodule SanctumWeb.CardLive.Pool do
         class="grid grid-cols-[repeat(auto-fill,minmax(452px,1fr))] items-start gap-[18px]"
       >
         <div
-          :for={{dom_id, card} <- @streams.cards}
+          :for={{dom_id, side} <- @streams.cards}
           id={dom_id}
           class="mc-tile flex items-start gap-[13px] border-2 border-neutral bg-base-200 p-2 shadow-comic"
         >
           <div class="h-[210px] w-[150px] flex-none border-2 border-neutral shadow-comic-sm">
             <.mc_card
-              name={card.name}
-              cost={card.cost}
-              aspect={card.aspect_key}
-              image_url={card.image_url}
-              gradient_from={card.gradient_from}
-              gradient_to={card.gradient_to}
+              name={side.name}
+              cost={side.cost}
+              aspect={side.aspect_key}
+              image_url={side.image_url}
+              gradient_from={side.gradient_from}
+              gradient_to={side.gradient_to}
               size="md"
               show_cost={false}
             />
@@ -121,88 +121,88 @@ defmodule SanctumWeb.CardLive.Pool do
           <div class="flex min-w-0 flex-1 flex-col">
             <div class="h-12 flex items-start gap-3">
               <div
-                :if={card.show_cost}
+                :if={side.show_cost}
                 class="flex flex-none items-center justify-center rounded-full font-elektra-med text-4xl/normal"
               >
-                {card.cost}
+                {side.cost}
               </div>
               <div class="min-w-0 flex-1">
                 <div class={[
                   "font-ibm-mono text-[9px] uppercase tracking-[0.2em]",
-                  card.aspect_text_class
+                  side.aspect_text_class
                 ]}>
-                  {card.type_name} · {card.aspect_name}
+                  {side.type_name} · {side.aspect_name}
                 </div>
                 <div class="mt-[3px] font-anton text-[22px] uppercase leading-[0.94]">
-                  {card.name}
+                  {side.name}
                 </div>
               </div>
             </div>
 
-            <div :if={card.is_ally} class="flex items-start gap-2 w-full">
+            <div :if={side.is_ally} class="flex items-start gap-2 w-full">
               <div class="flex flex-grow items-start justify-start">
                 <.stat_badge
                   stat={:thw}
-                  value={card.thwart}
-                  consequential={card.thwart_consequential}
+                  value={side.thwart}
+                  consequential={side.thwart_consequential}
                   size={64}
                 />
                 <.stat_badge
                   stat={:atk}
-                  value={card.attack}
-                  consequential={card.attack_consequential}
+                  value={side.attack}
+                  consequential={side.attack_consequential}
                   size={64}
                 />
               </div>
               <div class="flex items-start justify-end">
-                <.health_badge value={card.health} size={52} />
+                <.health_badge value={side.health} size={52} />
               </div>
             </div>
 
-            <div :if={card.is_hero} class="flex items-start gap-2 w-full">
+            <div :if={side.is_hero} class="flex items-start gap-2 w-full">
               <div class="flex flex-grow items-start justify-start">
-                <.stat_badge stat={:thw} value={card.thwart} size={64} hero={true} />
-                <.stat_badge stat={:atk} value={card.attack} size={64} hero={true} />
-                <.stat_badge stat={:def} value={card.defense} size={64} hero={true} />
+                <.stat_badge stat={:thw} value={side.thwart} size={64} hero={true} />
+                <.stat_badge stat={:atk} value={side.attack} size={64} hero={true} />
+                <.stat_badge stat={:def} value={side.defense} size={64} hero={true} />
               </div>
               <div class="flex items-start justify-end">
-                <.health_badge value={card.health} size={52} />
+                <.health_badge value={side.health} size={52} />
               </div>
             </div>
 
             <div class="my-2 h-px bg-neutral"></div>
 
             <div
-              :if={card.traits != ""}
+              :if={side.traits != ""}
               class="flex justify-center mb-1 font-komika text-xs font-semibold uppercase tracking-[0.02em] text-base-content/75"
             >
-              {card.traits}
+              {side.traits}
             </div>
 
             <div class="text-center font-barlow text-[13.5px] leading-[1.5] text-base-content/85">
-              {Sanctum.CardText.to_html(card.text)}
+              {Sanctum.CardText.to_html(side.text)}
             </div>
 
             <div
-              :if={card.flavor}
+              :if={side.flavor}
               class="text-center font-barlow italic text-xs text-base-content/65 my-2"
             >
-              {Sanctum.CardText.to_html(card.flavor)}
+              {Sanctum.CardText.to_html(side.flavor)}
             </div>
 
             <div
-              :if={card.pips != [] or (card.is_hero and card.hand_size)}
+              :if={side.pips != [] or (side.is_hero and side.hand_size)}
               class="mt-2.5 flex items-center gap-1"
             >
               <span
-                :for={{color_class, glyph} <- card.pips}
+                :for={{color_class, glyph} <- side.pips}
                 class={["font-champions text-2xl leading-none", color_class]}
               >
                 {glyph}
               </span>
               <.hand_size_badge
-                :if={card.is_hero and card.hand_size}
-                value={card.hand_size}
+                :if={side.is_hero and side.hand_size}
+                value={side.hand_size}
                 class="ml-auto text-base-content/75"
               />
             </div>
@@ -287,7 +287,7 @@ defmodule SanctumWeb.CardLive.Pool do
     reset? = Keyword.get(opts, :reset, false)
 
     page =
-      Sanctum.Games.Card
+      Sanctum.Games.CardSide
       |> Ash.Query.for_read(:browse, filters(socket.assigns),
         actor: socket.assigns[:current_user]
       )
@@ -297,13 +297,15 @@ defmodule SanctumWeb.CardLive.Pool do
     |> assign(:offset, offset)
     |> assign(:end_of_timeline?, !page.more?)
     |> then(fn s -> if reset?, do: assign(s, :count, page.count), else: s end)
-    |> stream(:cards, Enum.map(page.results, &card_view(&1, socket.assigns.hero_colors)),
+    |> stream(
+      :cards,
+      Enum.map(page.results, &side_view(&1, socket.assigns.hero_colors)),
       reset: reset?
     )
   end
 
   defp count_cards(socket, extra_filters) do
-    Sanctum.Games.Card
+    Sanctum.Games.CardSide
     |> Ash.Query.for_read(:browse, Map.merge(%{aspect: "all", type: "all"}, extra_filters),
       actor: socket.assigns[:current_user]
     )
@@ -315,10 +317,12 @@ defmodule SanctumWeb.CardLive.Pool do
     %{query: assigns.query, aspect: assigns.aspect, type: assigns.type}
   end
 
-  # Builds the display map the tile renders from, derived from the primary side.
-  defp card_view(%{primary_side: side} = card, hero_colors) do
-    aspect_key = display_aspect(side)
+  # Builds the display map for a single card face. Each side is streamed as its
+  # own tile, so multi-sided cards appear as separate cards.
+  defp side_view(side, hero_colors) do
+    card = side.card
     {gradient_from, gradient_to} = hero_gradient(card.set, hero_colors)
+    aspect_key = display_aspect(side)
 
     resources =
       [
@@ -330,7 +334,7 @@ defmodule SanctumWeb.CardLive.Pool do
       |> Enum.flat_map(fn {res, n} -> List.duplicate(res, n || 0) end)
 
     %{
-      id: card.id,
+      id: side.id,
       name: side.name,
       type: side.type,
       cost: side.cost,


### PR DESCRIPTION
## Summary

The Card Pool rendered only each card's **primary side**, so multi-sided cards (hero/alter-ego identities, multi-face events) hid their other faces. Worse, searching an alternate title (e.g. "Peter Parker") returned the card with the *primary* side ("Spider-Man") ranked first — confusing, since the thing you searched for wasn't the result.

This flips the pool from **card-first** to **side-first**: each face is its own tile, and search matches the face you actually typed.

## Changes

- **New `:browse` read action on `CardSide`** (moved from `Card`). It queries faces directly:
  - filters `type`/`ownership` per side,
  - matches search against the side's *own* `name`,
  - sorts by side `code`, which groups a card's faces together with the primary side first (the primary side always holds the smallest code).
- **`CardLive.Pool`** now queries `CardSide`, loads `:card` for the hero gradient + set name, and maps each row to one tile — each side is its own card.
- **Removed** the now-unused `:browse` action and its helpers (`@player_types`, `@player_ownerships`, `to_enum/1`) from `Card`.

## Verification

- Confirmed per-side filtering yields the **same 1554 faces** as the old primary-side filter (zero dropped, zero added) — validated against the full catalog.
- Searching "peter" now returns **Peter Parker / Peter Quill / Peter Porker** directly, instead of Spider-Man first.
- Unfiltered view still groups a card's faces adjacently (Spider-Man immediately followed by Peter Parker), primary first.
- Aspect/type filters verified working per-side.
- `mix compile --warnings-as-errors`, `mix format --check`, full test suite (160 tests), Credo, and Sobelow all green.

> Note: the header count now reflects **faces** (1554), consistent with each tile being a card. Flag it if you'd prefer distinct-card counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)