### PR TITLE
fix(observability): stop background-noise transactions flooding Sentry

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -30,7 +30,7 @@ config :sentry,
   integrations: [oban: [capture_errors: true, cron: [enabled: true]]],
   enable_logs: true,
   logs: [level: :info, metadata: [:request_id, :game_id, :user_id]],
-  traces_sample_rate: 1.0
+  traces_sampler: {Sanctum.Observability, :traces_sampler}
 
 # Route OTel spans into Sentry instead of an OTLP collector.
 config :opentelemetry,

--- a/lib/sanctum/observability.ex
+++ b/lib/sanctum/observability.ex
@@ -1,0 +1,31 @@
+defmodule Sanctum.Observability do
+  @moduledoc """
+  Sentry tracing hooks. See `traces_sampler/1`.
+  """
+
+  @doc """
+  Root-span sampling decision for Sentry tracing (`:traces_sampler` in
+  config/prod.exs). Only called for spans that start a new trace — child spans
+  inherit their root's decision.
+
+  Drops the background noise that would otherwise flood the transaction quota
+  (Oban's Stager ticks once per second; each orphan repo query becomes its own
+  transaction):
+
+    * Oban plugin ticks (`Elixir.Oban.Stager process`, Cron/Pruner/Lifeline) —
+      dropping the root also drops the plugin's child query spans.
+    * Bare `sanctum.repo.query:*` roots — queries with no surrounding trace
+      (oban_met sampling, peer election, card/deck sync tasks). Queries inside
+      request, LiveView, and Oban job traces are children and are unaffected.
+
+  Everything else (HTTP requests, LiveView, Oban jobs) is sampled at 100%.
+  """
+  def traces_sampler(%{transaction_context: %{name: name}}) do
+    oban_plugin_tick? =
+      String.starts_with?(name, "Elixir.Oban.") and String.ends_with?(name, " process")
+
+    orphan_query? = String.starts_with?(name, "sanctum.repo.query")
+
+    if oban_plugin_tick? or orphan_query?, do: 0.0, else: 1.0
+  end
+end

--- a/test/sanctum/observability_test.exs
+++ b/test/sanctum/observability_test.exs
@@ -1,0 +1,28 @@
+defmodule Sanctum.ObservabilityTest do
+  use ExUnit.Case, async: true
+
+  alias Sanctum.Observability
+
+  defp sample(name), do: Observability.traces_sampler(%{transaction_context: %{name: name}})
+
+  describe "traces_sampler/1" do
+    test "drops Oban plugin ticks" do
+      assert sample("Elixir.Oban.Stager process") == 0.0
+      assert sample("Elixir.Oban.Plugins.Cron process") == 0.0
+      assert sample("Elixir.Oban.Plugins.Pruner process") == 0.0
+    end
+
+    test "drops orphan repo query roots" do
+      assert sample("sanctum.repo.query:oban_jobs") == 0.0
+      assert sample("sanctum.repo.query:decks") == 0.0
+      assert sample("sanctum.repo.query") == 0.0
+    end
+
+    test "samples real traffic at 100%" do
+      assert sample("GET /games/:id") == 1.0
+      # opentelemetry_oban names job spans "process <queue>"
+      assert sample("process default") == 1.0
+      assert sample("SanctumWeb.GameLive.Show.mount") == 1.0
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Prod logs are flooded with:

```
[warning] Failed to send Sentry event. Sentry failed to report event: the event was dropped because the category is currently rate-limited by Sentry
```

The initial Sentry rollout (#139) sampled every root span at 100%. Two background sources turned that into ~100k junk transactions/day:

1. **Oban plugin ticks** — `OpentelemetryOban.setup()` instruments plugin telemetry by default, and Oban's Stager fires **once per second** (`Elixir.Oban.Stager process`), plus Cron/Pruner/Lifeline every minute.
2. **Orphan Ecto query spans** — every query outside a request/job trace (oban_met sampling, peer election, thousands of queries inside card/deck-sync tasks) becomes its own root span, which Sentry promotes to a standalone transaction.

That exhausted the transaction quota same-day; Sentry now rate-limits the category and the SDK logs a warning per dropped envelope.

## Fix

Replace the blanket `traces_sample_rate: 1.0` with a `traces_sampler` (`Sanctum.Observability.traces_sampler/1`) that returns 0.0 for the two noise shapes and 1.0 for everything else. It's only consulted for **root** spans — children inherit the root's decision via trace state, so:

- dropping an Oban plugin tick also drops its child query spans
- Ecto spans inside request/LiveView/Oban-job traces are unaffected (still 100%)

The sampler approach was chosen over Sentry's exact-name `drop:` list because a `drop:`-listed parent returns empty trace state, orphaning its children into new root transactions.

## Notes

- Unit-tested (`test/sanctum/observability_test.exs`); `mix ck` + 175 tests green.
- The transaction quota may already be exhausted for this billing cycle — check Stats in the Sentry UI. Errors and logs are separate categories and should still flow. The warning spam stops once the SDK stops attempting the noise sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)