### PR TITLE
fix(sync): correct swapped A/B side images for main schemes

### DIFF
--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -614,16 +614,34 @@ defmodule Sanctum.MarvelCdb do
 
   defp not_found?(_), do: false
 
-  # The side's image with fallback to the double-sided parent entry, which
-  # alone carries the front (`imagesrc`) and back (`backimagesrc`) scans for
-  # main schemes and friends.
+  # Resolves the image for a side.
+  #
+  # For a face of a double-sided parent (main schemes, Intangible, …) the
+  # per-side `imagesrc` MarvelCDB emits is unreliable: its auto-generated side
+  # entries carry images that don't line up with their own text. A main
+  # scheme's "a" (setup) side has no image and would fall back to the parent's
+  # front scan, while the "b" (scheme) side ships the parent's *back* scan —
+  # so both faces come out swapped. The parent itself is internally consistent
+  # (`imagesrc` ↔ `text`, `backimagesrc` ↔ `back_text`), so we pick the parent
+  # scan whose text matches this side. Non-double-sided sides (heroes, allies,
+  # …) carry their own correct image.
   defp resolve_imagesrc(entry, parent) do
     cond do
+      parent && parent["double_sided"] -> resolve_double_sided_imagesrc(entry, parent)
       src = presence(entry["imagesrc"]) -> src
-      is_nil(parent) -> nil
-      extract_side_identifier(entry["code"]) == "a" -> presence(parent["imagesrc"])
-      extract_side_identifier(entry["code"]) == "b" -> presence(parent["backimagesrc"])
       true -> nil
+    end
+  end
+
+  defp resolve_double_sided_imagesrc(entry, parent) do
+    back_text = presence(parent["back_text"])
+    front = presence(parent["imagesrc"])
+    back = presence(parent["backimagesrc"])
+
+    if back_text && entry["text"] == back_text do
+      back || front
+    else
+      front || back
     end
   end
 

--- a/test/sanctum/card_sync_test.exs
+++ b/test/sanctum/card_sync_test.exs
@@ -62,7 +62,12 @@ defmodule Sanctum.CardSyncTest do
       "pack_code" => "angel",
       "imagesrc" => "/bundles/cards/42001c.png"
     },
-    # Main scheme: parent alone carries the front image; the a-side has none
+    # Main scheme: MarvelCDB's scans are inverted relative to the stage. The
+    # parent pairs `imagesrc` with `text` (the scheme/1B face) and
+    # `backimagesrc` with `back_text` (the setup/1A face), but the per-side
+    # entries don't line up — the "a" (setup) side has no image and the "b"
+    # (scheme) side ships the *setup* scan (`01097b.png`). Each side must get
+    # the parent scan whose text matches it, not its own imagesrc.
     %{
       "code" => "01097",
       "name" => "The Break-In!",
@@ -71,6 +76,8 @@ defmodule Sanctum.CardSyncTest do
       "card_set_code" => "rhino",
       "stage" => "1",
       "double_sided" => true,
+      "text" => "If this stage is completed, the players lose the game.",
+      "back_text" => "Contents: Rhino (I) and Rhino (II). Setup: Advance to stage 1B.",
       "imagesrc" => "/bundles/cards/01097.png",
       "backimagesrc" => "/bundles/cards/01097b.png"
     },
@@ -81,6 +88,7 @@ defmodule Sanctum.CardSyncTest do
       "pack_code" => "core",
       "card_set_code" => "rhino",
       "stage" => "1A",
+      "text" => "Contents: Rhino (I) and Rhino (II). Setup: Advance to stage 1B.",
       "imagesrc" => nil
     },
     %{
@@ -90,6 +98,7 @@ defmodule Sanctum.CardSyncTest do
       "pack_code" => "core",
       "card_set_code" => "rhino",
       "stage" => "1B",
+      "text" => "If this stage is completed, the players lose the game.",
       "imagesrc" => "/bundles/cards/01097b.png"
     },
     # Double-sided card with NO side entries (Intangible): synthesize both
@@ -161,12 +170,14 @@ defmodule Sanctum.CardSyncTest do
     assert [%{name: "Angel"}, %{name: "Warren Worthington III"}, %{name: "Archangel"}] =
              sides("42001")
 
-    # Main scheme: the a-side inherits the PARENT's front image (01097.png,
-    # not 01097a.png which doesn't exist); stages parse to integers
+    # Main scheme: images resolve by matching each side's text to the parent's
+    # front/back scan, NOT by side letter — so the setup "a" side gets the
+    # `b`-suffixed scan and the scheme "b" side gets the unsuffixed scan (the
+    # opposite of what the filenames suggest). Stages parse to integers.
     assert [side_a, side_b] = sides("01097")
-    assert side_a.image_url == bucket_url("01097.png")
+    assert side_a.image_url == bucket_url("01097b.png")
     assert side_a.stage == 1
-    assert side_b.image_url == bucket_url("01097b.png")
+    assert side_b.image_url == bucket_url("01097.png")
 
     # Intangible: both sides synthesized from the lone parent entry
     assert [front, back] = sides("26002")

--- a/test/sanctum/marvel_cdb_test.exs
+++ b/test/sanctum/marvel_cdb_test.exs
@@ -96,6 +96,72 @@ defmodule Sanctum.MarvelCdbTest do
     end
   end
 
+  describe "create_card_from_entries/2 image resolution" do
+    # MarvelCDB's main-scheme payload is internally inconsistent: the parent
+    # double-sided entry pairs `imagesrc` with `text` and `backimagesrc` with
+    # `back_text`, but the auto-generated per-side entries don't line up — the
+    # "a" (setup) side has no image and the "b" (scheme) side ships the *back*
+    # scan. Each Sanctum side must get the parent scan whose text matches it.
+    test "assigns main-scheme side images by matching parent text, not side letter" do
+      parent = %{
+        "code" => "01097",
+        "name" => "The Break-In!",
+        "type_code" => "main_scheme",
+        "card_set_code" => "rhino",
+        "pack_code" => "core",
+        "quantity" => 1,
+        "double_sided" => true,
+        "imagesrc" => "/bundles/cards/01097.png",
+        "backimagesrc" => "/bundles/cards/01097b.png",
+        "text" => "If this stage is completed, the players lose the game.",
+        "back_text" => "Contents: Rhino (I) and Rhino (II). Setup: Advance to stage 1B.",
+        "threat" => 7,
+        "base_threat" => 0,
+        "escalation_threat" => 1
+      }
+
+      side_a = %{
+        "code" => "01097a",
+        "name" => "The Break-In!",
+        "type_code" => "main_scheme",
+        "card_set_code" => "rhino",
+        "pack_code" => "core",
+        "double_sided" => false,
+        "imagesrc" => nil,
+        "text" => "Contents: Rhino (I) and Rhino (II). Setup: Advance to stage 1B."
+      }
+
+      side_b = %{
+        "code" => "01097b",
+        "name" => "The Break-In!",
+        "type_code" => "main_scheme",
+        "card_set_code" => "rhino",
+        "pack_code" => "core",
+        "double_sided" => false,
+        # MarvelCDB puts the *back* scan on the scheme side — the bug source.
+        "imagesrc" => "/bundles/cards/01097b.png",
+        "text" => "If this stage is completed, the players lose the game.",
+        "threat" => 7,
+        "base_threat" => 0,
+        "escalation_threat" => 1
+      }
+
+      assert {:ok, card} =
+               MarvelCdb.create_card_from_entries([parent, side_a, side_b], image_url_fun: & &1)
+
+      sides =
+        card
+        |> Ash.load!([:card_sides])
+        |> Map.fetch!(:card_sides)
+        |> Map.new(&{&1.side_identifier, &1})
+
+      # Side "a" is the setup face → the "b"-suffixed (grayscale setup) scan.
+      assert sides["a"].image_url == "/bundles/cards/01097b.png"
+      # Side "b" is the scheme face → the unsuffixed (colored threat) scan.
+      assert sides["b"].image_url == "/bundles/cards/01097.png"
+    end
+  end
+
   describe "helper functions" do
     test "extract_base_code/1" do
       assert MarvelCdb.extract_base_code("01001a") == "01001"


### PR DESCRIPTION
## Problem

The card pool renders main-scheme faces with their **A/B side images swapped**. For _The Break-In!_ (`01097`), the record labeled **1A** shows the colored threat scan (actually 1B) and the record labeled **1B** shows the grayscale Contents/Setup scan (actually 1A). Text and stats are correct on each side — only the images are wrong.

## Root cause

MarvelCDB's main-scheme payload is internally inconsistent. The parent `double_sided` entry pairs its scans reliably (`imagesrc` ↔ `text`, `backimagesrc` ↔ `back_text`), but the auto-generated per-side entries don't line up:

| entry | text | image |
|---|---|---|
| `01097` (parent) | scheme/threat (1B) | `imagesrc: 01097.png`, `backimagesrc: 01097b.png` |
| `01097a` (printed **1A**, setup) | "Contents/Setup" | `imagesrc: null` |
| `01097b` (printed **1B**, scheme) | "If this stage…" | `imagesrc: 01097b.png` |

Verified against the actual scans: `01097.png` is the printed **1B** face and `01097b.png` is the printed **1A** face — the opposite of what the filenames imply.

`resolve_imagesrc/2` trusted (1) each side's own `imagesrc`, then (2) a positional `a→imagesrc / b→backimagesrc` guess. Both are wrong here: side `a` had no image and fell back to the *scheme* scan; side `b` carried the *setup* scan on its own `imagesrc`. Both faces came out swapped.

## Fix

For any face of a double-sided parent, pick the parent scan whose **text matches** the side (the one internally-consistent signal), instead of trusting the per-side image or the side letter. This self-corrects the swap and also handles synthesized faces (Intangible-style cards). Non-double-sided sides (heroes, allies) keep their own image.

Added a deterministic offline test (`create_card_from_entries/2 image resolution`) pinning side `a`→`01097b.png` and side `b`→`01097.png`.

## Note

This corrects the sync logic; existing rows still hold the swapped `image_url`s. **A card re-sync** (`/cards/sync`, or `mix sanctum.sync_cards` in dev) rewrites the affected sides in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)