### PR TITLE
fix(deploy): stop node when idle instead of letting Fly autostop kill Oban jobs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,11 @@ config :sanctum, Oban,
   queues: [default: 10],
   repo: Sanctum.Repo,
   plugins: [
+    # Prune old completed/discarded jobs so the table doesn't grow unbounded.
+    Oban.Plugins.Pruner,
+    # Rescue jobs orphaned in the `executing` state (e.g. a hard node kill during
+    # a Fly restart) back to `available` so they run again instead of hanging.
+    {Oban.Plugins.Lifeline, rescue_after: :timer.hours(24)},
     {Oban.Plugins.Cron,
      crontab: [
        {"0 * * * *", Sanctum.Decks.DecklistSyncWorker},

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,6 +66,12 @@ if config_env() == :prod do
 
   config :sanctum, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
+  # Let the node stop itself when idle (see `Sanctum.AutoShutdown`) so Fly can
+  # scale the machine to zero. Fly's own proxy autostop is disabled in fly.toml
+  # (`auto_stop_machines = "off"`) because it can't see in-flight Oban jobs.
+  # Opt out with SANCTUM_AUTO_STOP=false (e.g. to keep a machine pinned up).
+  config :sanctum, :auto_stop, System.get_env("SANCTUM_AUTO_STOP", "true") == "true"
+
   config :sanctum, SanctumWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],
     http: [

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,9 @@
 app = 'sanctum'
 primary_region = 'iad'
 kill_signal = 'SIGTERM'
+# Give the BEAM room to drain connections + Oban jobs on deploy/restart SIGTERMs
+# before Fly SIGKILLs (default is 5s, shorter than Oban's shutdown grace period).
+kill_timeout = 30
 
 [build]
 
@@ -19,7 +22,11 @@ kill_signal = 'SIGTERM'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  # Fly's proxy autostop is disabled: it decides purely from inbound HTTP
+  # connections and can't see in-flight Oban jobs, so it would stop the machine
+  # mid-job. The node stops *itself* when idle instead (see Sanctum.AutoShutdown).
+  # auto_start_machines still boots it on the next request, preserving scale-to-zero.
+  auto_stop_machines = 'off'
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']

--- a/lib/sanctum/application.ex
+++ b/lib/sanctum/application.ex
@@ -19,6 +19,7 @@ defmodule Sanctum.Application do
       {Phoenix.PubSub, name: Sanctum.PubSub},
       {Task.Supervisor, name: Sanctum.TaskSupervisor},
       Sanctum.CardSync.Server,
+      {Sanctum.AutoShutdown, enabled?: Application.get_env(:sanctum, :auto_stop, false)},
       # Start a worker by calling: Sanctum.Worker.start_link(arg)
       # {Sanctum.Worker, arg},
       # Start to serve requests, typically the last entry

--- a/lib/sanctum/auto_shutdown.ex
+++ b/lib/sanctum/auto_shutdown.ex
@@ -1,0 +1,104 @@
+defmodule Sanctum.AutoShutdown do
+  @moduledoc """
+  Gracefully stops the node once it is idle — no active HTTP/WebSocket
+  connections and no runnable Oban jobs — so Fly.io can scale the machine to
+  zero.
+
+  Fly's proxy-based autostop is blind to background work: it decides purely from
+  inbound HTTP connections, so it would happily stop a machine mid-Oban-job,
+  leaving the job orphaned. Instead we turn Fly autostop *off*
+  (`auto_stop_machines = "off"` in fly.toml, with `auto_start_machines = true`)
+  and let the node decide when it is safe to stop — because only the node knows
+  whether Oban is busy. `auto_start_machines` still boots the machine on the next
+  request, preserving scale-to-zero.
+
+  Runs only when the `:auto_stop` application env is true (set in prod via
+  runtime.exs). Elsewhere `init/1` returns `:ignore`, so it is a no-op in dev and
+  test and never self-terminates the node.
+  """
+  use GenServer
+
+  require Logger
+
+  # States that mean "there is work due right now". Jobs that are merely
+  # `scheduled`/`retryable` for the future are intentionally excluded: the node
+  # may sleep and Oban promotes them to `available` on the next boot.
+  @busy_states ["available", "executing"]
+
+  @default_interval :timer.minutes(10)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    if Keyword.get(opts, :enabled?, false) do
+      interval = Keyword.get(opts, :interval, @default_interval)
+      {:ok, %{interval: interval}, {:continue, :schedule}}
+    else
+      :ignore
+    end
+  end
+
+  @impl true
+  def handle_continue(:schedule, state) do
+    schedule_check(state.interval)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:check, state) do
+    if idle?() do
+      Logger.info("[AutoShutdown] node idle — stopping so Fly can scale to zero")
+      # Graceful OTP shutdown: children (incl. Oban) drain in reverse start order.
+      System.stop(0)
+      {:noreply, state}
+    else
+      schedule_check(state.interval)
+      {:noreply, state}
+    end
+  end
+
+  defp schedule_check(interval), do: Process.send_after(self(), :check, interval)
+
+  defp idle?, do: not connections?() and not oban_busy?()
+
+  # Count live connections on Bandit's ThousandIsland listener — the Bandit
+  # equivalent of Cowboy's `:ranch.procs/2`. An open browser (LiveView socket)
+  # counts as a connection, so active players keep the node alive. If we can't
+  # determine the count, err on the side of staying up.
+  defp connections? do
+    case listener_pid() do
+      nil ->
+        true
+
+      pid ->
+        case ThousandIsland.connection_pids(pid) do
+          {:ok, []} -> false
+          {:ok, _pids} -> true
+          _ -> true
+        end
+    end
+  end
+
+  defp listener_pid do
+    SanctumWeb.Endpoint
+    |> Supervisor.which_children()
+    |> Enum.find_value(fn
+      {{SanctumWeb.Endpoint, :http}, pid, _, _} when is_pid(pid) -> pid
+      _ -> nil
+    end)
+  rescue
+    _ -> nil
+  end
+
+  defp oban_busy? do
+    import Ecto.Query
+
+    Sanctum.Repo.exists?(from(j in Oban.Job, where: j.state in ^@busy_states))
+  rescue
+    # If the DB check fails, keep the node up rather than risk killing work.
+    _ -> true
+  end
+end


### PR DESCRIPTION
## Problem

Fly's proxy-based autostop decides purely from inbound HTTP connection load, so it's **blind to background work**. It would stop the machine mid-Oban-job, leaving the job orphaned in the `executing` state — and nothing rescued it (no `Lifeline` plugin was configured), so it hung forever. Scheduled deck syncs and cron runs were dying this way.

## Approach

Take the stop decision away from Fly's proxy and give it to the node, which is the only place that can see whether Oban is busy. Scale-to-zero is preserved — `auto_start_machines` still boots the machine on the next request.

This mirrors the pattern already proven in `studio_cms` (adapted from Cowboy/`:ranch` to Bandit/`ThousandIsland`).

## Changes

- **`fly.toml`**: `auto_stop_machines` `'stop'` → `'off'`; add `kill_timeout = 30` so the BEAM can drain connections + Oban jobs on deploy/restart SIGTERMs (Fly's default is 5s, shorter than Oban's 15s shutdown grace).
- **`Sanctum.AutoShutdown`** (new): a `GenServer` that every 10 min checks the ThousandIsland connection count (Bandit's equivalent of `:ranch.procs`) and Oban jobs in `available`/`executing`, and calls `System.stop(0)` **only when both are empty**. `send_after`-scheduled, fails safe (stays up) on any error, and returns `:ignore` in dev/test so it never self-terminates outside prod.
- **`config/runtime.exs`**: prod-only `:auto_stop` config, toggled by `SANCTUM_AUTO_STOP` (default on).
- **`config/config.exs`**: add `Oban.Plugins.Pruner` + `{Oban.Plugins.Lifeline, rescue_after: :timer.hours(24)}` as defense-in-depth — any job orphaned by a hard kill is rescued back to `available`.

## Notes / tradeoffs

- Only `available` + `executing` count as "busy". `scheduled`/`retryable` (future work) are intentionally excluded so a long retry backoff can't pin the machine awake; Oban promotes those on the next boot. This is acceptable given crons don't need to fire on a strict schedule for this app.
- Cron ticks that land while the machine is asleep are skipped, not backfilled (standard Oban Cron behavior) — acceptable here.

## Verification

- `mix ck` (format + Credo + Sobelow) clean.
- 164 tests pass.
- `ThousandIsland.connection_pids/1` and the Oban `available`/`executing` query both confirmed against the running dev node; disabled path returns `:ignore`, enabled path schedules without firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)