### PR TITLE
fix(deck sync): handle heroes with no alter-ego side

### DIFF
--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -75,7 +75,7 @@ defmodule Sanctum.DeckSync do
 
   defp import_decklists(decklists) do
     Enum.reduce(decklists, %{imported: 0, failed: 0}, fn decklist, acc ->
-      case MarvelCdb.import_decklist(decklist, mcdb_type: :decklist) do
+      case import_one(decklist) do
         {:ok, _deck} ->
           Map.update!(acc, :imported, &(&1 + 1))
 
@@ -84,6 +84,16 @@ defmodule Sanctum.DeckSync do
           Map.update!(acc, :failed, &(&1 + 1))
       end
     end)
+  end
+
+  # A single malformed deck must never abort the whole run: import_decklist can
+  # raise (e.g. a hero_code whose card isn't in the catalog yet), not just return
+  # `{:error, _}`, so rescue and treat any raise as a per-deck failure.
+  defp import_one(decklist) do
+    MarvelCdb.import_decklist(decklist, mcdb_type: :decklist)
+  rescue
+    exception ->
+      {:error, Exception.format(:error, exception, __STACKTRACE__)}
   end
 
   # `:since` wins; otherwise resume one overlap window before the cursor; else

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -177,9 +177,11 @@ defmodule Sanctum.MarvelCdb do
     hero_side = Enum.find(card_loaded.card_sides, &(&1.type == :hero))
     alter_ego_side = Enum.find(card_loaded.card_sides, &(&1.type == :alter_ego))
 
+    # A few heroes have no alter-ego flip side (e.g. SP//dr, whose reverse is a
+    # `support` card), so `alter_ego_side` can legitimately be nil.
     hero_attrs = %{
-      hero_name: hero_side.name,
-      alter_ego_name: alter_ego_side.name,
+      hero_name: hero_side && hero_side.name,
+      alter_ego_name: alter_ego_side && alter_ego_side.name,
       set: hero_card.set,
       base_code: hero_card.base_code,
       card_id: hero_card.id


### PR DESCRIPTION
## Problem

The `DecklistSyncWorker` was failing on **every scheduled run** — 17 jobs discarded, all with the same error:

```
** (KeyError) key :name not found in: nil
    lib/sanctum/marvel_cdb.ex:182: Sanctum.MarvelCdb.create_or_find_hero/2
```

Two compounding bugs:

1. **Root cause** — `create_or_find_hero/2` assumed every hero card has an `:alter_ego` side and called `alter_ego_side.name` unconditionally. **SP//dr** (Peni Parker, set `spdr`) is the one hero in the catalog with no alter-ego — her reverse face (`31001b`) is a `support` card. Any SP//dr decklist coming through the sync raised a `KeyError`.

2. **Blast radius** — `DeckSync.import_decklists/1` only handled `{:error, reason}` return tuples, but this was a *raised* exception. It propagated up and aborted the entire run before the sync cursor advanced — so **all** decklist syncing stopped (and the cursor froze), not just SP//dr decks.

## Changes

- **`marvel_cdb.ex`** — guard both side lookups in `create_or_find_hero/2`: `hero_name` and `alter_ego_name` tolerate a missing side. Both `Hero` attributes are nullable, so a hero with no alter-ego persists cleanly.
- **`deck_sync.ex`** — wrap each per-deck import in a `rescue` so any raise (this bug, or e.g. a hero whose card isn't in the catalog yet) is recorded as a single-deck failure instead of killing the run.

## Verification

- `mix compile`, `mix format`, `mix credo` clean on both files.
- Existing `deck_sync` / `marvel_cdb` tests pass.
- Reproduced the `nil` alter-ego side against the live SP//dr card and confirmed the guarded path resolves to `alter_ego_name: nil`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)