### PR TITLE
feat(ui): make card pool, deck browser & deck detail mobile-friendly

### DIFF
--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -95,7 +95,7 @@ defmodule SanctumWeb.CoreComponents do
 
   def button(%{rest: rest} = assigns) do
     base =
-      "inline-flex items-center justify-center gap-2 cursor-pointer font-barlow-condensed font-extrabold uppercase tracking-[0.08em] text-[13px] transition-all active:translate-x-px active:translate-y-px disabled:opacity-40 disabled:pointer-events-none"
+      "inline-flex min-h-[44px] items-center justify-center gap-2 cursor-pointer font-barlow-condensed font-extrabold uppercase tracking-[0.08em] text-[13px] transition-all active:translate-x-px active:translate-y-px disabled:opacity-40 disabled:pointer-events-none sm:min-h-0"
 
     variants = %{
       "primary" =>
@@ -103,7 +103,7 @@ defmodule SanctumWeb.CoreComponents do
       "ghost" =>
         "px-4 py-2.5 bg-base-300 text-base-content border-2 border-neutral shadow-comic-sm hover:text-white",
       "icon" =>
-        "size-10 rounded-full bg-base-300 text-base-content border-2 border-neutral hover:text-white",
+        "size-11 rounded-full bg-base-300 text-base-content border-2 border-neutral hover:text-white sm:size-10",
       nil =>
         "px-4 py-2.5 bg-base-300 text-base-content border-2 border-neutral shadow-comic-sm hover:text-white"
     }
@@ -153,8 +153,8 @@ defmodule SanctumWeb.CoreComponents do
     ~H"""
     <button
       class={[
-        "inline-flex items-center gap-1.5 cursor-pointer border-2 px-3 py-1.5",
-        "font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.07em] transition-colors",
+        "inline-flex min-h-[44px] items-center gap-1.5 cursor-pointer border-2 px-3.5 py-1.5 sm:min-h-0 sm:px-3",
+        "font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.07em] transition-colors sm:text-[12px]",
         (@active && "border-transparent bg-primary text-primary-content") ||
           "border-neutral bg-base-300 text-base-content hover:text-white",
         @class

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -47,31 +47,110 @@ defmodule SanctumWeb.Layouts do
 
       <!-- sticky top bar -->
       <header class="sticky top-0 z-30 border-b-[3px] border-neutral bg-base-100/90 backdrop-blur">
-        <div class="mx-auto flex max-w-[1480px] items-center gap-6 px-6 py-3.5">
-          <a href="/" class="font-bangers text-[34px] leading-none tracking-wide text-primary">
+        <div class="mx-auto flex max-w-[1480px] items-center gap-3 px-4 py-3.5 sm:gap-6 sm:px-6">
+          <a
+            href="/"
+            class="font-bangers text-[28px] leading-none tracking-wide text-primary sm:text-[34px]"
+          >
             SANCTUM
           </a>
-          <nav class="flex h-[34px] items-end gap-5">
+          <nav class="hidden h-[34px] items-end gap-5 sm:flex">
             <.nav_tab navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.nav_tab>
             <.nav_tab navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.nav_tab>
             <.nav_tab navigate={~p"/guess"} active={@active_tab == :guess}>Flavor Town</.nav_tab>
           </nav>
-          <div class="ml-auto flex items-center gap-4">
+          <div class="ml-auto hidden items-center gap-4 sm:flex">
             <span class="font-ibm-mono text-xs text-base-content/40">
               v{Application.spec(:sanctum, :vsn)}
             </span>
             <.button :if={!@current_user} variant="primary" navigate={~p"/sign-in"}>Sign In</.button>
           </div>
+
+          <!-- hamburger (mobile only) -->
+          <button
+            type="button"
+            class="ml-auto flex size-11 items-center justify-center border-2 border-neutral bg-base-300 text-base-content sm:hidden"
+            phx-click={open_drawer()}
+            aria-label="Open menu"
+          >
+            <.icon name="hero-bars-3" class="size-6" />
+          </button>
         </div>
       </header>
 
-      <main class="relative z-10 mx-auto max-w-[1480px] px-6 pb-24 pt-7">
+      <!-- mobile slideout drawer -->
+      <div
+        id="mobile-nav-overlay"
+        class="fixed inset-0 z-40 hidden bg-black/70 sm:hidden"
+        phx-click={close_drawer()}
+        aria-hidden="true"
+      >
+      </div>
+      <div
+        id="mobile-nav-panel"
+        class="fixed inset-y-0 left-0 z-50 hidden w-[80%] max-w-[300px] translate-x-0 flex-col border-r-[3px] border-neutral bg-base-100 px-6 py-5 shadow-comic-lg sm:hidden"
+      >
+        <div class="flex items-center justify-between border-b-2 border-neutral pb-4">
+          <span class="font-bangers text-[28px] leading-none tracking-wide text-primary">
+            SANCTUM
+          </span>
+          <button
+            type="button"
+            class="flex size-11 items-center justify-center border-2 border-neutral bg-base-300 text-base-content"
+            phx-click={close_drawer()}
+            aria-label="Close menu"
+          >
+            <.icon name="hero-x-mark" class="size-6" />
+          </button>
+        </div>
+        <nav class="mt-6 flex flex-col gap-1">
+          <.drawer_link navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.drawer_link>
+          <.drawer_link navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.drawer_link>
+          <.drawer_link navigate={~p"/guess"} active={@active_tab == :guess}>Flavor Town</.drawer_link>
+        </nav>
+        <div class="mt-auto flex items-center justify-between border-t-2 border-neutral pt-4">
+          <span class="font-ibm-mono text-xs text-base-content/40">
+            v{Application.spec(:sanctum, :vsn)}
+          </span>
+          <.button :if={!@current_user} variant="primary" navigate={~p"/sign-in"}>Sign In</.button>
+        </div>
+      </div>
+
+      <main class="relative z-10 mx-auto max-w-[1480px] px-4 pb-24 pt-7 sm:px-6">
         {render_slot(@inner_block)}
       </main>
     </div>
 
     <.flash_group flash={@flash} />
     """
+  end
+
+  # Slide the mobile drawer + overlay in from the left.
+  defp open_drawer(js \\ %JS{}) do
+    js
+    |> JS.show(
+      to: "#mobile-nav-overlay",
+      transition: {"transition-opacity ease-out duration-200", "opacity-0", "opacity-100"}
+    )
+    |> JS.show(
+      to: "#mobile-nav-panel",
+      display: "flex",
+      transition:
+        {"transition-transform ease-out duration-200", "-translate-x-full", "translate-x-0"}
+    )
+  end
+
+  defp close_drawer(js \\ %JS{}) do
+    js
+    |> JS.hide(
+      to: "#mobile-nav-overlay",
+      transition: {"transition-opacity ease-in duration-150", "opacity-100", "opacity-0"}
+    )
+    |> JS.hide(
+      to: "#mobile-nav-panel",
+      transition:
+        {"transition-transform ease-in duration-150", "translate-x-0", "-translate-x-full"}
+    )
   end
 
   attr :active, :boolean, default: false
@@ -85,6 +164,26 @@ defmodule SanctumWeb.Layouts do
         "pb-[3px] text-[13px] font-bold uppercase tracking-[0.13em] transition-colors",
         (@active && "border-b-[3px] border-primary text-primary") ||
           "text-base-content/55 hover:text-white"
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
+  attr :active, :boolean, default: false
+  attr :rest, :global, include: ~w(href navigate patch)
+  slot :inner_block, required: true
+
+  # Block-level nav link used inside the mobile slideout drawer.
+  defp drawer_link(assigns) do
+    ~H"""
+    <.link
+      class={[
+        "border-2 px-4 py-3 font-barlow-condensed text-[16px] font-bold uppercase tracking-[0.1em] transition-colors",
+        (@active && "border-transparent bg-primary text-primary-content") ||
+          "border-neutral bg-base-300 text-base-content hover:text-white"
       ]}
       {@rest}
     >

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -61,7 +61,7 @@ defmodule SanctumWeb.CardLive.Pool do
             phx-debounce="200"
             autocomplete="off"
             placeholder="Search cards by name…"
-            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-[15px] text-base-content outline-none focus:border-primary"
+            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-base text-base-content outline-none focus:border-primary sm:text-[15px]"
           />
         </form>
         <div class="whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
@@ -99,15 +99,15 @@ defmodule SanctumWeb.CardLive.Pool do
         id="card-pool"
         phx-update="stream"
         phx-viewport-bottom={!@end_of_timeline? && "next-page"}
-        class="grid grid-cols-[repeat(auto-fill,minmax(452px,1fr))] items-start gap-[18px]"
+        class="grid grid-cols-1 items-start gap-[18px] sm:grid-cols-[repeat(auto-fill,minmax(452px,1fr))]"
       >
         <div
           :for={{dom_id, side} <- @streams.cards}
           id={dom_id}
-          class="mc-tile flex items-start gap-[13px] border-2 border-neutral bg-base-200 p-2 shadow-comic"
+          class="mc-tile flex flex-col items-start gap-[13px] border-2 border-neutral bg-base-200 p-2 shadow-comic sm:flex-row"
         >
           <div class={[
-            "flex-none border-2 border-neutral shadow-comic-sm",
+            "flex-none self-center border-2 border-neutral shadow-comic-sm sm:self-start",
             (side.is_landscape && "h-[150px] w-[210px]") || "h-[210px] w-[150px]"
           ]}>
             <.mc_card

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -48,7 +48,7 @@ defmodule SanctumWeb.DeckLive.Index do
             phx-debounce="200"
             autocomplete="off"
             placeholder="Search decks or heroes…"
-            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-[15px] text-base-content outline-none focus:border-primary"
+            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-base text-base-content outline-none focus:border-primary sm:text-[15px]"
           />
         </form>
         <div class="whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
@@ -68,10 +68,14 @@ defmodule SanctumWeb.DeckLive.Index do
             {label}
           </.filter_pill>
         </div>
-        <form id="deck-hero-filter" phx-change="filter_hero" class="ml-auto min-w-[200px]">
+        <form
+          id="deck-hero-filter"
+          phx-change="filter_hero"
+          class="ml-auto min-w-[180px] flex-1 sm:min-w-[200px] sm:flex-none"
+        >
           <select
             name="hero_id"
-            class="w-full border-[2.5px] border-line bg-black px-3 py-2 font-barlow-condensed text-[14px] font-bold uppercase tracking-[0.04em] text-base-content outline-none focus:border-primary"
+            class="min-h-[44px] w-full border-[2.5px] border-line bg-black px-3 py-2 font-barlow-condensed text-base font-bold uppercase tracking-[0.04em] text-base-content outline-none focus:border-primary sm:min-h-0 sm:text-[14px]"
           >
             <option value="all" selected={@hero_id == "all"}>All heroes</option>
             <option :for={{id, name} <- @hero_options} value={id} selected={@hero_id == id}>
@@ -99,13 +103,13 @@ defmodule SanctumWeb.DeckLive.Index do
         id="deck-feed"
         phx-update="stream"
         phx-viewport-bottom={!@end_of_timeline? && "next-page"}
-        class="grid grid-cols-[repeat(auto-fill,minmax(520px,1fr))] items-start gap-3"
+        class="grid grid-cols-1 items-start gap-3 sm:grid-cols-[repeat(auto-fill,minmax(520px,1fr))]"
       >
         <.link
           :for={{dom_id, deck} <- @streams.decks}
           id={dom_id}
           navigate={~p"/decks/#{deck.id}"}
-          class="mc-tile flex items-stretch gap-4 border-2 border-neutral bg-base-200 p-3.5 shadow-comic"
+          class="mc-tile flex items-stretch gap-3 border-2 border-neutral bg-base-200 p-3 shadow-comic sm:gap-4 sm:p-3.5"
         >
           <div class="h-[151px] w-[108px] flex-none border-2 border-neutral shadow-comic-sm">
             <.mc_card
@@ -119,52 +123,56 @@ defmodule SanctumWeb.DeckLive.Index do
             />
           </div>
 
-          <div class="flex min-w-0 flex-1 flex-col">
-            <div class="flex flex-wrap items-center gap-1.5">
-              <span
-                :for={a <- deck.aspects}
-                class={[
-                  "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
-                  a.text,
-                  a.border
-                ]}
+          <div class="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-stretch sm:gap-4">
+            <div class="flex min-w-0 flex-1 flex-col">
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span
+                  :for={a <- deck.aspects}
+                  class={[
+                    "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
+                    a.text,
+                    a.border
+                  ]}
+                >
+                  {a.label}
+                </span>
+                <span class="border-2 border-neutral bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em] text-base-content/70">
+                  {deck.source_label}
+                </span>
+              </div>
+
+              <div class="mt-2 break-words font-anton text-[26px] uppercase leading-[0.95]">
+                {deck.title}
+              </div>
+
+              <div
+                :if={deck.tagline}
+                class="mt-1.5 break-words font-barlow text-[14px] leading-[1.42] text-base-content/60"
               >
-                {a.label}
-              </span>
-              <span class="border-2 border-neutral bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em] text-base-content/70">
-                {deck.source_label}
-              </span>
-            </div>
+                {deck.tagline}
+              </div>
 
-            <div class="mt-2 font-anton text-[26px] uppercase leading-[0.95]">{deck.title}</div>
-
-            <div
-              :if={deck.tagline}
-              class="mt-1.5 font-barlow text-[14px] leading-[1.42] text-base-content/60"
-            >
-              {deck.tagline}
-            </div>
-
-            <div :if={deck.author} class="mt-auto flex items-center gap-2 pt-3">
-              <span class="flex size-[26px] items-center justify-center rounded-full border-2 border-neutral bg-primary font-bangers text-sm text-primary-content">
-                {deck.author_initial}
-              </span>
-              <span class="font-barlow-condensed text-[13px] font-bold text-primary">
-                {deck.author}
-              </span>
-            </div>
-          </div>
-
-          <div class="flex w-[120px] flex-none flex-col justify-center gap-2 border-l-2 border-neutral pl-4">
-            <.uniqueness_meter percentile={deck.uniqueness} />
-            <div>
-              <div class="font-anton text-[26px] leading-none">{deck.total_card_count}</div>
-              <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
-                Cards
+              <div :if={deck.author} class="mt-auto flex items-center gap-2 pt-3">
+                <span class="flex size-[26px] items-center justify-center rounded-full border-2 border-neutral bg-primary font-bangers text-sm text-primary-content">
+                  {deck.author_initial}
+                </span>
+                <span class="font-barlow-condensed text-[13px] font-bold text-primary">
+                  {deck.author}
+                </span>
               </div>
             </div>
-            <div class="font-ibm-mono text-[11px] leading-[1.5] text-base-content/40">
-              {deck.updated}
+
+            <div class="flex flex-none items-center gap-4 border-t-2 border-neutral pt-3 sm:w-[120px] sm:flex-col sm:items-start sm:justify-center sm:gap-2 sm:border-l-2 sm:border-t-0 sm:pl-4 sm:pt-0">
+              <.uniqueness_meter percentile={deck.uniqueness} class="w-[110px] sm:w-full" />
+              <div>
+                <div class="font-anton text-[26px] leading-none">{deck.total_card_count}</div>
+                <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                  Cards
+                </div>
+              </div>
+              <div class="ml-auto font-ibm-mono text-[11px] leading-[1.5] text-base-content/40 sm:ml-0">
+                {deck.updated}
+              </div>
             </div>
           </div>
         </.link>

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -54,7 +54,7 @@ defmodule SanctumWeb.DeckLive.Show do
             <div class="font-ibm-mono text-[11px] uppercase tracking-[0.25em] text-primary">
               {@cover.source_label} · {@cover.hero_name}
             </div>
-            <h1 class="mt-1.5 font-anton text-[46px] uppercase leading-[0.88] [text-wrap:balance]">
+            <h1 class="mt-1.5 font-anton text-[34px] uppercase leading-[0.9] [text-wrap:balance] sm:text-[46px] sm:leading-[0.88]">
               {@deck.title}
             </h1>
 
@@ -71,7 +71,7 @@ defmodule SanctumWeb.DeckLive.Show do
               </span>
             </div>
 
-            <div class="mt-4 flex items-end gap-6">
+            <div class="mt-4 flex flex-wrap items-end gap-x-6 gap-y-3">
               <div>
                 <div class="font-anton text-[30px] leading-none">{@cover.total_cards}</div>
                 <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">


### PR DESCRIPTION
## Summary

The browse surfaces were built for desktop and broke on phones — horizontal scroll on every page, form fields that trigger iOS focus auto-zoom, and touch targets well under the accessibility benchmark. This makes all three responsive at the `sm` breakpoint while leaving the desktop comic-dossier layout untouched.

### What was wrong (measured at 390px)
- **Horizontal overflow:** the Card Pool grid (`minmax(452px,…)`) and Deck feed (`minmax(520px,…)`) forced tracks wider than the viewport; a deck with a long MarvelCDB URL in its description also blew out its tile.
- **Auto-zoom:** search inputs / hero `<select>` rendered below 16px, so iOS zooms on focus.
- **Small tap targets:** filter pills 34px, hamburger/buttons 36px — under the 44px Apple HIG / WCAG 2.5.5 (AAA) benchmark (WCAG 2.5.8 AA floor is 24px).

### Changes
- **App shell:** top-nav collapses into a hamburger + left slideout drawer (with dimmed overlay) below `sm`; trimmed page/header padding on mobile.
- **Card Pool:** single-column grid on mobile; each tile stacks (art on top, details below) so the fixed-size stat badges get full width instead of clipping; 16px search input.
- **Deck Browser:** single-column feed; the 3-column tile reflows so the stats rail drops below the content as a row on mobile; `break-words` on title/tagline; 16px search + hero select.
- **Deck Detail:** cover meta row wraps; title scales down on mobile.
- **Shared components:** filter pills, buttons, and the hero select get a 44px min tap height on mobile, reverting to compact density at `sm`+.

### Verification
Driven with playwright at **320px** and **390px** (no horizontal scroll on any page; all controls ≥44px) and **1280px** (desktop layout unchanged). `mix ck` clean (Credo + Sobelow), format check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)