### PR TITLE
feat(admin): deck import tool on the admin dashboard

### DIFF
--- a/lib/sanctum_web/live/admin_live/index.ex
+++ b/lib/sanctum_web/live/admin_live/index.ex
@@ -51,6 +51,50 @@ defmodule SanctumWeb.AdminLive.Index do
 
       <section class="mt-8">
         <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
+          Import Deck
+        </h2>
+        <div class="border-[3px] border-neutral bg-base-300 p-4 space-y-3">
+          <form phx-submit="import_deck" class="flex flex-col gap-3 sm:flex-row sm:items-start">
+            <div class="w-full">
+              <.input
+                name="deck_url"
+                value={@deck_import.url}
+                placeholder="https://marvelcdb.com/decklist/view/…"
+                autocomplete="off"
+              />
+            </div>
+            <.button variant="primary" disabled={@deck_import.status == :running}>
+              <.icon name="hero-arrow-down-tray" />
+              {if @deck_import.status == :running, do: "Importing…", else: "Import"}
+            </.button>
+          </form>
+
+          <p class="font-ibm-mono text-xs text-base-content/40">
+            Paste a MarvelCDB decklist or deck URL to sync that deck into Sanctum.
+          </p>
+
+          <p
+            :if={@deck_import.status == :error}
+            class="break-words font-ibm-mono text-xs text-error"
+          >
+            {@deck_import.error}
+          </p>
+
+          <div
+            :if={@deck_import.status == :done}
+            class="flex flex-wrap items-center gap-x-3 gap-y-1 font-ibm-mono text-xs"
+          >
+            <span class="text-success">Imported “{@deck_import.deck.title}”</span>
+            <%!-- href, not navigate: /decks/:id is in a different live_session --%>
+            <.link href={~p"/decks/#{@deck_import.deck.id}"} class="text-primary underline">
+              Open deck view →
+            </.link>
+          </div>
+        </div>
+      </section>
+
+      <section class="mt-8">
+        <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
           Manage
         </h2>
         <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -142,8 +186,88 @@ defmodule SanctumWeb.AdminLive.Index do
      |> assign(:page_title, "Admin")
      |> assign(:dev_routes?, Application.get_env(:sanctum, :dev_routes, false))
      |> assign(:stats, load_stats())
-     |> assign(:jobs, load_job_counts())}
+     |> assign(:jobs, load_job_counts())
+     |> assign(:deck_import, %{status: :idle, deck: nil, error: nil, url: ""})}
   end
+
+  @impl true
+  def handle_event("import_deck", %{"deck_url" => url}, socket) do
+    case parse_deck_url(url) do
+      {:ok, canonical_url} ->
+        {:noreply,
+         socket
+         |> assign(:deck_import, %{status: :running, deck: nil, error: nil, url: String.trim(url)})
+         |> start_async(:import_deck, fn -> import_deck(canonical_url) end)}
+
+      :error ->
+        {:noreply,
+         assign(socket, :deck_import, %{
+           status: :error,
+           deck: nil,
+           error:
+             "Not a MarvelCDB deck URL — expected marvelcdb.com/decklist/view/… or marvelcdb.com/deck/view/…",
+           url: url
+         })}
+    end
+  end
+
+  @impl true
+  def handle_async(:import_deck, {:ok, result}, socket) do
+    deck_import = socket.assigns.deck_import
+
+    socket =
+      case result do
+        {:ok, deck} ->
+          socket
+          |> assign(:deck_import, %{deck_import | status: :done, deck: deck})
+          |> assign(:stats, load_stats())
+
+        {:error, reason} ->
+          assign(socket, :deck_import, %{
+            deck_import
+            | status: :error,
+              error: import_error(reason)
+          })
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_async(:import_deck, {:exit, reason}, socket) do
+    deck_import = %{
+      socket.assigns.deck_import
+      | status: :error,
+        error: "Import crashed: #{inspect(reason)}"
+    }
+
+    {:noreply, assign(socket, :deck_import, deck_import)}
+  end
+
+  # Accept anything a user is likely to paste — http/https, www, trailing slug
+  # or query string — plus a bare decklist id, and reduce it to the canonical
+  # URL form `MarvelCdb.load_deck/1` matches on.
+  defp parse_deck_url(input) do
+    input = String.trim(input)
+
+    case Regex.run(~r{marvelcdb\.com/(decklist|deck)/view/(\d+)}, input) do
+      [_, type, id] -> {:ok, "https://marvelcdb.com/#{type}/view/#{id}"}
+      nil -> if input =~ ~r/^\d+$/, do: {:ok, input}, else: :error
+    end
+  end
+
+  # load_deck can raise (e.g. a hero card missing from the catalog), not just
+  # return `{:error, _}` — surface any raise as a failed import.
+  defp import_deck(url) do
+    Sanctum.MarvelCdb.load_deck(url)
+  rescue
+    exception -> {:error, Exception.format(:error, exception, __STACKTRACE__)}
+  end
+
+  defp import_error(:not_found),
+    do: "MarvelCDB returned 404 — deck not found (private decks can't be fetched)."
+
+  defp import_error(reason) when is_binary(reason), do: reason
+  defp import_error(reason), do: inspect(reason)
 
   # Aggregate counts for the health snapshot. `authorize?: false` is deliberate:
   # the route is already admin-gated and these are non-sensitive row counts, so

--- a/test/sanctum_web/live/admin_live/index_test.exs
+++ b/test/sanctum_web/live/admin_live/index_test.exs
@@ -1,0 +1,121 @@
+defmodule SanctumWeb.AdminLive.IndexTest do
+  @moduledoc false
+
+  # async: false — the import test toggles the global `:marvel_cdb_req_options`
+  # env to route MarvelCDB requests to a Req.Test stub.
+  use SanctumWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Sanctum.Factory
+
+  setup %{conn: conn} do
+    conn = log_in_user(conn, Sanctum.AccountsFixtures.admin_user_fixture())
+    {:ok, conn: conn}
+  end
+
+  test "renders the deck import form", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/admin")
+
+    assert html =~ "Import Deck"
+    assert html =~ "deck_url"
+  end
+
+  test "rejects input that is not a MarvelCDB deck URL", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin")
+
+    html =
+      view
+      |> form("form[phx-submit=import_deck]", %{"deck_url" => "https://example.com/nope"})
+      |> render_submit()
+
+    assert html =~ "Not a MarvelCDB deck URL"
+  end
+
+  test "imports a deck from a pasted URL and links to its deck view", %{conn: conn} do
+    seed_catalog()
+    stub_decklist_endpoint()
+
+    original = Application.get_env(:sanctum, :marvel_cdb_req_options)
+
+    Application.put_env(:sanctum, :marvel_cdb_req_options,
+      plug: {Req.Test, Sanctum.MarvelCdb},
+      retry: false
+    )
+
+    on_exit(fn -> Application.put_env(:sanctum, :marvel_cdb_req_options, original) end)
+
+    {:ok, view, _html} = live(conn, ~p"/admin")
+
+    # A messy-but-real paste: http scheme + trailing slug, normalized before import.
+    view
+    |> form("form[phx-submit=import_deck]", %{
+      "deck_url" => "http://marvelcdb.com/decklist/view/55555/spider-legend"
+    })
+    |> render_submit()
+
+    html = render_async(view)
+
+    assert html =~ "Imported"
+    assert html =~ "Web Warrior"
+
+    {:ok, deck} = Sanctum.Decks.get_deck_by_mcdb_id("55555")
+    assert deck
+    assert html =~ ~p"/decks/#{deck.id}"
+  end
+
+  # The hero (both sides) and one player card, so the decklist import resolves
+  # every code from the local catalog without extra MarvelCDB fetches.
+  defp seed_catalog do
+    hero_card =
+      create(Sanctum.Games.Card, attrs: %{base_code: "90050", code: "90050a", set: "spider_man"})
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: hero_card.id,
+        name: "Spider-Man",
+        type: :hero,
+        code: "90050a",
+        side_identifier: "A",
+        is_primary_side: true
+      }
+    )
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: hero_card.id,
+        name: "Peter Parker",
+        type: :alter_ego,
+        code: "90050b",
+        side_identifier: "B",
+        is_primary_side: false
+      }
+    )
+
+    player_card = create(Sanctum.Games.Card, attrs: %{base_code: "90051", code: "90051"})
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: player_card.id,
+        name: "Web Kick",
+        type: :event,
+        code: "90051",
+        side_identifier: "A",
+        is_primary_side: true
+      }
+    )
+  end
+
+  defp stub_decklist_endpoint do
+    Req.Test.stub(Sanctum.MarvelCdb, fn conn ->
+      assert conn.request_path == "/api/public/decklist/55555"
+
+      Req.Test.json(conn, %{
+        "id" => 55_555,
+        "name" => "Web Warrior",
+        "hero_code" => "90050a",
+        "meta" => ~s({"aspect":"justice"}),
+        "slots" => %{"90051" => 2}
+      })
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

Adds an **Import Deck** tool to the `/admin` dashboard: paste a MarvelCDB decklist/deck URL (or a bare decklist id), and it syncs that deck into Sanctum, then links straight to the imported deck's `/decks/:id` view.

- Pasted input is normalized before import — `http`/`https`, `www`, trailing slugs, and query strings are all accepted; anything that isn't a MarvelCDB deck URL is rejected inline without a network call.
- The import runs via `start_async` so the LiveView stays responsive while MarvelCDB is fetched; raises inside `MarvelCdb.load_deck/1` (e.g. a hero card missing from the catalog) are rescued and surfaced as inline errors, matching how the scheduled deck sync handles them.
- Success shows the imported deck's title, refreshes the catalog stat tiles, and links with a plain `href` since `/decks/:id` lives in a different live_session.

## Testing

- New `SanctumWeb.AdminLive.IndexTest`: form render, invalid-URL rejection, and a full stubbed import (messy `http://…/slug` paste → deck created → link rendered) via `Req.Test`.
- Verified end-to-end against the dev server: imported a real decklist and followed the link to its working deck view.
- `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)