### PR TITLE
fix(deck sync): ensure only one decklist sync runs at a time

### DIFF
--- a/lib/sanctum/decks/decklist_sync_worker.ex
+++ b/lib/sanctum/decks/decklist_sync_worker.ex
@@ -2,9 +2,18 @@ defmodule Sanctum.Decks.DecklistSyncWorker do
   @moduledoc """
   Oban worker that runs the incremental decklist sync. Scheduled via the
   `Oban.Plugins.Cron` crontab in config; also enqueueable ad hoc.
+
+  `unique` guarantees only one sync is ever in flight: a new job (from the hourly
+  cron or an ad-hoc enqueue) is suppressed whenever one is already queued or
+  executing, but a fresh run proceeds once the prior one reaches a terminal
+  state. This matters because a single run mutates the shared sync cursor and
+  makes a burst of MarvelCDB calls — two at once would race and double the load.
   """
 
-  use Oban.Worker, queue: :default, max_attempts: 3
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: :infinity, states: :incomplete]
 
   @impl Oban.Worker
   def perform(_job) do


### PR DESCRIPTION
## Problem

`DecklistSyncWorker` had no uniqueness config, so the hourly cron (or an ad-hoc enqueue) could stack a second run on top of one that's still executing. A single run mutates the shared sync cursor (`deck_sync_state`) and makes a burst of MarvelCDB calls — two concurrent runs would race on the cursor and double the outbound load.

This pairs with #124: now that the node stays alive while Oban jobs are in flight, it's more likely for a slow sync to still be running when the next cron tick fires.

## Change

Add Oban `unique` across all non-terminal states:

```elixir
unique: [period: :infinity, states: :incomplete]
```

A new job is suppressed whenever one is already queued or executing (`:incomplete` = `scheduled`/`available`/`executing`/`retryable`/`suspended`), while a fresh run still proceeds once the prior one reaches a terminal state. `period: :infinity` means the dedup isn't time-boxed — it's purely "is there one already in flight?".

This mirrors the existing `unique` debounce on `ComputeUniquenessWorker` (which uses a time-boxed `period: 300` since bursty collapse, not strict single-flight, is what it needs).

## Verification

- Confirmed dedup against the running dev node inside a rolled-back transaction: two `DecklistSyncWorker.new(%{})` inserts returned the **same job id** with `conflict?: true` on the second — nothing committed or executed.
- 164 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)