### PR TITLE
feat(admin): unify admin routes under /admin with dashboard + Oban Web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ area, etc.) — a prior separate `GameScheme` was folded into it.
 
 - **MarvelCDB sync** — `mix sanctum.sync_cards` / `mix sanctum.sync_decks` (dev)
   and `Sanctum.Release.sync_cards()` (prod, data-only). Card sync also runs
-  interactively from the `/cards/sync` admin LiveView, backed by
+  interactively from the `/admin/cards/sync` admin LiveView, backed by
   `Sanctum.CardSync.Server` (GenServer + `Task` broadcasting throttled progress
   over PubSub). Sync groups payload entries per `base_code` to resolve sides
   (MarvelCDB's `linked_to_code` chains are incomplete). See `lib/sanctum/marvel_cdb.ex`.
@@ -86,11 +86,14 @@ area, etc.) — a prior separate `GameScheme` was folded into it.
   `lib/sanctum/card_images.ex`.
 - **Deck import** — decks come from MarvelCDB; Oban workers handle sync
   (`decklist_sync_worker`) and uniqueness computation (`compute_uniqueness_worker`).
-- **Admin lockdown** — all `/cards/*` management routes live in an `:admin_routes`
+- **Admin lockdown** — all `/admin/*` routes live in an `:admin_routes`
   live session behind a `:live_admin_required` on_mount hook (`User.admin`), plus
-  admin-only Card/CardSide mutation policies (reads are open). Bootstrap the first
-  admin with `Sanctum.Release.promote_admin(email)`. System writes (sync, seeds,
-  deck import) run with `authorize?: false`.
+  admin-only Card/CardSide mutation policies (reads are open). The `/admin/oban`
+  dashboard is the exception: Oban Web builds its own live_session (bypassing our
+  on_mount), so it's gated by a `:require_admin` **conn plug** and served with a
+  scoped nonce-based CSP (`:oban_csp`) that permits Oban's inline bootstrap script.
+  Bootstrap the first admin with `Sanctum.Release.promote_admin(email)`. System
+  writes (sync, seeds, deck import) run with `authorize?: false`.
 - **Design system** — the pinned dark "comic-dossier" theme: self-hosted fonts,
   design tokens, halftone/offset-shadow utilities, an app shell, and the `mc_card`
   component. See `lib/sanctum_web/components`.
@@ -101,7 +104,8 @@ area, etc.) — a prior separate `GameScheme` was folded into it.
 - `/cards` — `CardLive.Pool` (card browser, public read)
 - `/decks`, `/decks/:id` — deck browser
 - `/guess` — `GuessLive.Play` (card-guessing mini-game)
-- `/cards/manage`, `/cards/new`, `/cards/sync`, `/cards/:id/edit` — **admin only**
+- `/admin` — `AdminLive.Index` (admin landing: system-health stats + links); the
+  `/admin/cards*` management routes and `/admin/oban` — **admin only**
 
 ## Development Commands
 
@@ -127,9 +131,9 @@ mix dialyzer                 # static analysis (PLTs in priv/plts/)
 
 ## Dev Dashboards
 
-- `/dev/dashboard` — Phoenix LiveDashboard
-- `/oban` — Oban job monitoring
-- `/admin` — AshAdmin resource management
+- `/dev/dashboard` — Phoenix LiveDashboard (dev only)
+- `/admin/oban` — Oban job monitoring (**admin only, available in prod**)
+- `/admin/ash` — AshAdmin resource management (dev only)
 - `/dev/mailbox` — email preview
 
 ## Notes

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -35,7 +35,7 @@ defmodule SanctumWeb.Layouts do
 
   attr :active_tab, :atom,
     default: nil,
-    values: [nil, :cards, :guess, :decks],
+    values: [nil, :cards, :guess, :decks, :admin],
     doc: "which top-nav tab to highlight"
 
   slot :inner_block, required: true
@@ -59,6 +59,13 @@ defmodule SanctumWeb.Layouts do
             <.nav_tab navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.nav_tab>
             <.nav_tab navigate={~p"/flavor-town"} active={@active_tab == :guess}>
               Flavor Town
+            </.nav_tab>
+            <.nav_tab
+              :if={@current_user && @current_user.admin}
+              navigate={~p"/admin"}
+              active={@active_tab == :admin}
+            >
+              Admin
             </.nav_tab>
           </nav>
           <div class="ml-auto hidden items-center gap-4 sm:flex">
@@ -109,6 +116,13 @@ defmodule SanctumWeb.Layouts do
           <.drawer_link navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.drawer_link>
           <.drawer_link navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.drawer_link>
           <.drawer_link navigate={~p"/flavor-town"} active={@active_tab == :guess}>Flavor Town</.drawer_link>
+          <.drawer_link
+            :if={@current_user && @current_user.admin}
+            navigate={~p"/admin"}
+            active={@active_tab == :admin}
+          >
+            Admin
+          </.drawer_link>
         </nav>
         <div class="mt-auto flex items-center justify-between border-t-2 border-neutral pt-4">
           <span class="font-ibm-mono text-xs text-base-content/40">

--- a/lib/sanctum_web/live/admin_live/index.ex
+++ b/lib/sanctum_web/live/admin_live/index.ex
@@ -1,0 +1,184 @@
+defmodule SanctumWeb.AdminLive.Index do
+  @moduledoc """
+  Admin landing page: a quick system-health snapshot plus links to the
+  admin-only surfaces. Gated by the `:admin_routes` live session, so a
+  non-admin never reaches `mount/3`.
+  """
+  use SanctumWeb, :live_view
+
+  import Ecto.Query, only: [from: 2]
+
+  @job_states [:available, :executing, :scheduled, :retryable, :discarded, :cancelled, :completed]
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app current_user={@current_user} flash={@flash} active_tab={:admin}>
+      <.header>
+        Admin
+        <:subtitle>System health and management surfaces.</:subtitle>
+      </.header>
+
+      <section class="mt-6">
+        <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
+          Catalog
+        </h2>
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <.stat_tile label="Cards" value={@stats.cards} />
+          <.stat_tile label="Card Sides" value={@stats.card_sides} />
+          <.stat_tile label="Decks" value={@stats.decks} />
+          <.stat_tile label="Heroes" value={@stats.heroes} />
+          <.stat_tile label="Villains" value={@stats.villains} />
+          <.stat_tile label="Scenarios" value={@stats.scenarios} />
+          <.stat_tile label="Users" value={@stats.users} />
+          <.stat_tile label="Games" value={@stats.games} />
+        </div>
+      </section>
+
+      <section class="mt-8">
+        <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
+          Background Jobs
+        </h2>
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+          <.stat_tile label="Available" value={@jobs.available} />
+          <.stat_tile label="Executing" value={@jobs.executing} />
+          <.stat_tile label="Scheduled" value={@jobs.scheduled} />
+          <.stat_tile label="Retryable" value={@jobs.retryable} accent={@jobs.retryable > 0} />
+          <.stat_tile label="Discarded" value={@jobs.discarded} accent={@jobs.discarded > 0} />
+          <.stat_tile label="Completed" value={@jobs.completed} />
+        </div>
+      </section>
+
+      <section class="mt-8">
+        <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
+          Manage
+        </h2>
+        <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <.admin_link navigate={~p"/admin/cards"} icon="hero-rectangle-stack" title="Manage Cards">
+            Browse, edit, and delete the card catalog.
+          </.admin_link>
+          <.admin_link navigate={~p"/admin/cards/sync"} icon="hero-arrow-path" title="Sync Cards">
+            Pull the latest catalog from MarvelCDB.
+          </.admin_link>
+          <.admin_link href={~p"/admin/oban"} icon="hero-queue-list" title="Job Monitor">
+            Inspect and retry background jobs (Oban).
+          </.admin_link>
+
+          <.admin_link
+            :if={@dev_routes?}
+            href="/dev/dashboard"
+            icon="hero-chart-bar"
+            title="LiveDashboard"
+          >
+            Runtime metrics and processes (dev only).
+          </.admin_link>
+          <.admin_link :if={@dev_routes?} href="/admin/ash" icon="hero-circle-stack" title="AshAdmin">
+            Raw resource management (dev only).
+          </.admin_link>
+          <.admin_link :if={@dev_routes?} href="/dev/mailbox" icon="hero-envelope" title="Mailbox">
+            Preview sent emails (dev only).
+          </.admin_link>
+        </div>
+      </section>
+
+      <p class="mt-8 font-ibm-mono text-xs text-base-content/40">
+        Sanctum v{Application.spec(:sanctum, :vsn)}
+      </p>
+    </Layouts.app>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :integer, required: true
+  attr :accent, :boolean, default: false
+
+  defp stat_tile(assigns) do
+    ~H"""
+    <div class={[
+      "border-[3px] border-neutral bg-base-300 px-4 py-3",
+      @accent && "bg-error/15"
+    ]}>
+      <div class={[
+        "font-bangers text-3xl leading-none",
+        (@accent && "text-error") || "text-primary"
+      ]}>
+        {@value}
+      </div>
+      <div class="mt-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+        {@label}
+      </div>
+    </div>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :icon, :string, required: true
+  attr :rest, :global, include: ~w(href navigate patch)
+  slot :inner_block, required: true
+
+  defp admin_link(assigns) do
+    ~H"""
+    <.link
+      class="group flex items-start gap-3 border-[3px] border-neutral bg-base-300 px-4 py-3.5 transition-colors hover:border-primary"
+      {@rest}
+    >
+      <.icon name={@icon} class="mt-0.5 size-6 text-primary" />
+      <div>
+        <div class="font-barlow-condensed text-lg font-bold uppercase tracking-[0.06em] text-base-content group-hover:text-white">
+          {@title}
+        </div>
+        <div class="mt-0.5 text-sm text-base-content/55">
+          {render_slot(@inner_block)}
+        </div>
+      </div>
+    </.link>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Admin")
+     |> assign(:dev_routes?, Application.get_env(:sanctum, :dev_routes, false))
+     |> assign(:stats, load_stats())
+     |> assign(:jobs, load_job_counts())}
+  end
+
+  # Aggregate counts for the health snapshot. `authorize?: false` is deliberate:
+  # the route is already admin-gated and these are non-sensitive row counts, so
+  # we skip per-resource read policies rather than thread an actor through each.
+  defp load_stats do
+    %{
+      cards: count(Sanctum.Games.Card),
+      card_sides: count(Sanctum.Games.CardSide),
+      decks: count(Sanctum.Decks.Deck),
+      heroes: count(Sanctum.Heroes.Hero),
+      villains: count(Sanctum.Villains.Villain),
+      scenarios: count(Sanctum.Games.Scenario),
+      users: count(Sanctum.Accounts.User),
+      games: count(Sanctum.Games.Game)
+    }
+  end
+
+  defp count(resource) do
+    Ash.count!(resource, authorize?: false)
+  rescue
+    _ -> 0
+  end
+
+  # Oban jobs aren't Ash resources; query the framework table directly for a
+  # by-state tally, keyed by the raw state string. We then project onto the
+  # fixed @job_states set (avoiding String.to_atom on DB values). Falls back to
+  # zeros if the table isn't available.
+  defp load_job_counts do
+    counts =
+      from(j in "oban_jobs", group_by: j.state, select: {j.state, count(j.id)})
+      |> Sanctum.Repo.all()
+      |> Map.new()
+
+    Map.new(@job_states, fn state -> {state, Map.get(counts, Atom.to_string(state), 0)} end)
+  rescue
+    _ -> Map.new(@job_states, &{&1, 0})
+  end
+end

--- a/lib/sanctum_web/live/card_live/form.ex
+++ b/lib/sanctum_web/live/card_live/form.ex
@@ -148,8 +148,8 @@ defmodule SanctumWeb.CardLive.Form do
     |> assign(card_form: to_form(card_form))
   end
 
-  defp return_path("index", _card), do: ~p"/cards/manage"
-  defp return_path("show", card), do: ~p"/cards/#{card.id}"
+  defp return_path("index", _card), do: ~p"/admin/cards"
+  defp return_path("show", card), do: ~p"/admin/cards/#{card.id}"
 
   defp card_side_form(assigns) do
     ~H"""

--- a/lib/sanctum_web/live/card_live/index.ex
+++ b/lib/sanctum_web/live/card_live/index.ex
@@ -8,10 +8,10 @@ defmodule SanctumWeb.CardLive.Index do
       <.header>
         Listing Cards
         <:actions>
-          <.button navigate={~p"/cards/sync"}>
+          <.button navigate={~p"/admin/cards/sync"}>
             <.icon name="hero-arrow-path" /> Sync
           </.button>
-          <.button variant="primary" navigate={~p"/cards/new"}>
+          <.button variant="primary" navigate={~p"/admin/cards/new"}>
             <.icon name="hero-plus" /> New Card
           </.button>
         </:actions>
@@ -21,7 +21,7 @@ defmodule SanctumWeb.CardLive.Index do
         <.table
           id="cards"
           rows={@streams.cards}
-          row_click={fn {_id, card} -> JS.navigate(~p"/cards/#{card}") end}
+          row_click={fn {_id, card} -> JS.navigate(~p"/admin/cards/#{card}") end}
           phx-viewport-bottom={!@end_of_timeline? && "next-page"}
         >
           <:col :let={{_id, card}} label="Image">
@@ -68,10 +68,10 @@ defmodule SanctumWeb.CardLive.Index do
 
           <:action :let={{_id, card}}>
             <div class="sr-only">
-              <.link navigate={~p"/cards/#{card}"}>Show</.link>
+              <.link navigate={~p"/admin/cards/#{card}"}>Show</.link>
             </div>
 
-            <.link navigate={~p"/cards/#{card}/edit"}>Edit</.link>
+            <.link navigate={~p"/admin/cards/#{card}/edit"}>Edit</.link>
           </:action>
 
           <:action :let={{id, card}}>

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -20,10 +20,10 @@ defmodule SanctumWeb.CardLive.Show do
         </:subtitle>
 
         <:actions>
-          <.button navigate={~p"/cards/manage"}>
+          <.button navigate={~p"/admin/cards"}>
             <.icon name="hero-arrow-left" /> Back
           </.button>
-          <.button variant="primary" navigate={~p"/cards/#{@card}/edit?return_to=show"}>
+          <.button variant="primary" navigate={~p"/admin/cards/#{@card}/edit?return_to=show"}>
             <.icon name="hero-pencil-square" /> Edit
           </.button>
         </:actions>

--- a/lib/sanctum_web/live/card_live/sync.ex
+++ b/lib/sanctum_web/live/card_live/sync.ex
@@ -13,7 +13,7 @@ defmodule SanctumWeb.CardLive.Sync do
           Pulls the card catalog from MarvelCDB and mirrors card scans into the public bucket.
         </:subtitle>
         <:actions>
-          <.button navigate={~p"/cards/manage"}>
+          <.button navigate={~p"/admin/cards"}>
             <.icon name="hero-arrow-left" /> Back to cards
           </.button>
         </:actions>

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -132,7 +132,7 @@ defmodule SanctumWeb.DeckLive.Show do
                 <div class="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
                   <.link
                     :for={c <- g.cards}
-                    navigate={~p"/cards/#{c.card_id}"}
+                    navigate={~p"/admin/cards/#{c.card_id}"}
                     class="h-[101px] border-2 border-neutral shadow-comic-sm"
                   >
                     <.mc_card

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -23,6 +23,18 @@ defmodule SanctumWeb.Router do
     plug :set_actor, :user
   end
 
+  # Conn-level admin gate for non-LiveView-macro routes (e.g. the Oban
+  # dashboard) that can't use the :live_admin_required on_mount hook.
+  pipeline :require_admin do
+    plug :ensure_admin
+  end
+
+  # Route-scoped CSP that permits the Oban dashboard's inline bootstrap script
+  # (via a per-request nonce) without loosening the app-wide policy.
+  pipeline :oban_csp do
+    plug :put_oban_csp
+  end
+
   scope "/", SanctumWeb do
     pipe_through :browser
 
@@ -58,15 +70,32 @@ defmodule SanctumWeb.Router do
 
     ash_authentication_live_session :admin_routes,
       on_mount: [{SanctumWeb.LiveUserAuth, :live_admin_required}] do
-      # Admin card catalog management (data table + CRUD + sync).
-      live "/cards/manage", CardLive.Index, :index
-      live "/cards/new", CardLive.Form, :new
-      live "/cards/sync", CardLive.Sync, :index
-      live "/cards/:id/edit", CardLive.Form, :edit
+      # Admin landing page — system health + links to admin surfaces.
+      live "/admin", AdminLive.Index, :index
 
-      live "/cards/:id", CardLive.Show, :show
-      live "/cards/:id/show/edit", CardLive.Show, :edit
+      # Admin card catalog management (data table + CRUD + sync).
+      live "/admin/cards", CardLive.Index, :index
+      live "/admin/cards/new", CardLive.Form, :new
+      live "/admin/cards/sync", CardLive.Sync, :index
+      live "/admin/cards/:id/edit", CardLive.Form, :edit
+
+      live "/admin/cards/:id", CardLive.Show, :show
+      live "/admin/cards/:id/show/edit", CardLive.Show, :edit
     end
+  end
+
+  # Oban Web job dashboard — admin-only, available in every environment.
+  #
+  # oban_dashboard/2 builds its OWN live_session with a fixed session extractor
+  # that drops our Ash auth token, so the LiveView on_mount hooks can't see
+  # current_user. We gate it at the plug level instead (:require_admin runs
+  # against conn.assigns.current_user, populated by load_from_session). Oban Web
+  # also emits an inline bootstrap <script>, which our strict prod CSP would
+  # block — :oban_csp swaps in a scoped, nonce-based policy for this route only.
+  scope "/admin" do
+    pipe_through [:browser, :require_admin, :oban_csp]
+
+    oban_dashboard("/oban", csp_nonce_assign_key: :csp_nonce)
   end
 
   scope "/", SanctumWeb do
@@ -121,21 +150,50 @@ defmodule SanctumWeb.Router do
       live_dashboard "/dashboard", metrics: SanctumWeb.Telemetry
       forward "/mailbox", Plug.Swoosh.MailboxPreview
     end
-
-    scope "/" do
-      pipe_through :browser
-
-      oban_dashboard("/oban")
-    end
   end
 
   if Application.compile_env(:sanctum, :dev_routes) do
     import AshAdmin.Router
 
-    scope "/admin" do
+    # Nested under /admin/ash so the admin landing page can own /admin.
+    scope "/admin/ash" do
       pipe_through :browser
 
       ash_admin "/"
     end
+  end
+
+  # Redirects non-admins away from admin-only conn routes (the Oban dashboard).
+  defp ensure_admin(conn, _opts) do
+    case conn.assigns[:current_user] do
+      %{admin: true} ->
+        conn
+
+      _ ->
+        conn
+        |> Phoenix.Controller.put_flash(:error, "You do not have permission to access that page.")
+        |> Phoenix.Controller.redirect(to: "/")
+        |> halt()
+    end
+  end
+
+  # Emits a per-request nonce (consumed by the Oban dashboard's inline script)
+  # and replaces the app-wide CSP header for this route only. Styles stay
+  # 'unsafe-inline' because Oban Web uses inline style attributes a nonce can't
+  # cover; scripts are locked to self + the nonce.
+  defp put_oban_csp(conn, _opts) do
+    nonce = 18 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+
+    policy =
+      "default-src 'self';" <>
+        "script-src 'self' 'nonce-#{nonce}';" <>
+        "style-src 'self' 'unsafe-inline';" <>
+        "img-src 'self' data:;" <>
+        "font-src 'self' data:;" <>
+        "connect-src 'self';"
+
+    conn
+    |> assign(:csp_nonce, nonce)
+    |> put_resp_header("content-security-policy", policy)
   end
 end

--- a/test/sanctum_web/live/card_live/admin_access_test.exs
+++ b/test/sanctum_web/live/card_live/admin_access_test.exs
@@ -5,7 +5,7 @@ defmodule SanctumWeb.CardLive.AdminAccessTest do
 
   import Phoenix.LiveViewTest
 
-  @admin_paths ["/cards/manage", "/cards/new", "/cards/sync"]
+  @admin_paths ["/admin", "/admin/cards", "/admin/cards/new", "/admin/cards/sync"]
 
   describe "anonymous visitors" do
     test "are redirected to sign-in", %{conn: conn} do

--- a/test/sanctum_web/live/card_live/form_test.exs
+++ b/test/sanctum_web/live/card_live/form_test.exs
@@ -13,7 +13,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "renders new card form", %{conn: conn} do
-      {:ok, _view, html} = live(conn, ~p"/cards/new")
+      {:ok, _view, html} = live(conn, ~p"/admin/cards/new")
 
       assert html =~ "New Card"
       assert html =~ "Card Information"
@@ -26,7 +26,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "validates required fields on change", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/cards/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/new")
 
       # Test card form validation
       html =
@@ -38,7 +38,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "creates card with basic data", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/cards/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/new")
 
       unique_id = :rand.uniform(100_000)
 
@@ -58,7 +58,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "shows validation errors for invalid card data", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/cards/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/new")
 
       # Submit with missing required fields
       html =
@@ -70,7 +70,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "shows card sides section", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/cards/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/new")
 
       # The card sides section should be visible
       html = view |> render()
@@ -114,7 +114,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "renders edit form with existing data", %{conn: conn, card: card} do
-      {:ok, _view, html} = live(conn, ~p"/cards/#{card.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
       assert html =~ "Edit Card"
       assert html =~ card.base_code
@@ -122,13 +122,13 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "displays traits as comma-separated string", %{conn: conn, card: card} do
-      {:ok, _view, html} = live(conn, ~p"/cards/#{card.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
       assert html =~ "Test, Trait"
     end
 
     test "updates existing card basic fields", %{conn: conn, card: card} do
-      {:ok, view, _html} = live(conn, ~p"/cards/#{card.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
       {:ok, _view, html} =
         view
@@ -142,7 +142,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "updates card side fields", %{conn: conn, card: card} do
-      {:ok, view, _html} = live(conn, ~p"/cards/#{card.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
       {:ok, _view, html} =
         view
@@ -167,7 +167,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "updates card side traits", %{conn: conn, card: card} do
-      {:ok, view, _html} = live(conn, ~p"/cards/#{card.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
       {:ok, _view, html} =
         view
@@ -188,7 +188,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "handles validation errors on update", %{conn: conn, card: card} do
-      {:ok, view, _html} = live(conn, ~p"/cards/#{card.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
       # Try to submit with invalid data
       html =
@@ -208,17 +208,17 @@ defmodule SanctumWeb.CardLive.FormTest do
     end
 
     test "cancel button navigates back to index", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/cards/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/new")
 
       assert {:ok, _, _html} =
                view
                |> element("a", "Cancel")
                |> render_click()
-               |> follow_redirect(conn, ~p"/cards/manage")
+               |> follow_redirect(conn, ~p"/admin/cards")
     end
 
     test "successful save redirects to index", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/cards/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/cards/new")
 
       unique_id = :rand.uniform(100_000)
 

--- a/test/sanctum_web/live/card_live/show_test.exs
+++ b/test/sanctum_web/live/card_live/show_test.exs
@@ -28,7 +28,7 @@ defmodule SanctumWeb.CardLive.ShowTest do
       }
     )
 
-    {:ok, _view, html} = live(conn, ~p"/cards/#{card}")
+    {:ok, _view, html} = live(conn, ~p"/admin/cards/#{card}")
 
     # title + card-level info
     assert html =~ "Test Hero"

--- a/test/sanctum_web/live/card_live/sync_test.exs
+++ b/test/sanctum_web/live/card_live/sync_test.exs
@@ -13,7 +13,7 @@ defmodule SanctumWeb.CardLive.SyncTest do
   test "renders the sync page with a start button when no sync is running", %{conn: conn} do
     # The singleton server may hold :idle or a previous test's :done state —
     # either way, no sync is running and the form must be startable.
-    {:ok, _view, html} = live(conn, ~p"/cards/sync")
+    {:ok, _view, html} = live(conn, ~p"/admin/cards/sync")
 
     assert html =~ "Card Sync"
     assert html =~ "Start sync"
@@ -21,7 +21,7 @@ defmodule SanctumWeb.CardLive.SyncTest do
   end
 
   test "renders live progress from PubSub broadcasts", %{conn: conn} do
-    {:ok, view, _html} = live(conn, ~p"/cards/sync")
+    {:ok, view, _html} = live(conn, ~p"/admin/cards/sync")
 
     running = %{
       status: :running,

--- a/test/sanctum_web/oban_dashboard_access_test.exs
+++ b/test/sanctum_web/oban_dashboard_access_test.exs
@@ -1,0 +1,27 @@
+defmodule SanctumWeb.ObanDashboardAccessTest do
+  @moduledoc """
+  The Oban dashboard builds its own live_session outside our
+  `:admin_routes` live session, so it's gated by the `:require_admin`
+  conn plug rather than the `:live_admin_required` on_mount hook. These
+  tests pin that plug's behavior.
+  """
+
+  use SanctumWeb.ConnCase, async: true
+
+  describe "GET /admin/oban" do
+    test "redirects anonymous visitors home", %{conn: conn} do
+      conn = get(conn, "/admin/oban")
+      assert redirected_to(conn) == "/"
+    end
+
+    test "redirects authenticated non-admins home", %{conn: conn} do
+      conn =
+        conn
+        |> log_in_user(user_fixture())
+        |> get("/admin/oban")
+
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "permission"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Consolidates every admin-locked surface under a single `/admin` prefix, adds an admin landing page with system-health stats, and makes the **Oban Web** job dashboard available in production to admins (it was previously dev-only).

## Changes

- **Route move.** Admin card routes relocate from `/cards/*` to `/admin/cards/*` (`/cards/manage` → `/admin/cards`). All `~p` references and tests updated.
- **Admin landing (`/admin`).** New `AdminLive.Index`: a system-health snapshot (catalog counts + Oban job counts by state) and a grid of links to the admin surfaces. Surfaced as an **Admin** nav link (desktop + mobile drawer) for admin users only.
- **Oban dashboard (`/admin/oban`), all environments.** Oban Web builds its *own* `live_session` with a fixed session extractor that drops our Ash auth token, so `:live_admin_required` (an on_mount hook) can't see `current_user`. It's gated instead by a **`:require_admin` conn plug** (runs against `conn.assigns.current_user` from `load_from_session`). Oban Web also emits an inline bootstrap `<script>` that the strict prod CSP (`default-src 'self'`, no `script-src 'unsafe-inline'`) would block, so a scoped **`:oban_csp` plug** swaps in a per-request nonce-based policy for that route only — the app-wide CSP is untouched.
- **AshAdmin** moves from `/admin` to `/admin/ash` (dev-only) so the landing page can own `/admin`.

## Testing

- `mix test` — 164 tests, 0 failures. Added `oban_dashboard_access_test.exs` (anonymous + non-admin both redirect away from `/admin/oban`) and extended `admin_access_test.exs` to cover `/admin`.
- `mix ck` — format, Credo, and Sobelow all clean.
- Verified live against the dev server: `/admin/oban` (anon) → 302 `/`, `/admin` (anon) → 302 `/sign-in`. A probe confirmed an admin passes the `:require_admin` gate into Oban's `mount/3`.

> Note: the Oban dashboard render depends on `Oban.Met`, which isn't started under the test env's `testing: :manual` mode (it runs normally in dev/prod), so the full admin render is verified by reasoning + the gate probe rather than an automated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)