### PR TITLE
feat(flavor-town): redesign the guessing game for mobile & rename route to /flavor-town

### DIFF
--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -57,7 +57,9 @@ defmodule SanctumWeb.Layouts do
           <nav class="hidden h-[34px] items-end gap-5 sm:flex">
             <.nav_tab navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.nav_tab>
             <.nav_tab navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.nav_tab>
-            <.nav_tab navigate={~p"/guess"} active={@active_tab == :guess}>Flavor Town</.nav_tab>
+            <.nav_tab navigate={~p"/flavor-town"} active={@active_tab == :guess}>
+              Flavor Town
+            </.nav_tab>
           </nav>
           <div class="ml-auto hidden items-center gap-4 sm:flex">
             <span class="font-ibm-mono text-xs text-base-content/40">
@@ -106,7 +108,7 @@ defmodule SanctumWeb.Layouts do
         <nav class="mt-6 flex flex-col gap-1">
           <.drawer_link navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.drawer_link>
           <.drawer_link navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.drawer_link>
-          <.drawer_link navigate={~p"/guess"} active={@active_tab == :guess}>Flavor Town</.drawer_link>
+          <.drawer_link navigate={~p"/flavor-town"} active={@active_tab == :guess}>Flavor Town</.drawer_link>
         </nav>
         <div class="mt-auto flex items-center justify-between border-t-2 border-neutral pt-4">
           <span class="font-ibm-mono text-xs text-base-content/40">

--- a/lib/sanctum_web/live/guess_live/play.ex
+++ b/lib/sanctum_web/live/guess_live/play.ex
@@ -30,75 +30,102 @@ defmodule SanctumWeb.GuessLive.Play do
         </div>
       </.panel>
 
-      <div :if={@status != :empty} class="mx-auto max-w-[720px]">
-        <!-- flavor prompt -->
-        <.panel class="px-6 py-8">
-          <div class="font-ibm-mono text-[10px] uppercase tracking-[0.25em] text-base-content/45">
+      <div
+        :if={@status != :empty}
+        class={["mx-auto max-w-[720px]", @status == :playing && "pb-36 sm:pb-0"]}
+      >
+        <!-- flavor prompt — the hero of the round -->
+        <.panel class="relative overflow-hidden px-5 py-9 sm:px-6 sm:py-8">
+          <div
+            class="pointer-events-none absolute -left-1 -top-5 font-bangers text-[90px] leading-none text-primary/15 select-none sm:text-[70px]"
+            aria-hidden="true"
+          >
+            “
+          </div>
+          <div class="relative font-ibm-mono text-[10px] uppercase tracking-[0.25em] text-base-content/45">
             Flavor text
           </div>
-          <blockquote class="mt-3 font-barlow text-[20px] italic leading-[1.5] text-base-content/90">
+          <blockquote class="relative mt-3 font-barlow text-[23px] italic leading-[1.42] text-base-content/90 [text-wrap:balance] sm:text-[20px] sm:leading-[1.5]">
             “{@card.primary_side.flavor}”
           </blockquote>
         </.panel>
 
-        <!-- guess form -->
-        <form :if={@status == :playing} phx-submit="guess" class="mt-5 flex gap-2.5">
-          <input
-            type="text"
-            name="guess"
-            value=""
-            autocomplete="off"
-            phx-mounted={JS.focus()}
-            placeholder="Name the card…"
-            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 font-barlow text-[15px] text-base-content outline-none focus:border-primary placeholder:text-base-content/40"
-          />
-          <.button variant="primary" type="submit">Guess</.button>
-        </form>
-
-        <div :if={@status == :playing} class="mt-2.5 text-right">
-          <button
-            type="button"
-            phx-click="give-up"
-            class="font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/40 hover:text-base-content/70"
-          >
-            Give up
-          </button>
+        <!-- hint progress HUD (persistent during play) -->
+        <div :if={@status == :playing and @hints != []} class="mt-4 flex items-center gap-2.5">
+          <span class="font-ibm-mono text-[10px] uppercase tracking-[0.25em] text-base-content/45">
+            Hints
+          </span>
+          <div class="flex items-center gap-1.5">
+            <span
+              :for={n <- 1..length(@hints)}
+              class={[
+                "size-[11px] border-2 border-neutral",
+                (n <= @revealed_count && "bg-primary") || "bg-base-300"
+              ]}
+            />
+          </div>
+          <span class={[
+            "ml-auto font-ibm-mono text-[10px] uppercase tracking-[0.15em]",
+            (@revealed_count >= length(@hints) && "text-error") || "text-base-content/45"
+          ]}>
+            {hint_hud_label(@hints, @revealed_count)}
+          </span>
         </div>
 
         <!-- revealed hints -->
-        <div :if={@revealed_count > 0} class="mt-6">
-          <div class="font-ibm-mono text-[10px] uppercase tracking-[0.25em] text-base-content/45">
-            Hints
-          </div>
-          <ol class="mt-2.5 flex flex-col gap-2">
+        <div :if={@revealed_count > 0} class="mt-5">
+          <ol class="flex flex-col gap-2">
             <li
               :for={{hint, i} <- Enum.with_index(Enum.take(@hints, @revealed_count), 1)}
-              class="flex gap-3 border-2 border-neutral bg-base-200 px-3.5 py-2.5 shadow-comic-sm"
+              class="flex gap-3 border-2 border-neutral bg-base-200 px-3.5 py-3 shadow-comic-sm"
             >
               <span class="font-anton text-[15px] text-primary">{i}.</span>
-              <span class="font-barlow text-[15px] text-base-content/90">{hint.text}</span>
+              <span class="font-barlow text-[15px] leading-[1.4] text-base-content/90">
+                {hint.text}
+              </span>
             </li>
           </ol>
-          <div
-            :if={@status == :playing}
-            class="mt-2 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/40"
-          >
-            {hints_remaining_label(@hints, @revealed_count)}
-          </div>
         </div>
 
         <!-- missed guesses -->
-        <div
-          :if={@guesses != []}
-          class="mt-4 font-barlow text-[13px] text-base-content/50"
-        >
+        <div :if={@guesses != []} class="mt-4 font-barlow text-[13px] text-base-content/50">
           Missed guesses: {Enum.join(@guesses, ", ")}
         </div>
 
+        <!-- guess bar: sticky to the bottom on mobile, inline on desktop -->
+        <div
+          :if={@status == :playing}
+          class="fixed inset-x-0 bottom-0 z-20 border-t-2 border-neutral bg-base-100/95 px-4 py-3 backdrop-blur sm:static sm:mt-5 sm:border-0 sm:bg-transparent sm:px-0 sm:py-0 sm:backdrop-blur-none"
+        >
+          <div class="mx-auto max-w-[720px]">
+            <form phx-submit="guess" class="flex gap-2.5">
+              <input
+                type="text"
+                name="guess"
+                value=""
+                autocomplete="off"
+                phx-mounted={JS.focus()}
+                placeholder="Name the card…"
+                class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 font-barlow text-base text-base-content outline-none focus:border-primary placeholder:text-base-content/40 sm:text-[15px]"
+              />
+              <.button variant="primary" type="submit">Guess</.button>
+            </form>
+            <div class="mt-2 text-center sm:mt-2.5 sm:text-right">
+              <button
+                type="button"
+                phx-click="give-up"
+                class="inline-flex min-h-[44px] items-center font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/40 hover:text-base-content/70 sm:min-h-0"
+              >
+                Give up
+              </button>
+            </div>
+          </div>
+        </div>
+
         <!-- result + reveal -->
-        <.panel :if={@status in [:won, :lost]} class="mt-6 px-6 py-6 text-center">
+        <.panel :if={@status in [:won, :lost]} class="mt-6 px-5 py-7 text-center sm:px-6 sm:py-6">
           <div class={[
-            "font-bangers text-[34px] tracking-[0.02em]",
+            "font-bangers text-[38px] tracking-[0.02em] sm:text-[34px]",
             (@status == :won && "text-success") || "text-error"
           ]}>
             {(@status == :won && "You got it!") || "Out of guesses!"}
@@ -132,7 +159,9 @@ defmodule SanctumWeb.GuessLive.Play do
             </div>
           </div>
 
-          <.button variant="primary" phx-click="new-game" class="mt-6">Play again</.button>
+          <.button variant="primary" phx-click="new-game" class="mt-6 w-full sm:w-auto">
+            Play again
+          </.button>
         </.panel>
       </div>
     </Layouts.app>
@@ -200,11 +229,12 @@ defmodule SanctumWeb.GuessLive.Play do
     end
   end
 
-  defp hints_remaining_label(hints, revealed) do
+  # Compact HUD counter shown beside the hint pips during play.
+  defp hint_hud_label(hints, revealed) do
     case length(hints) - revealed do
-      0 -> "No more hints — the next wrong guess ends the round."
-      1 -> "1 hint remaining."
-      n -> "#{n} hints remaining."
+      0 -> "Final guess"
+      1 -> "1 left"
+      n -> "#{n} left"
     end
   end
 

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -49,8 +49,8 @@ defmodule SanctumWeb.Router do
       live "/decks", DeckLive.Index, :index
       live "/decks/:id", DeckLive.Show, :show
 
-      # Public "Name That Card" flavor-text guessing mini-game.
-      live "/guess", GuessLive.Play, :index
+      # Public "Flavor Town" flavor-text guessing mini-game.
+      live "/flavor-town", GuessLive.Play, :index
 
       # Dev playground for refining the comic stat badges.
       live "/dev/stat-badges", DevLive.StatBadges, :index

--- a/test/sanctum_web/live/guess_live/play_test.exs
+++ b/test/sanctum_web/live/guess_live/play_test.exs
@@ -35,7 +35,7 @@ defmodule SanctumWeb.GuessLive.PlayTest do
   test "shows the flavor text and no answer up front", %{conn: conn} do
     seed_card("Nick Fury", "The ultimate spy.")
 
-    {:ok, _view, html} = live(conn, ~p"/guess")
+    {:ok, _view, html} = live(conn, ~p"/flavor-town")
 
     assert html =~ "Flavor Town"
     assert html =~ "The ultimate spy."
@@ -45,7 +45,7 @@ defmodule SanctumWeb.GuessLive.PlayTest do
   test "a wrong guess reveals the first hint", %{conn: conn} do
     seed_card("Nick Fury", "The ultimate spy.")
 
-    {:ok, view, _html} = live(conn, ~p"/guess")
+    {:ok, view, _html} = live(conn, ~p"/flavor-town")
 
     html = view |> form("form", %{guess: "Definitely Wrong"}) |> render_submit()
 
@@ -57,7 +57,7 @@ defmodule SanctumWeb.GuessLive.PlayTest do
   test "a correct guess wins and reveals the card", %{conn: conn} do
     seed_card("Nick Fury", "The ultimate spy.")
 
-    {:ok, view, _html} = live(conn, ~p"/guess")
+    {:ok, view, _html} = live(conn, ~p"/flavor-town")
 
     html = view |> form("form", %{guess: "nick fury"}) |> render_submit()
 
@@ -69,6 +69,6 @@ defmodule SanctumWeb.GuessLive.PlayTest do
   test "is reachable by a logged-out visitor", %{conn: conn} do
     seed_card("Nick Fury", "The ultimate spy.")
 
-    assert {:ok, _view, _html} = live(conn, ~p"/guess")
+    assert {:ok, _view, _html} = live(conn, ~p"/flavor-town")
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to the mobile pass (#111) covering the last browse surface. The flavor-guessing game worked on phones but felt unfinished there — so this reworks it into something that reads as a deliberate mobile game screen, and renames the route from `/guess` to `/flavor-town` to match the nav label.

### What was off on mobile
- The guess input floated mid-screen with a large empty void beneath it.
- The flavor text — the whole point of the game — didn't read as the focus.
- No sense of progress until you'd already missed.
- "Give up" was a tiny floating link; the input was 15px (iOS focus auto-zoom).

### Changes
- **Sticky guess bar:** the input + Guess button anchor to the bottom of the viewport on mobile (thumb-reachable, app-like), reverting to an inline form at `sm`+. The space above now reads as intentional "board" space instead of dead void.
- **Hint HUD:** a persistent pip row (`● ● ○ ○ …`) with an `N left` counter that turns red on the final guess, so the round shows its stakes before any miss. Replaces the old text-only "N hints remaining" line that only appeared after a miss.
- **Flavor quote as hero:** larger on mobile, balanced wrapping, a subtle oversized quotation mark.
- **Affordances:** "Give up" is now a 44px tap target; "Play again" is full-width on mobile; 16px input.
- **Route rename:** `/guess` → `/flavor-town` (top-nav + drawer links updated).

### Verification
Driven with playwright across the playing / hints / reveal states at **390px** (no horizontal scroll, all controls ≥44px) and **1280px** (desktop layout preserved — the guess bar goes inline). `mix ck` clean (Credo + Sobelow), format check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)