### PR TITLE
perf(deck-sync): batch slot card lookups and pace deck imports

### DIFF
--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -28,6 +28,11 @@ defmodule Sanctum.DeckSync do
   # Be polite between day requests, matching the card sync's pacing.
   @download_pause_ms 200
 
+  # Brief yield between deck imports so a burst (a busy day, or a backfill)
+  # doesn't monopolize the database — on Neon's small shared compute a
+  # back-to-back import stream visibly delays interactive queries.
+  @deck_pause_ms 50
+
   @doc """
   Runs the sync. Options:
 
@@ -75,6 +80,8 @@ defmodule Sanctum.DeckSync do
 
   defp import_decklists(decklists) do
     Enum.reduce(decklists, %{imported: 0, failed: 0}, fn decklist, acc ->
+      Process.sleep(@deck_pause_ms)
+
       case import_one(decklist) do
         {:ok, _deck} ->
           Map.update!(acc, :imported, &(&1 + 1))

--- a/lib/sanctum/games.ex
+++ b/lib/sanctum/games.ex
@@ -19,6 +19,7 @@ defmodule Sanctum.Games do
       define :update_card_side, action: :update
       define :get_card_side, get_by: :id, action: :read
       define :get_card_side_by_code, args: [:code], get?: true, action: :by_code
+      define :list_card_sides_by_codes, args: [:codes], action: :by_codes
 
       define :get_card_side_by_card_and_side,
         args: [:card_id, :side_identifier],
@@ -29,6 +30,7 @@ defmodule Sanctum.Games do
     resource Sanctum.Games.CardAlt do
       define :create_card_alt, action: :create
       define :get_card_alt_by_code, args: [:code], get?: true, action: :by_code
+      define :list_card_alts_by_codes, args: [:codes], action: :by_codes
     end
 
     resource Sanctum.Games.Game do

--- a/lib/sanctum/games/card_alt.ex
+++ b/lib/sanctum/games/card_alt.ex
@@ -39,6 +39,11 @@ defmodule Sanctum.Games.CardAlt do
       argument :code, :string, allow_nil?: false
       filter expr(code == ^arg(:code))
     end
+
+    read :by_codes do
+      argument :codes, {:array, :string}, allow_nil?: false
+      filter expr(code in ^arg(:codes))
+    end
   end
 
   policies do

--- a/lib/sanctum/games/card_side.ex
+++ b/lib/sanctum/games/card_side.ex
@@ -86,6 +86,11 @@ defmodule Sanctum.Games.CardSide do
       filter expr(code == ^arg(:code))
     end
 
+    read :by_codes do
+      argument :codes, {:array, :string}, allow_nil?: false
+      filter expr(code in ^arg(:codes))
+    end
+
     read :by_card_and_side do
       argument :card_id, :uuid, allow_nil?: false
       argument :side_identifier, :string, allow_nil?: false

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -117,9 +117,11 @@ defmodule Sanctum.MarvelCdb do
   # as multiple physical copies, each with its own code. Aggregate by resolved
   # `card_id`, summing quantities and OR-ing the deck-limit-ignore flag.
   defp build_slots(cards_map, ignore_limits) do
+    card_ids = resolve_slot_codes(Map.keys(cards_map))
+
     cards_map
     |> Enum.reduce(%{}, fn {code, count}, acc ->
-      card_id = load_card!(code).id
+      card_id = Map.fetch!(card_ids, code)
       ignore? = Map.has_key?(ignore_limits, code)
 
       Map.update(acc, card_id, %{quantity: count, ignore_deck_limit: ignore?}, fn slot ->
@@ -131,6 +133,24 @@ defmodule Sanctum.MarvelCdb do
     end)
     |> Enum.map(fn {card_id, slot} -> Map.put(slot, :card_id, card_id) end)
   end
+
+  # Resolves slot codes to canonical card ids in bulk — one CardSide query plus
+  # one CardAlt query for the leftovers, rather than up to two queries per code.
+  # CardSide wins over CardAlt for a code present in both, matching load_card/1.
+  # Only codes absent from the catalog entirely fall back to the per-code
+  # fetch-and-create path (which has to call MarvelCDB anyway).
+  defp resolve_slot_codes(codes) do
+    sides = lookup_codes(codes, &Games.list_card_sides_by_codes!/1)
+    alts = codes |> unresolved(sides) |> lookup_codes(&Games.list_card_alts_by_codes!/1)
+    known = Map.merge(sides, alts)
+    fetched = codes |> unresolved(known) |> Map.new(&{&1, load_card!(&1).id})
+    Map.merge(known, fetched)
+  end
+
+  defp lookup_codes([], _list_fun), do: %{}
+  defp lookup_codes(codes, list_fun), do: Map.new(list_fun.(codes), &{&1.code, &1.card_id})
+
+  defp unresolved(codes, resolved), do: Enum.reject(codes, &Map.has_key?(resolved, &1))
 
   # MarvelCDB stores `meta` as a JSON-encoded string (or nil/empty).
   defp parse_meta(meta) when is_binary(meta) and meta != "" do


### PR DESCRIPTION
## Why

On Neon's free tier the app and the deck sync share a single 0.25 CU compute. Deck import resolved every slot code with up to two point queries (CardSide, then CardAlt fallback) via `load_card!/1` — ~50+ round-trips per deck, fired back-to-back with no pacing between decks. A busy day or a backfill visibly delays interactive LiveView queries and evicts the hot cache.

## What

- **Batch slot resolution** — new `by_codes` read actions on `CardSide` and `CardAlt` (+ domain interfaces); `MarvelCdb.build_slots/2` now resolves all of a deck's slot codes with one CardSide query plus one CardAlt query for the leftovers (~50 queries per deck → 2–3). Precedence matches `load_card/1` (side wins over alt); only codes absent from the catalog fall back to the per-code fetch-and-create path, which has to call MarvelCDB anyway.
- **Per-deck pacing** — `DeckSync.import_decklists` sleeps 50ms between deck imports so sync bursts yield the database to interactive queries. Steady-state cost is negligible (~1.5s on a 30-deck day).

## Testing

- `mix test` — 172 tests, 0 failures
- `mix ck` — format, Credo, Sobelow all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)