### PR TITLE
feat(deck sync): live progress dashboard + graceful slow-MarvelCDB handling

### DIFF
--- a/lib/mix/tasks/sanctum.sync_decks.ex
+++ b/lib/mix/tasks/sanctum.sync_decks.ex
@@ -32,8 +32,16 @@ defmodule Mix.Tasks.Sanctum.SyncDecks do
       |> maybe_put_date(:since, opts[:since])
       |> maybe_put_date(:until, opts[:until])
 
-    {:ok, _summary} = Sanctum.DeckSync.run(sync_opts)
-    :ok
+    case Sanctum.DeckSync.run(sync_opts) do
+      {:ok, _summary} ->
+        :ok
+
+      {:error, summary} ->
+        Mix.raise(
+          "Deck sync halted at #{summary.halted.date}: #{inspect(summary.halted.reason)} " <>
+            "(#{summary.imported} imported before halting). Re-run to resume from the checkpoint."
+        )
+    end
   end
 
   defp maybe_put_date(opts, _key, nil), do: opts

--- a/lib/sanctum/application.ex
+++ b/lib/sanctum/application.ex
@@ -19,6 +19,7 @@ defmodule Sanctum.Application do
       {Phoenix.PubSub, name: Sanctum.PubSub},
       {Task.Supervisor, name: Sanctum.TaskSupervisor},
       Sanctum.CardSync.Server,
+      Sanctum.DeckSync.Monitor,
       {Sanctum.AutoShutdown, enabled?: Application.get_env(:sanctum, :auto_stop, false)},
       # Start a worker by calling: Sanctum.Worker.start_link(arg)
       # {Sanctum.Worker, arg},

--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -8,6 +8,13 @@ defmodule Sanctum.DeckSync do
   run also re-scans a small trailing window to catch late-arriving decks before
   advancing the cursor.
 
+  The cursor is checkpointed at the last day fetched *successfully* — a 404 (no
+  decks that day) counts as success, but a transient fetch failure (timeout /
+  5xx / rate-limit) **halts the run** and leaves the cursor at the last good
+  day. `run/1` then returns `{:error, summary}` so the caller (the Oban worker)
+  can fail and retry, resuming from the checkpoint. This keeps a slow or flaky
+  MarvelCDB from silently skipping days.
+
   Entry points: `mix sanctum.sync_decks` (manual/backfill) and
   `Sanctum.Decks.DecklistSyncWorker` (scheduled via Oban Cron).
   """
@@ -41,7 +48,10 @@ defmodule Sanctum.DeckSync do
     * `:progress_fun` — `fun/1` receiving progress events; defaults to
       CLI-style logging
 
-  Returns `{:ok, %{days, imported, failed}}`.
+  Returns `{:ok, summary}` when the whole range was fetched, or `{:error,
+  summary}` when a transient failure halted it early. `summary` is a map of
+  `%{days, processed, imported, failed, halted}` where `halted` is `nil` or
+  `%{date, reason}`.
   """
   def run(opts \\ []) do
     progress = Keyword.get(opts, :progress_fun, &log_progress/1)
@@ -51,43 +61,92 @@ defmodule Sanctum.DeckSync do
     dates = date_range(start_date, until)
     progress.({:started, %{from: start_date, to: until, days: length(dates)}})
 
-    {imported, failed} =
-      Enum.reduce(dates, {0, 0}, fn date, {imported, failed} ->
-        {di, df} = sync_date(date, progress)
-        {imported + di, failed + df}
+    initial = %{imported: 0, failed: 0, processed: 0, last_ok: nil, halted: nil}
+
+    acc =
+      Enum.reduce_while(dates, initial, fn date, acc ->
+        case sync_date(date, progress) do
+          {:ok, imported, failed} ->
+            {:cont,
+             %{
+               acc
+               | imported: acc.imported + imported,
+                 failed: acc.failed + failed,
+                 processed: acc.processed + 1,
+                 last_ok: date
+             }}
+
+          {:error, reason} ->
+            # A transient fetch failure (timeout / 5xx / rate-limit): stop the
+            # walk so the cursor never advances past a day we couldn't fetch.
+            {:halt, %{acc | halted: %{date: date, reason: reason}}}
+        end
       end)
 
-    {:ok, _state} = Decks.set_last_synced_date(until)
+    checkpoint_cursor(acc.last_ok)
 
-    summary = %{days: length(dates), imported: imported, failed: failed}
+    summary = %{
+      days: length(dates),
+      processed: acc.processed,
+      imported: acc.imported,
+      failed: acc.failed,
+      halted: acc.halted
+    }
+
     progress.({:done, summary})
-    {:ok, summary}
+
+    if acc.halted, do: {:error, summary}, else: {:ok, summary}
+  end
+
+  # Advance the cursor to the last day we successfully fetched, but never rewind
+  # it: a halted run or a historical `--since` backfill of old dates must not
+  # drag the frontier backward. Nothing fetched (nil) leaves the cursor as-is.
+  defp checkpoint_cursor(nil), do: :ok
+
+  defp checkpoint_cursor(%Date{} = last_ok) do
+    advance? =
+      case current_cursor() do
+        %Date{} = cursor -> Date.compare(last_ok, cursor) == :gt
+        nil -> true
+      end
+
+    if advance?, do: {:ok, _state} = Decks.set_last_synced_date(last_ok)
+    :ok
   end
 
   defp sync_date(date, progress) do
     case MarvelCdb.get_decklists_by_date(date) do
       {:ok, decklists} ->
-        result = import_decklists(decklists)
+        result = import_decklists(decklists, date, progress)
         progress.({:date, Map.put(result, :date, date)})
         Process.sleep(@download_pause_ms)
-        {result.imported, result.failed}
+        {:ok, result.imported, result.failed}
+
+      # 404 means MarvelCDB simply has no decklists for this date — a normal,
+      # permanent outcome, not a failure. Record an empty day and keep going.
+      {:error, :not_found} ->
+        progress.({:date, %{date: date, imported: 0, failed: 0}})
+        Process.sleep(@download_pause_ms)
+        {:ok, 0, 0}
 
       {:error, reason} ->
         progress.({:date_error, %{date: date, reason: reason}})
-        {0, 0}
+        {:error, reason}
     end
   end
 
-  defp import_decklists(decklists) do
+  defp import_decklists(decklists, date, progress) do
     Enum.reduce(decklists, %{imported: 0, failed: 0}, fn decklist, acc ->
       Process.sleep(@deck_pause_ms)
 
       case import_one(decklist) do
         {:ok, _deck} ->
+          progress.({:deck, %{date: date, name: decklist["name"], ok?: true}})
           Map.update!(acc, :imported, &(&1 + 1))
 
         {:error, reason} ->
           Logger.warning("Failed to import decklist #{decklist["id"]}: #{inspect(reason)}")
+          progress.({:deck, %{date: date, name: decklist["name"], ok?: false}})
           Map.update!(acc, :failed, &(&1 + 1))
       end
     end)
@@ -136,6 +195,13 @@ defmodule Sanctum.DeckSync do
 
   defp log_progress({:date_error, %{date: date, reason: reason}}),
     do: Logger.warning("  #{date}: fetch failed: #{inspect(reason)}")
+
+  defp log_progress({:done, %{halted: %{date: date, reason: reason}} = s}),
+    do:
+      Logger.warning(
+        "Deck sync halted at #{date} (#{inspect(reason)}) after #{s.processed} day(s): " <>
+          "#{s.imported} imported, #{s.failed} failed"
+      )
 
   defp log_progress({:done, %{days: days, imported: imported, failed: failed}}),
     do: Logger.info("Deck sync done: #{days} days, #{imported} imported, #{failed} failed")

--- a/lib/sanctum/deck_sync/monitor.ex
+++ b/lib/sanctum/deck_sync/monitor.ex
@@ -1,0 +1,151 @@
+defmodule Sanctum.DeckSync.Monitor do
+  @moduledoc """
+  Holds the latest decklist-sync progress and fans it out over PubSub.
+
+  Unlike the interactive card sync, the deck sync runs headless inside an Oban
+  worker (`Sanctum.Decks.DecklistSyncWorker`). That worker passes `report/1` as
+  its `progress_fun`, so every progress event flows into this singleton
+  GenServer, which folds it into a running snapshot and broadcasts the snapshot
+  (throttled) to the `"deck_sync"` topic. The admin dashboard subscribes for
+  live updates and calls `status/0` on mount to render a run already underway —
+  or the outcome of the last one, since the snapshot is retained between runs.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @topic "deck_sync"
+
+  # A single day can import dozens of decks; cap the broadcast rate so LiveViews
+  # repaint at most ~10x/s. Lifecycle events (started/date/done/error) always
+  # broadcast so the dashboard never lags a phase change.
+  @broadcast_interval_ms 100
+  @max_failures_kept 50
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  def subscribe, do: Phoenix.PubSub.subscribe(Sanctum.PubSub, @topic)
+
+  @doc "Latest sync snapshot — also what PubSub delivers as `{:deck_sync, snapshot}`."
+  def status, do: GenServer.call(__MODULE__, :status)
+
+  @doc """
+  Progress sink for `Sanctum.DeckSync.run/1`. Fire-and-forget so a slow or
+  restarting monitor never stalls the sync.
+  """
+  def report(event), do: GenServer.cast(__MODULE__, {:progress, event})
+
+  @impl true
+  def init(:ok), do: {:ok, %{last_broadcast: 0, sync: idle_sync()}}
+
+  @impl true
+  def handle_call(:status, _from, state), do: {:reply, state.sync, state}
+
+  @impl true
+  def handle_cast({:progress, event}, state) do
+    log(event)
+    state = %{state | sync: apply_event(state.sync, event)}
+    {:noreply, broadcast(state, broadcast_mode(event))}
+  end
+
+  defp idle_sync do
+    %{
+      status: :idle,
+      from: nil,
+      to: nil,
+      current_date: nil,
+      current_deck: nil,
+      days_total: nil,
+      days_done: 0,
+      imported: 0,
+      failed: 0,
+      failures: [],
+      started_at: nil,
+      finished_at: nil
+    }
+  end
+
+  defp apply_event(_sync, {:started, %{from: from, to: to, days: days}}) do
+    %{idle_sync() | status: :running, from: from, to: to, days_total: days, started_at: now()}
+  end
+
+  defp apply_event(sync, {:deck, %{date: date, name: name, ok?: ok?}}) do
+    %{
+      sync
+      | current_date: date,
+        current_deck: name,
+        imported: sync.imported + if(ok?, do: 1, else: 0),
+        failed: sync.failed + if(ok?, do: 0, else: 1)
+    }
+  end
+
+  defp apply_event(sync, {:date, %{date: date}}) do
+    %{sync | current_date: date, current_deck: nil, days_done: sync.days_done + 1}
+  end
+
+  defp apply_event(sync, {:date_error, %{date: date, reason: reason}}) do
+    %{
+      sync
+      | current_date: date,
+        current_deck: nil,
+        days_done: sync.days_done + 1,
+        failures: add_failure(sync.failures, "#{date}: fetch failed: #{inspect(reason)}")
+    }
+  end
+
+  defp apply_event(sync, {:done, %{imported: imported, failed: failed} = summary}) do
+    %{
+      sync
+      | status: if(summary[:halted], do: :error, else: :done),
+        current_date: nil,
+        current_deck: nil,
+        imported: imported,
+        failed: failed,
+        finished_at: now()
+    }
+  end
+
+  defp apply_event(sync, _event), do: sync
+
+  defp add_failure(failures, message), do: Enum.take([message | failures], @max_failures_kept)
+
+  # Mirror the CLI logging the worker loses by routing progress here instead of
+  # `Sanctum.DeckSync`'s default logger. Per-deck events are intentionally silent
+  # (too chatty for the logs); the dashboard is where you watch them tick by.
+  defp log({:started, %{from: from, to: to, days: days}}),
+    do: Logger.info("Deck sync: #{from}..#{to} (#{days} days)")
+
+  defp log({:date, %{date: date, imported: imported, failed: failed}}),
+    do: Logger.info("Deck sync #{date}: #{imported} imported, #{failed} failed")
+
+  defp log({:date_error, %{date: date, reason: reason}}),
+    do: Logger.warning("Deck sync #{date}: fetch failed: #{inspect(reason)}")
+
+  defp log({:done, %{halted: %{date: date, reason: reason}} = s}),
+    do:
+      Logger.warning(
+        "Deck sync halted at #{date} (#{inspect(reason)}): #{s.imported} imported, #{s.failed} failed"
+      )
+
+  defp log({:done, %{days: days, imported: imported, failed: failed}}),
+    do: Logger.info("Deck sync done: #{days} days, #{imported} imported, #{failed} failed")
+
+  defp log(_event), do: :ok
+
+  defp broadcast_mode({:deck, _}), do: :throttled
+  defp broadcast_mode(_event), do: :force
+
+  defp broadcast(state, mode) do
+    now = System.monotonic_time(:millisecond)
+
+    if mode == :force or now - state.last_broadcast >= @broadcast_interval_ms do
+      Phoenix.PubSub.broadcast(Sanctum.PubSub, @topic, {:deck_sync, state.sync})
+      %{state | last_broadcast: now}
+    else
+      state
+    end
+  end
+
+  defp now, do: DateTime.utc_now()
+end

--- a/lib/sanctum/decks/decklist_sync_worker.ex
+++ b/lib/sanctum/decks/decklist_sync_worker.ex
@@ -17,14 +17,27 @@ defmodule Sanctum.Decks.DecklistSyncWorker do
 
   @impl Oban.Worker
   def perform(_job) do
-    with {:ok, summary} <- Sanctum.DeckSync.run() do
-      # New decks shift their heroes' uniqueness rankings; recompute. `unique`
-      # on the worker debounces this against the nightly cron run.
-      if summary.imported > 0 do
-        Sanctum.Decks.ComputeUniquenessWorker.new(%{}) |> Oban.insert()
-      end
+    # Route progress into the Monitor so the admin dashboard can watch the run
+    # live (and see its outcome afterward); the Monitor also handles logging.
+    result = Sanctum.DeckSync.run(progress_fun: &Sanctum.DeckSync.Monitor.report/1)
+    summary = elem(result, 1)
 
-      :ok
+    # New decks shift their heroes' uniqueness rankings; recompute. Do this even
+    # for a halted run — partial progress still imports decks. `unique` on the
+    # worker debounces this against the nightly cron run.
+    if summary.imported > 0 do
+      Sanctum.Decks.ComputeUniquenessWorker.new(%{}) |> Oban.insert()
+    end
+
+    case result do
+      {:ok, _summary} ->
+        :ok
+
+      {:error, summary} ->
+        # A transient fetch failure halted the run. Fail the job so Oban retries
+        # with backoff; the cursor was checkpointed at the last good day, so the
+        # retry resumes there rather than re-walking the whole range.
+        {:error, "deck sync halted at #{summary.halted.date}: #{inspect(summary.halted.reason)}"}
     end
   end
 end

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -28,6 +28,10 @@ defmodule Sanctum.MarvelCdb do
 
   @base_url "https://marvelcdb.com/api/public"
 
+  # MarvelCDB's by-date endpoint can be sluggish; give a slow-but-alive response
+  # room to land before treating it as a transient failure.
+  @decklist_receive_timeout_ms 20_000
+
   @doc """
   Imports a single deck from a MarvelCDB URL or bare id.
 
@@ -355,7 +359,10 @@ defmodule Sanctum.MarvelCdb do
   @spec get_decklists_by_date(Date.t()) :: {:ok, list(map())} | {:error, term()}
   def get_decklists_by_date(%Date{} = date) do
     "#{@base_url}/decklists/by_date/#{Date.to_iso8601(date)}"
-    |> Req.get([max_retries: 1] ++ req_options())
+    |> Req.get(
+      [retry: :transient, max_retries: 2, receive_timeout: @decklist_receive_timeout_ms] ++
+        req_options()
+    )
     |> handle_response()
   end
 

--- a/lib/sanctum_web/live/admin_live/index.ex
+++ b/lib/sanctum_web/live/admin_live/index.ex
@@ -51,6 +51,70 @@ defmodule SanctumWeb.AdminLive.Index do
 
       <section class="mt-8">
         <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
+          Deck Sync
+        </h2>
+        <div class="border-[3px] border-neutral bg-base-300 p-4 space-y-4">
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span class={[
+              "inline-flex items-center border-2 px-3 py-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em]",
+              deck_status_class(@deck_sync.status)
+            ]}>
+              {deck_status_label(@deck_sync.status)}
+            </span>
+            <span :if={@deck_sync.started_at} class="font-ibm-mono text-xs text-base-content/55">
+              started {fmt_ts(@deck_sync.started_at)}
+            </span>
+            <span :if={@deck_sync.finished_at} class="font-ibm-mono text-xs text-base-content/55">
+              &middot; finished {fmt_ts(@deck_sync.finished_at)}
+            </span>
+          </div>
+
+          <div :if={@deck_sync.status == :running} class="space-y-2">
+            <div class="flex items-baseline justify-between font-ibm-mono text-xs text-base-content/70">
+              <span>
+                {if @deck_sync.current_date,
+                  do: "Syncing #{@deck_sync.current_date}",
+                  else: "Starting…"}
+              </span>
+              <span :if={@deck_sync.days_total} class="tabular-nums">
+                day {@deck_sync.days_done} / {@deck_sync.days_total}
+              </span>
+            </div>
+            <div class="h-2 w-full overflow-hidden bg-base-100">
+              <div
+                class="h-full bg-primary transition-[width] duration-150"
+                style={"width: #{deck_percent(@deck_sync)}%"}
+              >
+              </div>
+            </div>
+            <div
+              :if={@deck_sync.current_deck}
+              class="truncate font-ibm-mono text-xs text-base-content/70"
+            >
+              importing: {@deck_sync.current_deck}
+            </div>
+          </div>
+
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <.text_tile label="Cursor" value={fmt_date(@deck_health.cursor)} />
+            <.text_tile label="Last Run" value={fmt_last_run(@deck_health.last_run)} />
+            <.stat_tile label="Imported" value={@deck_sync.imported} />
+            <.stat_tile label="Failed" value={@deck_sync.failed} accent={@deck_sync.failed > 0} />
+          </div>
+
+          <div :if={@deck_sync.failures != []}>
+            <h3 class="mb-2 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-error">
+              Recent failures ({length(@deck_sync.failures)})
+            </h3>
+            <ul class="space-y-1 font-ibm-mono text-xs text-base-content/70">
+              <li :for={failure <- @deck_sync.failures} class="truncate">{failure}</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="mt-8">
+        <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
           Import Deck
         </h2>
         <div class="border-[3px] border-neutral bg-base-300 p-4 space-y-3">
@@ -155,6 +219,22 @@ defmodule SanctumWeb.AdminLive.Index do
     """
   end
 
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+
+  defp text_tile(assigns) do
+    ~H"""
+    <div class="border-[3px] border-neutral bg-base-300 px-4 py-3">
+      <div class="truncate font-barlow-condensed text-xl font-bold leading-none text-primary">
+        {@value}
+      </div>
+      <div class="mt-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+        {@label}
+      </div>
+    </div>
+    """
+  end
+
   attr :title, :string, required: true
   attr :icon, :string, required: true
   attr :rest, :global, include: ~w(href navigate patch)
@@ -181,12 +261,16 @@ defmodule SanctumWeb.AdminLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    if connected?(socket), do: Sanctum.DeckSync.Monitor.subscribe()
+
     {:ok,
      socket
      |> assign(:page_title, "Admin")
      |> assign(:dev_routes?, Application.get_env(:sanctum, :dev_routes, false))
      |> assign(:stats, load_stats())
      |> assign(:jobs, load_job_counts())
+     |> assign(:deck_sync, Sanctum.DeckSync.Monitor.status())
+     |> assign(:deck_health, load_deck_health())
      |> assign(:deck_import, %{status: :idle, deck: nil, error: nil, url: ""})}
   end
 
@@ -269,6 +353,20 @@ defmodule SanctumWeb.AdminLive.Index do
   defp import_error(reason) when is_binary(reason), do: reason
   defp import_error(reason), do: inspect(reason)
 
+  # Live progress from the deck-sync Monitor. Reload the DB-backed health
+  # (cursor + last Oban run) once a run settles, since those change on completion.
+  @impl true
+  def handle_info({:deck_sync, sync}, socket) do
+    socket = assign(socket, :deck_sync, sync)
+
+    socket =
+      if sync.status in [:done, :error],
+        do: assign(socket, :deck_health, load_deck_health()),
+        else: socket
+
+    {:noreply, socket}
+  end
+
   # Aggregate counts for the health snapshot. `authorize?: false` is deliberate:
   # the route is already admin-gated and these are non-sensitive row counts, so
   # we skip per-resource read policies rather than thread an actor through each.
@@ -305,4 +403,61 @@ defmodule SanctumWeb.AdminLive.Index do
   rescue
     _ -> Map.new(@job_states, &{&1, 0})
   end
+
+  # DB-backed deck-sync health that outlives the in-memory Monitor snapshot: the
+  # persisted cursor and the most recent Oban job for the worker (any state).
+  defp load_deck_health do
+    %{cursor: deck_sync_cursor(), last_run: last_deck_sync_job()}
+  end
+
+  defp deck_sync_cursor do
+    case Sanctum.Decks.get_deck_sync_state() do
+      {:ok, %{last_synced_date: %Date{} = date}} -> date
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp last_deck_sync_job do
+    from(j in "oban_jobs",
+      where: j.worker == "Sanctum.Decks.DecklistSyncWorker",
+      order_by: [desc: j.id],
+      limit: 1,
+      select: %{state: j.state, completed_at: j.completed_at, attempted_at: j.attempted_at}
+    )
+    |> Sanctum.Repo.one()
+  rescue
+    _ -> nil
+  end
+
+  defp deck_status_label(:idle), do: "Idle"
+  defp deck_status_label(:running), do: "Running"
+  defp deck_status_label(:done), do: "Completed"
+  defp deck_status_label(:error), do: "Failed"
+
+  defp deck_status_class(:idle), do: "border-neutral text-base-content/60"
+  defp deck_status_class(:running), do: "border-info text-info"
+  defp deck_status_class(:done), do: "border-success text-success"
+  defp deck_status_class(:error), do: "border-error text-error"
+
+  defp deck_percent(%{days_total: total, days_done: done}) when is_integer(total) and total > 0,
+    do: Float.round(done / total * 100, 1)
+
+  defp deck_percent(_sync), do: 0
+
+  defp fmt_date(%Date{} = date), do: Date.to_iso8601(date)
+  defp fmt_date(_), do: "—"
+
+  defp fmt_ts(%struct{} = ts) when struct in [DateTime, NaiveDateTime],
+    do: Calendar.strftime(ts, "%Y-%m-%d %H:%M UTC")
+
+  defp fmt_ts(_), do: "—"
+
+  defp fmt_last_run(%{state: state, completed_at: completed, attempted_at: attempted}) do
+    ts = completed || attempted
+    if ts, do: "#{state} · #{fmt_ts(ts)}", else: state
+  end
+
+  defp fmt_last_run(_), do: "never"
 end

--- a/test/sanctum/deck_sync_test.exs
+++ b/test/sanctum/deck_sync_test.exs
@@ -1,0 +1,126 @@
+defmodule Sanctum.DeckSyncTest do
+  @moduledoc false
+
+  # async: false — the tests toggle the global `:marvel_cdb_req_options` env and
+  # share the singleton `DeckSyncState` cursor row.
+  use Sanctum.DataCase, async: false
+
+  alias Sanctum.Decks
+  alias Sanctum.DeckSync
+
+  setup do
+    original = Application.get_env(:sanctum, :marvel_cdb_req_options)
+
+    # Disable Req's own transient retry so a simulated error resolves in one
+    # shot — keeps these tests fast and deterministic. (`retry: false` is
+    # appended last, so it overrides the `retry: :transient` the by-date call
+    # passes.)
+    Application.put_env(:sanctum, :marvel_cdb_req_options,
+      plug: {Req.Test, Sanctum.MarvelCdb},
+      retry: false
+    )
+
+    on_exit(fn -> Application.put_env(:sanctum, :marvel_cdb_req_options, original) end)
+    :ok
+  end
+
+  # Stub the by-date endpoint, dispatching on the ISO date in the request path.
+  # Values: `{:ok, decks}` -> 200, `:not_found` -> 404, `:timeout` -> transport
+  # error. An un-mapped date flunks so we can assert a date was never fetched.
+  defp stub_by_date(responses) do
+    Req.Test.stub(Sanctum.MarvelCdb, fn conn ->
+      date = conn.request_path |> String.split("/") |> List.last()
+
+      case Map.fetch(responses, date) do
+        {:ok, {:ok, decks}} -> Req.Test.json(conn, decks)
+        {:ok, :not_found} -> conn |> Plug.Conn.put_status(404) |> Req.Test.json(%{})
+        {:ok, :timeout} -> Req.Test.transport_error(conn, :timeout)
+        :error -> flunk("unexpected fetch for #{date}")
+      end
+    end)
+  end
+
+  defp set_cursor(date), do: {:ok, _} = Decks.set_last_synced_date(date)
+
+  defp cursor do
+    {:ok, %{last_synced_date: date}} = Decks.get_deck_sync_state()
+    date
+  end
+
+  defp run(opts), do: DeckSync.run([progress_fun: fn _ -> :ok end] ++ opts)
+
+  test "advances the cursor to the last day on a fully successful run" do
+    set_cursor(~D[2024-01-09])
+
+    stub_by_date(%{
+      "2024-01-10" => {:ok, []},
+      "2024-01-11" => {:ok, []},
+      "2024-01-12" => {:ok, []}
+    })
+
+    assert {:ok, summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-12])
+    assert summary.halted == nil
+    assert summary.processed == 3
+    assert cursor() == ~D[2024-01-12]
+  end
+
+  test "treats a 404 as an empty synced day, not a failure" do
+    set_cursor(~D[2024-01-09])
+
+    stub_by_date(%{
+      "2024-01-10" => {:ok, []},
+      "2024-01-11" => :not_found,
+      "2024-01-12" => {:ok, []}
+    })
+
+    assert {:ok, summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-12])
+    assert summary.halted == nil
+    assert summary.failed == 0
+    assert summary.processed == 3
+    # Cursor advances past the empty (404) day.
+    assert cursor() == ~D[2024-01-12]
+  end
+
+  test "halts on a transient failure and checkpoints at the last good day" do
+    set_cursor(~D[2024-01-09])
+
+    # 2024-01-13 is intentionally left unstubbed: reaching it would flunk,
+    # proving the walk stopped at the first failure.
+    stub_by_date(%{
+      "2024-01-10" => {:ok, []},
+      "2024-01-11" => {:ok, []},
+      "2024-01-12" => :timeout
+    })
+
+    assert {:error, summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-13])
+    assert summary.halted.date == ~D[2024-01-12]
+    assert summary.processed == 2
+    # Cursor stops at the last successfully-fetched day so the next run resumes.
+    assert cursor() == ~D[2024-01-11]
+  end
+
+  test "never rewinds the cursor when the failure is at the first day" do
+    set_cursor(~D[2024-01-11])
+
+    stub_by_date(%{"2024-01-10" => :timeout})
+
+    assert {:error, summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-12])
+    assert summary.halted.date == ~D[2024-01-10]
+    assert summary.processed == 0
+    # Nothing fetched successfully → cursor left untouched (no rewind).
+    assert cursor() == ~D[2024-01-11]
+  end
+
+  test "never rewinds the cursor on a historical backfill of older dates" do
+    set_cursor(~D[2024-06-01])
+
+    stub_by_date(%{
+      "2024-01-10" => {:ok, []},
+      "2024-01-11" => {:ok, []}
+    })
+
+    assert {:ok, _summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-11])
+    # Older days synced, but the frontier must not move backward.
+    assert cursor() == ~D[2024-06-01]
+  end
+end


### PR DESCRIPTION
## Summary

Adds a live **Deck Sync** dashboard to `/admin` and makes the headless deck-sync worker resilient to a slow or flaky MarvelCDB.

### Backend — `Sanctum.DeckSync.Monitor` + graceful handling
- New `Sanctum.DeckSync.Monitor` GenServer (supervised singleton) folds the sync's progress events into a retained snapshot and fans it out over PubSub (throttled). The worker reports into it; it also handles logging.
- `DeckSync.run/1` **checkpoints the cursor at the last successfully-fetched day** and **halts on a transient fetch failure** (timeout / 5xx / rate-limit), returning `{:error, summary}` so the Oban worker fails and retries from the checkpoint — no silently-skipped days. A 404 (no decks that day) counts as success.
- `marvel_cdb.ex`: the by-date fetch gets a slowness-tolerant `receive_timeout` (20s) + `retry: :transient`.
- Per-deck progress events so the dashboard shows the deck currently importing; `mix sanctum.sync_decks` surfaces a descriptive halt message.

### UI — Deck Sync dashboard on `/admin`
Status badge, current date + day X/Y progress, the deck currently importing, imported/failed counts, the persisted cursor + last Oban run (DB-backed health), and recent failures. A halted run shows as **Failed**.

## Tests
`test/sanctum/deck_sync_test.exs` (5 tests): full-success cursor advance, 404-as-empty-day, halt-and-checkpoint, and no-rewind on both first-day-failure and historical backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)