### PR TITLE
feat(card pool): show every card side with encounter stats

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -74,6 +74,7 @@
   --color-aspect-protection: #46991b;
   --color-aspect-pool: #d074ac;
   --color-aspect-basic: #87868f;
+  --color-aspect-encounter: #c2703a;
 
   /* DEF stat has no aspect; the other combat stats reuse aspect hues. */
   --color-stat-defense: #2456a6;
@@ -515,6 +516,7 @@ main, #game-board {
   --aspect-protection: var(--color-aspect-protection);
   --aspect-pool: var(--color-aspect-pool);
   --aspect-basic: var(--color-aspect-basic);
+  --aspect-encounter: var(--color-aspect-encounter);
 
   /* Resource-pip colors (ChampionsIcons glyphs) */
   --res-energy: var(--color-res-energy);

--- a/lib/sanctum/games/card_side.ex
+++ b/lib/sanctum/games/card_side.ex
@@ -10,29 +10,13 @@ defmodule Sanctum.Games.CardSide do
     repo Sanctum.Repo
   end
 
-  # Ownership pools and types that belong in the player card pool (deck-buildable
-  # cards). Encounter/villain/identity/scheme faces are excluded. Hero signature
-  # cards are the `:hero` pool; pool cards are ordinary `:player` cards carrying
-  # the `:pool` aspect.
-  @player_ownerships [:player, :basic, :hero]
-  @player_types [
-    :hero,
-    :alter_ego,
-    :ally,
-    :event,
-    :support,
-    :upgrade,
-    :resource,
-    :player_side_scheme
-  ]
-
   actions do
     defaults [:read, :destroy]
 
-    # Public card pool browsing: player card faces filtered by name/aspect/type.
-    # Each side is its own row so multi-sided cards surface every face, and
-    # searching an alternate title (e.g. "Peter Parker") ranks that face first.
-    # Backs SanctumWeb.CardLive.Pool.
+    # Public card pool browsing: every card face — player *and* encounter —
+    # filtered by name/aspect/type. Each side is its own row so multi-sided
+    # cards surface every face, and searching an alternate title (e.g. "Peter
+    # Parker") ranks that face first. Backs SanctumWeb.CardLive.Pool.
     read :browse do
       argument :query, :string, allow_nil?: true
       argument :aspect, :string, allow_nil?: true
@@ -50,8 +34,6 @@ defmodule Sanctum.Games.CardSide do
         query =
           query
           |> Ash.Query.load(:card)
-          |> Ash.Query.filter(type in ^@player_types)
-          |> Ash.Query.filter(ownership in ^@player_ownerships)
           # Side `code` sorts by base_code across cards and primary-first within
           # a card (the primary side always holds the smallest code).
           |> Ash.Query.sort(code: :asc)

--- a/lib/sanctum_web/components/card.ex
+++ b/lib/sanctum_web/components/card.ex
@@ -39,7 +39,12 @@ defmodule SanctumWeb.Components.Card do
       border: "border-aspect-protection"
     },
     "pool" => %{text: "text-aspect-pool", bg: "bg-aspect-pool", border: "border-aspect-pool"},
-    "basic" => %{text: "text-aspect-basic", bg: "bg-aspect-basic", border: "border-aspect-basic"}
+    "basic" => %{text: "text-aspect-basic", bg: "bg-aspect-basic", border: "border-aspect-basic"},
+    "encounter" => %{
+      text: "text-aspect-encounter",
+      bg: "bg-aspect-encounter",
+      border: "border-aspect-encounter"
+    }
   }
 
   @res %{

--- a/lib/sanctum_web/components/health_badge.ex
+++ b/lib/sanctum_web/components/health_badge.ex
@@ -48,7 +48,7 @@ defmodule SanctumWeb.Components.HealthBadge do
   # whitespace can sneak in between the number and the icon — the formatter
   # reflows a nested <tspan> onto its own line, and that whitespace renders
   # as a full-size space glyph splitting the pair apart.
-  @player_icon ~s(<tspan dx="-10" dy="34" stroke-width="5" style="font-family:'ChampionsIcons';font-style:normal;font-size:80px;paint-order:stroke">v</tspan>)
+  @player_icon ~s(<tspan dx="-10" dy="10" stroke-width="5" style="font-family:'ChampionsIcons';font-style:normal;font-size:80px;paint-order:stroke">v</tspan>)
 
   @doc """
   Renders one health badge.

--- a/lib/sanctum_web/components/stat_badge.ex
+++ b/lib/sanctum_web/components/stat_badge.ex
@@ -175,7 +175,7 @@ defmodule SanctumWeb.Components.StatBadge do
         {@value}
         <tspan
           :if={@star}
-          dx="1"
+          dx="-30"
           dy="-34"
           stroke-width="3"
           style="font-family:'ChampionsIcons';font-style:normal;font-size:42px;paint-order:stroke"

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -1,8 +1,8 @@
 defmodule SanctumWeb.CardLive.Pool do
   @moduledoc """
-  Public "Card Pool" — every player card with full text and stats, filterable
-  by name, aspect, and type. The comic-dossier counterpart to the admin card
-  table.
+  Public "Card Pool" — every card side in the game (player *and* encounter) with
+  full text and stats, filterable by name, aspect, and type. The comic-dossier
+  counterpart to the admin card table.
   """
   use SanctumWeb, :live_view
 
@@ -44,7 +44,7 @@ defmodule SanctumWeb.CardLive.Pool do
       <.header>
         Card Pool
         <:subtitle>
-          Every player card, with full text and stats. Filter by aspect or type to find what you need.
+          Every card in the game — player and encounter — with full text and stats. Filter by aspect or type to find what you need.
         </:subtitle>
       </.header>
 
@@ -138,8 +138,16 @@ defmodule SanctumWeb.CardLive.Pool do
                 ]}>
                   {side.type_name} · {side.aspect_name}
                 </div>
-                <div class="mt-[3px] font-anton text-[22px] uppercase leading-[0.94]">
-                  {side.name}
+                <div class="mt-[3px] flex items-baseline gap-2">
+                  <div class="min-w-0 flex-1 font-anton text-[22px] uppercase leading-[0.94]">
+                    {side.name}
+                  </div>
+                  <div
+                    :if={side.stage_label}
+                    class="flex-none font-elektra-med text-[18px] leading-none text-white"
+                  >
+                    {side.stage_label}
+                  </div>
                 </div>
               </div>
             </div>
@@ -172,6 +180,38 @@ defmodule SanctumWeb.CardLive.Pool do
               </div>
               <div class="flex items-start justify-end">
                 <.health_badge value={side.health} size={52} />
+              </div>
+            </div>
+
+            <div :if={side.is_villain or side.is_minion} class="flex items-start gap-2 w-full">
+              <div class="flex flex-grow items-start justify-start">
+                <.stat_badge stat={:thw} value={side.scheme} label="SCH" size={64} />
+                <.stat_badge stat={:atk} value={side.attack} star={side.attack_star} size={64} />
+              </div>
+              <div :if={side.health} class="flex items-start justify-end">
+                <.health_badge value={side.health} player={side.health_per_player} size={52} />
+              </div>
+            </div>
+
+            <div
+              :if={side.is_scheme and (side.start_threat || side.escalation_threat)}
+              class="mb-1 w-full"
+            >
+              <div class="inline-flex -skew-x-[9deg] border-2 border-white bg-base-100 shadow-comic-sm">
+                <.scheme_cell value={side.start_threat} per_player={side.start_threat_pp} />
+                <div :if={side.is_main_scheme} class="w-px self-stretch bg-white"></div>
+                <.scheme_cell
+                  :if={side.is_main_scheme}
+                  value={side.escalation_threat}
+                  per_player={side.escalation_threat_pp}
+                  sign
+                />
+                <div :if={side.is_main_scheme} class="w-px self-stretch bg-white"></div>
+                <.scheme_cell
+                  :if={side.is_main_scheme}
+                  value={side.threat_target}
+                  per_player={side.threat_per_player}
+                />
               </div>
             </div>
 
@@ -229,6 +269,28 @@ defmodule SanctumWeb.CardLive.Pool do
     </Layouts.app>
     """
   end
+
+  # One segment of the main-scheme threat plate: starting threat, escalation,
+  # then threshold. The ChampionsIcons per-player icon is appended when the value
+  # scales per hero. Counter-skewed so the text stays upright in the comic plate.
+  attr :value, :any, default: nil
+  attr :per_player, :boolean, default: false
+  attr :sign, :boolean, default: false, doc: "prefix positive values with + (escalation threat)"
+
+  defp scheme_cell(assigns) do
+    ~H"""
+    <div class="flex skew-x-[9deg] items-baseline gap-0.5 px-2 font-elektra-med text-2xl/snug">
+      {scheme_value(@value, @sign)}
+      <span :if={@per_player} class="font-champions text-xs leading-none text-white">
+        v
+      </span>
+    </div>
+    """
+  end
+
+  defp scheme_value(nil, _sign), do: "—"
+  defp scheme_value(v, true) when is_integer(v) and v > 0, do: "+#{v}"
+  defp scheme_value(v, _sign), do: v
 
   @impl true
   def mount(_params, _session, socket) do
@@ -358,16 +420,38 @@ defmodule SanctumWeb.CardLive.Pool do
       flavor: Map.get(side, :flavor, ""),
       is_ally: side.type == :ally,
       is_hero: side.type == :hero,
+      is_villain: side.type == :villain,
+      is_minion: side.type == :minion,
+      is_scheme: side.type in [:main_scheme, :side_scheme, :player_side_scheme],
       hand_size: side.hand_size,
       attack: stat_value(side.attack),
+      attack_star: stat_star(side.attack),
       attack_consequential: stat_consequential(side.attack),
       thwart: stat_value(side.thwart),
       thwart_consequential: stat_consequential(side.thwart),
       defense: stat_value(side.defense),
       health: stat_value(side.health),
+      health_per_player: stat_per_player(side.health),
+      scheme: side.scheme,
+      is_main_scheme: side.type == :main_scheme,
+      threat_target: threat_target(side),
+      threat_per_player: threat_target_per_player?(side),
+      start_threat: stat_value(side.base_threat),
+      start_threat_pp: stat_per_player(side.base_threat),
+      escalation_threat: stat_value(side.escalation_threat),
+      escalation_threat_pp: stat_per_player(side.escalation_threat),
+      stage_label: stage_label(side),
       image_url: side.image_url
     }
   end
+
+  # Main-scheme stage + side, e.g. "1A"/"2B", from the printed stage number and
+  # side identifier.
+  defp stage_label(%{type: :main_scheme, stage: stage, side_identifier: side})
+       when is_integer(stage) and is_binary(side),
+       do: "#{stage}#{String.upcase(side)}"
+
+  defp stage_label(_), do: nil
 
   # Resolve a hero's gradient from stored MarvelCDB colors, falling back to a
   # stable slug-derived gradient for sets with no stored palette.
@@ -384,19 +468,44 @@ defmodule SanctumWeb.CardLive.Pool do
   defp stat_consequential(%{consequential: n}) when is_integer(n), do: n
   defp stat_consequential(_), do: 0
 
+  defp stat_star(%{star: true}), do: true
+  defp stat_star(_), do: false
+
+  # A per-player-scaling stat (X per hero) is marked with the champions star.
+  defp stat_per_player(%{scaling: scaling}) when scaling in [:per_player, "per_player"], do: true
+  defp stat_per_player(_), do: false
+
+  # A scheme's threat target: main schemes carry it in `max_threat`; side schemes
+  # (and player side schemes) carry it in `base_threat`.
+  defp threat_target(%{max_threat: %{value: v}}), do: v
+  defp threat_target(%{base_threat: %{value: v}}), do: v
+  defp threat_target(_), do: nil
+
+  defp threat_target_per_player?(%{max_threat: stat}) when not is_nil(stat),
+    do: stat_per_player(stat)
+
+  defp threat_target_per_player?(%{base_threat: stat}) when not is_nil(stat),
+    do: stat_per_player(stat)
+
+  defp threat_target_per_player?(_), do: false
+
   defp format_traits(traits) when is_list(traits), do: Enum.join(traits, " · ")
   defp format_traits(_), do: ""
 
   # The display key drives tile color/label: aspect cards (including pool) use
-  # their aspect; every other pool (hero signature, basic) uses its ownership.
+  # their aspect; every other pool uses its ownership. Encounter and campaign
+  # cards share the encounter accent.
   defp display_aspect(%{ownership: :player, aspect: aspect}) when not is_nil(aspect), do: aspect
   defp display_aspect(%{ownership: :hero}), do: :hero
   defp display_aspect(%{ownership: :basic}), do: :basic
+  defp display_aspect(%{ownership: :encounter}), do: :encounter
+  defp display_aspect(%{ownership: :campaign}), do: :encounter
   defp display_aspect(%{aspect: aspect}) when not is_nil(aspect), do: aspect
   defp display_aspect(_), do: :basic
 
   # Hero signature cards have no aspect; name them after their hero set instead.
   defp aspect_name(:hero, set), do: hero_name(set)
+  defp aspect_name(:encounter, _set), do: "Encounter"
   defp aspect_name(aspect, _set), do: aspect |> to_string() |> String.capitalize()
 
   defp hero_name(set) when is_binary(set) and set != "",

--- a/test/sanctum/card_sync_test.exs
+++ b/test/sanctum/card_sync_test.exs
@@ -235,7 +235,11 @@ defmodule Sanctum.CardSyncTest do
   end
 
   test "does not duplicate a side whose stored enum value no longer loads" do
-    assert {:ok, _} = CardSync.run(packs: :all, images?: false)
+    # Quiet progress: the second run intentionally fails one card, and the
+    # default progress reporter would dump that error to stdout via IO.puts.
+    quiet = fn _ -> :ok end
+
+    assert {:ok, _} = CardSync.run(packs: :all, images?: false, progress_fun: quiet)
 
     {:ok, card} = Games.get_card_by_code("01001")
 
@@ -247,7 +251,8 @@ defmodule Sanctum.CardSyncTest do
     count_sql = "SELECT count(*) FROM card_sides WHERE card_id::text = $1"
     before = Sanctum.Repo.query!(count_sql, [card.id]).rows
 
-    assert {:error, %{data: %{failures: failures}}} = CardSync.run(packs: :all, images?: false)
+    assert {:error, %{data: %{failures: failures}}} =
+             CardSync.run(packs: :all, images?: false, progress_fun: quiet)
 
     # The card group failed, but NOT with a duplicate-side constraint violation:
     # the un-loadable row's error propagates instead of being mistaken for "not


### PR DESCRIPTION
## Summary

Expands the public **Card Pool** from player-only cards to **every card side in the game** — player and encounter alike — with type-appropriate stat rendering.

## Changes

- **Browse all sides** — the `CardSide` `:browse` action no longer restricts to the player-type/ownership allowlist, so encounter cards (villains, minions, schemes, treacheries, attachments, environments, obligations) now appear. Name/aspect/type argument filters still apply. Result count went from player-only → all 3,896 sides.
- **Encounter stat rendering** in `CardLive.Pool`:
  - **Villains / minions** — scheme (SCH), attack (with star), and per-player health (the health badge shows the per-player icon).
  - **Side & player side schemes** — starting threat in a skewed, white-bordered "comic plate". Player side schemes keep their play cost next to the name, so cost and threat aren't conflated.
  - **Main schemes** — starting threat, escalation (`+`-prefixed), and threshold shown together in the plate, plus the stage+side label (e.g. `2B`) inline with the title.
  - Per-player scaling is marked with the ChampionsIcons player glyph (white).
- **Encounter accent** — new `--color-aspect-encounter` token and matching `encounter` entry in the `Card` component's aspect-class map.
- **Glyph tweaks** — nudged the health player-icon and stat-badge star positions.

## Testing

- `mix compile --warnings-as-errors`, `mix format --check-formatted`, and Credo all clean.
- `mix test` — 161 tests, 0 failures.
- Verified in the browser across heroes, allies, villains, minions, and all three scheme types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)