### PR TITLE
feat(ui): consistent page titles with Sanctum suffix

### DIFF
--- a/lib/sanctum_web/components/layouts/root.html.heex
+++ b/lib/sanctum_web/components/layouts/root.html.heex
@@ -14,7 +14,7 @@
 
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/images/icon-192.svg" />
-    <.live_title default="Sanctum" suffix=" · Phoenix Framework">
+    <.live_title default="Sanctum" suffix=" · Sanctum">
       {assigns[:page_title]}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />

--- a/lib/sanctum_web/live/card_live/index.ex
+++ b/lib/sanctum_web/live/card_live/index.ex
@@ -94,7 +94,7 @@ defmodule SanctumWeb.CardLive.Index do
   def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign(:page_title, "Listing Cards")
+     |> assign(:page_title, "Manage Cards")
      |> assign(:offset, 0)
      |> assign(:end_of_timeline?, false)
      |> paginate_cards(0)}

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -222,7 +222,7 @@ defmodule SanctumWeb.CardLive.Show do
 
     {:ok,
      socket
-     |> assign(:page_title, "Card - #{title}")
+     |> assign(:page_title, title)
      |> assign(:card, card)
      |> assign(:title, title)
      |> assign(:sides, sides)

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -259,7 +259,7 @@ defmodule SanctumWeb.DeckLive.Show do
 
     {:ok,
      socket
-     |> assign(:page_title, "Deck - #{deck.title}")
+     |> assign(:page_title, deck.title)
      |> assign(:deck, deck)
      |> assign(:cover, cover_view(deck, hero_gradient))
      |> assign(:groups, groups)

--- a/lib/sanctum_web/live/game_live/index.ex
+++ b/lib/sanctum_web/live/game_live/index.ex
@@ -8,7 +8,7 @@ defmodule SanctumWeb.GameLive.Index do
   alias Sanctum.Games
 
   def mount(_params, _session, socket) do
-    {:ok, socket |> assign_games()}
+    {:ok, socket |> assign(:page_title, "Games") |> assign_games()}
   end
 
   def handle_event("new-game", _params, socket) do

--- a/lib/sanctum_web/live/game_live/new.ex
+++ b/lib/sanctum_web/live/game_live/new.ex
@@ -10,6 +10,7 @@ defmodule SanctumWeb.GameLive.New do
   def mount(_params, _session, socket) do
     {:ok,
      socket
+     |> assign(:page_title, "New Game")
      |> assign_scenarios()
      |> assign_form()}
   end

--- a/lib/sanctum_web/live/game_live/show.ex
+++ b/lib/sanctum_web/live/game_live/show.ex
@@ -352,6 +352,7 @@ defmodule SanctumWeb.GameLive.Show do
        when is_binary(game_id) do
     case Games.get_game(game_id,
            load: [
+             :scenario,
              game_villain: [:active_side, card: [:primary_side]],
              main_scheme_cards: [active_side: [], card: [:primary_side]],
              encounter_deck: [
@@ -363,7 +364,9 @@ defmodule SanctumWeb.GameLive.Show do
            actor: current_user
          ) do
       {:ok, %Game{} = game} ->
-        assign(socket, :game, game)
+        socket
+        |> assign(:game, game)
+        |> assign(:page_title, game.scenario.name)
 
       {:error, err} ->
         Logger.warning(


### PR DESCRIPTION
## Summary

Makes the browser/document title consistent across the app: the suffix is now `· Sanctum` (was `· Phoenix Framework`), and per-page titles read sensibly everywhere.

## Changes

| Route | Before | After |
|---|---|---|
| `/` (games list) | *(none → bare "Sanctum")* | **Games** |
| `/games/new` | *(none)* | **New Game** |
| `/games/:id` | *(none)* | **scenario name** |
| `/decks/:id` | `Deck - {title}` | **{deck title}** |
| `/cards/:id` | `Card - {title}` | **{card title}** |
| `/cards/manage` | `Listing Cards` | **Manage Cards** |

Titles already clean were left as-is (`Card Pool`, `Browse Decks`, `Card Sync`, `New Card`/`Edit Card`, `Flavor Town`, `Stat Badges`).

`GameLive.Show` now loads the `:scenario` relationship so the tab can be titled by scenario name.

## Testing

- `mix ck` (format + Credo + Sobelow) passes clean
- `mix compile --warnings-as-errors` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)