### PR TITLE
fix(deck-sync): floor backfill at 2019-11-02 to skip MarvelCDB 500

### DIFF
--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -25,8 +25,12 @@ defmodule Sanctum.DeckSync do
   alias Sanctum.MarvelCdb
 
   # MarvelCDB launched in late 2019; used as the backfill floor when no cursor
-  # exists and no `:since` is given.
-  @default_start_date ~D[2019-11-01]
+  # exists and no `:since` is given. Floored at 2019-11-02 rather than 11-01
+  # because MarvelCDB's `/decklists/by_date/2019-11-01` endpoint permanently
+  # returns HTTP 500 (a server-side bug on that single earliest date). Since a
+  # 5xx halts the run to avoid skipping days, starting on 11-01 wedged the sync
+  # on day one forever; 11-01 holds no fetchable decks anyway.
+  @default_start_date ~D[2019-11-02]
 
   # Re-scan this many days before the cursor each run, so decks published late
   # (or edited on) a day that was already synced still get picked up.


### PR DESCRIPTION
## Problem

Deck sync is **permanently wedged on its first day** in prod:

```
Deck sync: 2019-11-01..2026-07-15 (2449 days)
retry: got response with status 500, will retry in 1000ms, 2 attempts left
retry: got response with status 500, will retry in 2000ms, 1 attempt left
Deck sync 2019-11-01: fetch failed: "Unexpected status code: 500"
Deck sync halted at 2019-11-01 ("Unexpected status code: 500"): 0 imported, 0 failed
```

## Root cause

MarvelCDB's `GET /api/public/decklists/by_date/2019-11-01` endpoint **permanently returns HTTP 500** — a server-side bug isolated to that single earliest date. Confirmed directly against the live API:

```
2019-11-01 -> 500   ← poisoned
2019-11-02 -> 200
...every other date -> 200
```

Prod has no `DeckSyncState` cursor yet, so a fresh backfill starts at `@default_start_date` (`2019-11-01`) and that date is request #1. Since the sync deliberately **halts on any 5xx** (so it never silently skips a day), it halts before advancing the cursor. Every scheduled run then restarts at `2019-11-01`, 500s, and halts again — `0 imported, 0 failed`, forever.

## Fix

Move the backfill floor forward one day to `2019-11-02`, which returns 200. `2019-11-01` holds no fetchable decks anyway (their endpoint 500s on it). Next scheduled worker run (cursor still nil → uses the new floor) will start cleanly and walk the whole range forward — no manual intervention needed.

## Test plan

- [x] `mix ck` (format + Credo + Sobelow) clean
- [x] `mix compile --warnings-as-errors` clean
- [x] Verified against live MarvelCDB API that `2019-11-02` onward returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)