### PR TITLE
feat(cards): support player side schemes as a distinct card type

### DIFF
--- a/lib/sanctum/games/card_side.ex
+++ b/lib/sanctum/games/card_side.ex
@@ -15,7 +15,16 @@ defmodule Sanctum.Games.CardSide do
   # cards are the `:hero` pool; pool cards are ordinary `:player` cards carrying
   # the `:pool` aspect.
   @player_ownerships [:player, :basic, :hero]
-  @player_types [:hero, :alter_ego, :ally, :event, :support, :upgrade, :resource]
+  @player_types [
+    :hero,
+    :alter_ego,
+    :ally,
+    :event,
+    :support,
+    :upgrade,
+    :resource,
+    :player_side_scheme
+  ]
 
   actions do
     defaults [:read, :destroy]

--- a/lib/sanctum/games/card_type.ex
+++ b/lib/sanctum/games/card_type.ex
@@ -14,6 +14,7 @@ defmodule Sanctum.Games.CardType do
       :main_scheme,
       :minion,
       :obligation,
+      :player_side_scheme,
       :resource,
       :side_scheme,
       :support,

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -832,6 +832,7 @@ defmodule Sanctum.MarvelCdb do
       "villain" -> :villain
       "main_scheme" -> :main_scheme
       "side_scheme" -> :side_scheme
+      "player_side_scheme" -> :player_side_scheme
       "ally" -> :ally
       "event" -> :event
       "resource" -> :resource

--- a/lib/sanctum_web/components/card.ex
+++ b/lib/sanctum_web/components/card.ex
@@ -55,6 +55,14 @@ defmodule SanctumWeb.Components.Card do
     "lg" => %{pad: 13, title: 20, sub: 13, cost: 34, res: 24, label: 11, badge: 26}
   }
 
+  # Card types printed in landscape orientation (wider than tall): schemes and
+  # environments. Villains and identities are portrait. Consumers use this to
+  # pick a landscape frame instead of the default portrait one.
+  @landscape_types [:main_scheme, :side_scheme, :player_side_scheme, :environment]
+
+  @doc "Whether a card type is printed in landscape orientation."
+  def landscape_type?(type), do: type in @landscape_types
+
   # Fallback gradient when a hero has no stored palette (non-hero sets,
   # un-synced heroes). Hero colors themselves come from MarvelCDB and are
   # passed in via gradient_from/gradient_to.

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -33,7 +33,8 @@ defmodule SanctumWeb.CardLive.Pool do
     {"event", "Event"},
     {"support", "Support"},
     {"upgrade", "Upgrade"},
-    {"resource", "Resource"}
+    {"resource", "Resource"},
+    {"player_side_scheme", "Side Scheme"}
   ]
 
   @impl true
@@ -105,9 +106,13 @@ defmodule SanctumWeb.CardLive.Pool do
           id={dom_id}
           class="mc-tile flex items-start gap-[13px] border-2 border-neutral bg-base-200 p-2 shadow-comic"
         >
-          <div class="h-[210px] w-[150px] flex-none border-2 border-neutral shadow-comic-sm">
+          <div class={[
+            "flex-none border-2 border-neutral shadow-comic-sm",
+            (side.is_landscape && "h-[150px] w-[210px]") || "h-[210px] w-[150px]"
+          ]}>
             <.mc_card
               name={side.name}
+              type={side.type}
               cost={side.cost}
               aspect={side.aspect_key}
               image_url={side.image_url}
@@ -179,7 +184,7 @@ defmodule SanctumWeb.CardLive.Pool do
               {side.traits}
             </div>
 
-            <div class="text-center font-barlow text-[13.5px] leading-[1.5] text-base-content/85">
+            <div class="font-barlow text-[13.5px] leading-[1.5] text-base-content/85">
               {Sanctum.CardText.to_html(side.text)}
             </div>
 
@@ -337,6 +342,7 @@ defmodule SanctumWeb.CardLive.Pool do
       id: side.id,
       name: side.name,
       type: side.type,
+      is_landscape: CardComponent.landscape_type?(side.type),
       cost: side.cost,
       show_cost: side.type != :resource and not is_nil(side.cost),
       aspect_key: aspect_key,

--- a/lib/sanctum_web/live/game_live/game_components.ex
+++ b/lib/sanctum_web/live/game_live/game_components.ex
@@ -3,9 +3,7 @@ defmodule SanctumWeb.GameLive.GameComponents do
 
   use SanctumWeb, :html
 
-  @landscape_types [
-    :main_scheme
-  ]
+  alias SanctumWeb.Components.Card
 
   attr :id, :string, required: true
   attr :game_card, Sanctum.Games.GameCard, required: true
@@ -107,7 +105,7 @@ defmodule SanctumWeb.GameLive.GameComponents do
       assign(assigns, :src, assigns.imgsrc || (active_side && active_side.image_url))
       |> assign(
         :aspect,
-        if active_side && active_side.type in @landscape_types do
+        if active_side && Card.landscape_type?(active_side.type) do
           "max-h-[71px] lg:max-h-[110px]"
         else
           "max-h-[100px] lg:max-h-[153px]"
@@ -172,7 +170,7 @@ defmodule SanctumWeb.GameLive.GameComponents do
       assign(assigns, :src, assigns.imgsrc || (active_side && active_side.image_url))
       |> assign(
         :aspect,
-        if active_side && active_side.type in @landscape_types do
+        if active_side && Card.landscape_type?(active_side.type) do
           "max-h-[71px] lg:max-h-[110px]"
         else
           "max-h-[100px] lg:max-h-[153px]"

--- a/lib/sanctum_web/live/game_live/show.ex
+++ b/lib/sanctum_web/live/game_live/show.ex
@@ -3,10 +3,6 @@ defmodule SanctumWeb.GameLive.Show do
 
   use SanctumWeb, :live_view
 
-  @landscape_types [
-    :main_scheme
-  ]
-
   require Logger
 
   import SanctumWeb.GameLive.GameComponents
@@ -14,6 +10,7 @@ defmodule SanctumWeb.GameLive.Show do
   alias Sanctum.Games.GamePlayer
   alias Sanctum.Games
   alias Sanctum.Games.Game
+  alias SanctumWeb.Components.Card
 
   on_mount {SanctumWeb.LiveUserAuth, :live_user_required}
 
@@ -23,8 +20,7 @@ defmodule SanctumWeb.GameLive.Show do
      |> assign(%{
        game_id: game_id,
        selected_card: nil,
-       show_player_form: false,
-       landscape_types: @landscape_types
+       show_player_form: false
      })
      |> stream(:facedown_encounters, [])
      |> stream(:hero_play_cards, [])
@@ -496,8 +492,8 @@ defmodule SanctumWeb.GameLive.Show do
             <% display_side = @selected_card.active_side %>
             <figure class={[
               "relative rounded-[4.5%] overflow-hidden",
-              display_side && display_side.type in @landscape_types && "h-[30dvh]",
-              (!display_side || display_side.type not in @landscape_types) && "h-[50dvh]"
+              display_side && Card.landscape_type?(display_side.type) && "h-[30dvh]",
+              (!display_side || !Card.landscape_type?(display_side.type)) && "h-[50dvh]"
             ]}>
               <img
                 class="h-full object-contain"


### PR DESCRIPTION
## Summary

Player side schemes (e.g. **Call for Backup**) had no real support in the card catalog. MarvelCDB types them as `player_side_scheme`, which `map_card_type/1` didn't handle — so they fell through to the `:resource` fallback and rendered as **Resources** in the Card Pool. Two display bugs compounded it:

- The pool's `mc_card` never received a `type`, so every tile's art overlay defaulted to **"EVENT"**.
- Landscape scheme scans were crammed into portrait thumbnails.

## Changes

- **Data model:** add `:player_side_scheme` to the `CardType` enum and map MarvelCDB's `player_side_scheme` type_code to it. A re-sync relabels the **28** affected faces (previously mistyped `:resource`).
- **Card Pool:** add the type to `@player_types`, add a **"Side Scheme"** type filter, and pass the real `type` through to `mc_card` so the art overlay reflects it (fixes the "EVENT"-on-every-tile bug too).
- **Landscape rendering:** render landscape card types (schemes, environments) with a landscape thumbnail beside the info panel. Introduce a shared `Card.landscape_type?/1` helper and use it in the pool and on the game board, replacing two duplicate local `@landscape_types` lists. Villains and identities stay portrait.

## Verification

- `mix ck` clean (format, Credo, Sobelow); compiles with `--warnings-as-errors`.
- Re-synced card data (`mix sanctum.sync_cards --skip-images`): Call for Backup now `type: player_side_scheme`.
- Drove the running app: the **Side Scheme** filter shows all **22** deck-buildable player side schemes, each with the correct `PLAYER SIDE SCHEME · <aspect>` header, cost bubble, and a correctly-oriented landscape thumbnail.

## Not included / follow-up

In-game *mechanics* for player side schemes (deck routing so they shuffle into the hero deck, a side-scheme play area, threat seeding on play) are intentionally out of scope here — this PR covers the card-type model and catalog/display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)