### PR TITLE
docs: rewrite CLAUDE.md to reflect current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,208 +1,144 @@
-# Marvel Champions Online
+# Marvel Champions Online (Sanctum)
 
-## Rules
+A web-based "smart table" for playing Marvel Champions: The Card Game online. It
+provides digital deck and game-state management — zones, tokens, card states —
+**without enforcing game rules**; players enforce the rules themselves. Built for
+personal use, designed with room to grow into multiplayer.
 
-- NEVER modify migrations manually. Migrations are managed using Ash and ash.codegen
+## Rules for Working in This Repo
 
-## Project Overview
-
-A web-based "smart table" application for playing Marvel Champions: The Card Game online. The app provides digital deck and game state management without enforcing game rules - players manage rules themselves. Built for personal use with potential for multiplayer expansion.
+- **NEVER modify migrations manually.** Migrations are managed by Ash — generate
+  them with `mix ash.codegen <name>`. The rare exception is framework-shipped
+  migrations (e.g. an `Oban.Migration.up(version: N)` when bumping Oban across a
+  schema version); those are added by hand deliberately.
+- **Ash is the source of truth for the data layer.** Resources define attributes,
+  relationships, actions, and policies. Don't hand-write Ecto schemas or raw SQL
+  migrations to model domain data — change the resource and run codegen.
+- **Single dark theme.** The UI is a pinned dark "comic-dossier" design. There is
+  no light/dark toggle — do not reintroduce daisyUI theme switching.
 
 ## Technical Stack
 
-- **Backend**: Elixir/Phoenix LiveView
-- **Frontend**: Phoenix LiveView + Custom JavaScript for interactions
-- **Database**: PostgreSQL (normalized schema, database as source of truth)
-- **Real-time**: Phoenix PubSub for state synchronization
-- **State Management**: GenServer processes per game + database persistence
+- **Backend**: Elixir/Phoenix, **Ash Framework** (resources, policies, actions)
+- **Frontend**: Phoenix LiveView + Tailwind + custom JS hooks; self-hosted fonts
+- **Database**: PostgreSQL (Neon in prod). The database is the authoritative source
+  of state — there is no in-memory game process.
+- **Real-time**: Phoenix PubSub
+- **Background jobs**: Oban + AshOban
+- **Deploy**: Fly.io (Depot builder), card images on a public Tigris S3 bucket
 
-## Architecture Principles
+## Architecture
 
-- **Database First**: PostgreSQL is the authoritative source of game state
-- **Process Per Game**: Each game runs in a supervised GenServer
-- **Smart Table Approach**: App manages cards/tokens/zones, players enforce rules
-- **Dual Mode Support**: Designed for both synchronous and asynchronous multiplayer
+State lives in **Postgres, modeled with Ash resources**, and is rendered/mutated
+directly by LiveViews. There is **no GenServer-per-game** — games are plain Ash
+resources. PubSub broadcasts changes to connected clients. The only long-lived
+process is `Sanctum.CardSync.Server` (drives MarvelCDB catalog sync).
 
-## Core Features (MVP)
+### Ash Domains
 
-### Game Management
-- Create/join games
-- Load deck compositions
-- Save/resume games
+| Domain | Purpose |
+|---|---|
+| `Sanctum.Accounts` | Users + tokens; auth (Google OAuth, magic link, password). `User.admin` boolean gates admin surfaces. |
+| `Sanctum.Games` | Cards, card sides, scenarios, and live game state. The core domain. |
+| `Sanctum.Decks` | Player decks imported from MarvelCDB; deck cards, aspects, uniqueness. |
+| `Sanctum.Heroes` | Hero catalog (incl. `meta.colors`-derived gradient palette). |
+| `Sanctum.Villains` | Villain catalog. |
 
-### Zone Management
-- Simplified zones: Identity, Player Area, Villain Area, Main Scheme, Side Schemes, Encounter
-- Card movement between zones
-- Proper visibility rules (hands private, play areas public)
+### Card Data Model
 
-### Card Interactions
-- Drag-and-drop card movement
-- Token/counter management (damage, threat, etc.)
-- Card state changes (exhaust, flip)
-- Card inspection (full text view)
+MarvelCDB's card representation is normalized into:
 
-### State Tracking
-- Player health
-- Villain health and stage
-- Scheme threat and progression
-- Turn/phase management
+- **`Card`** — the canonical card (`code`, `base_code`, `set`, `pack`,
+  `deck_limit`, `unique`, `permanent`, `is_multi_sided`). Has many `card_sides`,
+  a `primary_side`, many `alts`, and `many_to_many :decks`.
+- **`CardSide`** — one face of a card (identity/alter-ego, main-scheme A/B, etc.).
+  Holds the printed data: `name`/`subname`, `traits`, `type`, `ownership`,
+  `aspect`, `text`, `image_url`, and the game stats.
+- **`CardAlt`** — reprints. MarvelCDB's ~336 duplicate printings collapse into
+  `CardAlt` rows pointing at the canonical `Card`; deck slots resolve reprint
+  codes through the alt fallback.
 
-## Development Phases
+Key type/field conventions:
 
-### Phase 1: Foundation (Weeks 1-2)
-- Basic Phoenix app with LiveView
-- Core database schema and migrations
-- Card definition seeding (small subset)
-- Basic game creation and zone display
+- **`Stat`** (`Sanctum.Games.Stat`) — a **custom `Ash.Type`** (NOT an embedded
+  resource) stored as jsonb: `%{value, star, scaling}`. Used for `attack`,
+  `thwart`, `defense`, `health`, `recover`, and the threat stats. `cast_input`
+  accepts a bare number or a map, so sync/fixtures/forms all work.
+- **`CardOwnership`** enum (`:player | :basic | :pool | :hero | :encounter |
+  :campaign`) and a separate nullable **`CardAspect`** enum (4 aspects only) —
+  this replaced MarvelCDB's overloaded `faction_code`.
 
-### Phase 2: Core Mechanics (Weeks 3-4)
-- GenServer game processes
-- Basic card movement between zones
-- Simple deck loading into games
-- State persistence and recovery
+Live game state (`Game`, `GamePlayer`, `GameCard`, `GameVillain`,
+`GameEncounterDeck`, `Scenario`, `ModularSet`): `GameCard` is the single
+representation of an in-play card in any zone (main scheme, side scheme, player
+area, etc.) — a prior separate `GameScheme` was folded into it.
 
-### Phase 3: Enhanced Interactions (Weeks 5-6)
-- Drag-and-drop with JavaScript hooks
-- Token management UI
-- Card state changes (exhaust, flip)
-- Turn/phase progression
+## Subsystems
 
-### Phase 4: Polish & Multiplayer (Weeks 7-8)
-- Real-time multiplayer synchronization
-- Improved UI/UX
-- Game history and action log
-- Error handling and edge cases
+- **MarvelCDB sync** — `mix sanctum.sync_cards` / `mix sanctum.sync_decks` (dev)
+  and `Sanctum.Release.sync_cards()` (prod, data-only). Card sync also runs
+  interactively from the `/cards/sync` admin LiveView, backed by
+  `Sanctum.CardSync.Server` (GenServer + `Task` broadcasting throttled progress
+  over PubSub). Sync groups payload entries per `base_code` to resolve sides
+  (MarvelCDB's `linked_to_code` chains are incomplete). See `lib/sanctum/marvel_cdb.ex`.
+- **Card images** — mirrored once from MarvelCDB into a public Tigris bucket
+  (`sanctum-cards`); `card_sides.image_url` stores full bucket URLs. See
+  `lib/sanctum/card_images.ex`.
+- **Deck import** — decks come from MarvelCDB; Oban workers handle sync
+  (`decklist_sync_worker`) and uniqueness computation (`compute_uniqueness_worker`).
+- **Admin lockdown** — all `/cards/*` management routes live in an `:admin_routes`
+  live session behind a `:live_admin_required` on_mount hook (`User.admin`), plus
+  admin-only Card/CardSide mutation policies (reads are open). Bootstrap the first
+  admin with `Sanctum.Release.promote_admin(email)`. System writes (sync, seeds,
+  deck import) run with `authorize?: false`.
+- **Design system** — the pinned dark "comic-dossier" theme: self-hosted fonts,
+  design tokens, halftone/offset-shadow utilities, an app shell, and the `mc_card`
+  component. See `lib/sanctum_web/components`.
 
-## Key Technical Decisions
+### Routes (authenticated)
 
-- **State Authority**: Database is source of truth, GenServer caches for performance
-- **Persistence Strategy**: Write-through on actions, batch for performance later
-- **Process Lifecycle**: Aggressive hibernation, restart from DB on crash
-- **UI Boundaries**: Server handles game logic, client handles smooth interactions
-- **Multiplayer**: PubSub for real-time updates, async support via action queuing
-
-## Open Questions
-
-- Action batching strategy for performance
-- Token storage: JSONB vs separate table (starting with JSONB)
-- Mobile responsiveness requirements
-- Deck import/export formats
-- Asset management for card images
-
-## Success Criteria
-
-**MVP Success**: 
-- Solo play works end-to-end
-- Basic card interactions feel responsive
-- Games persist through server restarts
-- Simple deck building and loading
-
-**Full Success**:
-- Smooth multiplayer experience
-- Rich card interactions (drag-drop, context menus)
-- Comprehensive game state tracking
-- Robust error handling and recovery
-
-## Key Architecture Components
-
-### Ash Framework Integration
-- **Domain**: `Sanctum.Accounts` manages user resources and tokens
-- **Resources**: User and Token models with authentication strategies
-- **Authentication**: Magic link, password confirmation, and session-based auth
-- **Admin Interface**: AshAdmin available at `/admin` in development
-
-### Phoenix Application Structure
-- **Endpoint**: `SanctumWeb.Endpoint` with LiveView socket, static assets, and development tools
-- **Router**: Routes include authentication flows, game interface, and development dashboards
-- **Live Views**: Primary interface via `SanctumWeb.GameLive.Index`
-- **Authentication**: AshAuthentication.Phoenix integration with custom overrides
-
-### Background Jobs
-- **Oban**: Job processing with PostgreSQL backend
-- **AshOban**: Integration for Ash-based background jobs
-- **Queues**: Default queue with 10 workers
-
-### Security
-- **CSP**: Custom Content Security Policy plug with environment-specific policies
-- **Session**: Secure cookie-based sessions with CSRF protection
+- `/` — `GameLive.Index` (games list); `/games/new`, `/games/:id`
+- `/cards` — `CardLive.Pool` (card browser, public read)
+- `/decks`, `/decks/:id` — deck browser
+- `/guess` — `GuessLive.Play` (card-guessing mini-game)
+- `/cards/manage`, `/cards/new`, `/cards/sync`, `/cards/:id/edit` — **admin only**
 
 ## Development Commands
 
-### Setup and Dependencies
+The dev server runs on **port 4150** (not the usual Phoenix `4000`) — reach it at
+`http://localhost:4150`.
+
 ```bash
-mix setup                    # Full project setup: deps, database, assets
-mix deps.get                # Install dependencies only
-mix ash.setup               # Setup Ash resources and database
+mix setup                    # deps, database, assets
+iex -S mix phx.server        # dev server with console (http://localhost:4150)
+
+mix ash.codegen <name>       # generate migrations after resource changes
+mix ash.setup                # set up Ash resources + database
+mix ecto.reset               # drop + recreate database
+
+mix sanctum.sync_cards       # sync card catalog from MarvelCDB (dev)
+mix sanctum.sync_decks       # sync decks from MarvelCDB (dev)
+
+mix test                     # test suite (runs ash.setup quietly)
+mix ck                       # format + Credo + Sobelow (run before committing)
+mix format                   # format only
+mix dialyzer                 # static analysis (PLTs in priv/plts/)
 ```
 
-### Development Server
-```bash
-mix phx.server              # Start Phoenix server
-iex -S mix phx.server       # Start with IEx console
-```
+## Dev Dashboards
 
-### Database Operations
-```bash
-mix ecto.setup              # Create, migrate, and seed database
-mix ecto.reset              # Drop and recreate database
-mix ash.setup --quiet       # Quiet Ash setup for testing
-```
+- `/dev/dashboard` — Phoenix LiveDashboard
+- `/oban` — Oban job monitoring
+- `/admin` — AshAdmin resource management
+- `/dev/mailbox` — email preview
 
-### Assets and Frontend
-```bash
-mix assets.setup            # Install Tailwind and esbuild
-mix assets.build            # Build CSS and JS assets
-mix assets.deploy           # Build and minify for production
-```
+## Notes
 
-### Testing and Quality
-```bash
-mix test                    # Run test suite (includes ash.setup)
-mix ck                      # Run formatter, Credo, and Sobelow checks
-mix credo suggest --min-priority=normal  # Code quality analysis
-mix sobelow --config --exit # Security analysis
-mix format                  # Format code
-```
-
-### Development Tools
-```bash
-mix dialyzer                # Static analysis (PLT files in priv/plts/)
-mix coveralls               # Test coverage reports
-```
-
-## Development Environment
-
-### Docker Support
-- PostgreSQL database via docker-compose
-- Adminer database interface on port 8080
-- Production Dockerfile with multi-stage build
-
-### Development Dashboard Access
-- **Live Dashboard**: `/dev/dashboard` - Phoenix metrics and debugging
-- **Oban Dashboard**: `/oban` - Background job monitoring  
-- **Ash Admin**: `/admin` - Resource management interface
-- **Mailbox Preview**: `/dev/mailbox` - Email preview in development
-
-### Asset Pipeline
-- **Tailwind**: CSS framework with custom fonts (Metropolis, Exo2, Komika, Elektra)
-- **esbuild**: JavaScript bundling with ES2022 target
-- **Static Assets**: Custom fonts and images in `priv/static/`
-
-## Configuration Notes
-
-### Environment-Specific Behavior
-- **Development**: Includes live reload, code reloader, and development dashboards
-- **Production**: Optimized CSP, minified assets, and secure headers
-- **Test**: Ash setup runs quietly, Ecto sandbox mode
-
-### Authentication Flow
-- Magic link email authentication via Swoosh mailer
-- Session-based authentication with secure cookies
-- User registration, password reset, and confirmation workflows
-- API authentication via bearer tokens
-
-### Code Quality Tools
-- **Credo**: Configured with low priority for TODOs and module docs
-- **Sobelow**: Security analysis with configuration
-- **ExCoveralls**: Test coverage with multiple output formats
-- **Dialyzer**: Type analysis with custom PLT locations
+- **Detailed decision history** (entity redesigns, card model v2, image sourcing,
+  admin lockdown, design migration, CI/deploy fixes) lives in the Obsidian vault
+  under `01 - Projects/Personal/Sanctum/` — consult it before large changes rather
+  than duplicating that context here.
+- Auth: Google OAuth registration is **open** (any Google account can sign in), so
+  authentication ≠ trust — the `User.admin` flag is what gates privileged surfaces.
+- `docs/card_fields.md` and `docs/card_model_v2.md` document the card data model
+  and its most recent redesign.


### PR DESCRIPTION
## Why

The original `CLAUDE.md` was the Phase-1 planning proposal and had drifted substantially from the codebase. Most notably it asserted a **GenServer-per-game** architecture that was never built (the only long-lived process is `CardSync.Server`), described only the `Accounts` domain, and framed already-resolved decisions as open questions.

## What changed

Rewrote it from a "here's the plan" proposal into a "here's the system" onboarding doc:

- **Fixed the architecture section** — state lives in Postgres via Ash resources rendered by LiveView; there is no game process. The one real GenServer (`CardSync.Server`) is named as such.
- **Documented all five Ash domains** (Accounts, Games, Decks, Heroes, Villains) and the `Card`/`CardSide`/`CardAlt` data model — including the `Stat` custom Ash type (with the "not an embedded resource" gotcha) and the `CardOwnership`/`CardAspect` split.
- **Added the real subsystems** — MarvelCDB sync, Tigris card images, admin lockdown (`User.admin` + `promote_admin`), deck Oban workers, and the pinned dark comic-dossier design system.
- **Dropped stale content** — Development Phases (Weeks 1–8), Success Criteria, and Open Questions.
- **Added guardrails for agents** — `ash.codegen`-only migrations, no hand-written Ecto schemas/SQL for domain data, and no reintroducing a light/dark toggle.
- Points at the Obsidian vault and `docs/` for deep decision history rather than duplicating it.

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)