### PR TITLE
fix(observability): move traces_sampler to runtime config to unbreak deploy

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -29,8 +29,14 @@ config :sentry,
   in_app_otp_apps: [:sanctum],
   integrations: [oban: [capture_errors: true, cron: [enabled: true]]],
   enable_logs: true,
-  logs: [level: :info, metadata: [:request_id, :game_id, :user_id]],
-  traces_sampler: {Sanctum.Observability, :traces_sampler}
+  logs: [level: :info, metadata: [:request_id, :game_id, :user_id]]
+
+# :traces_sampler is configured in config/runtime.exs, NOT here: Sentry's
+# config validation checks the sampler function is exported, and during
+# `mix sentry.package_source_code` in the Docker build the app's modules are
+# compiled but not loaded, so a compile-time sampler fails the build. At
+# release boot (embedded mode) all modules load before apps start, so the
+# runtime-config check passes.
 
 # Route OTel spans into Sentry instead of an OTLP collector.
 config :opentelemetry,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -75,9 +75,14 @@ if config_env() == :prod do
   # SENTRY_DSN is set by `fly extensions sentry create`; with no DSN the SDK
   # sends nothing, so dev/test (which never reach this block) stay no-op.
   # FLY_IMAGE_REF is set per-deploy by Fly and doubles as the release tag.
+  # The sampler lives here rather than config/prod.exs so that
+  # `mix sentry.package_source_code` (Docker build) never sees it — its config
+  # validation requires the sampler module to be loaded, which only holds at
+  # release boot.
   config :sentry,
     dsn: System.get_env("SENTRY_DSN"),
-    release: System.get_env("FLY_IMAGE_REF")
+    release: System.get_env("FLY_IMAGE_REF"),
+    traces_sampler: {Sanctum.Observability, :traces_sampler}
 
   config :sanctum, SanctumWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],


### PR DESCRIPTION
## Problem

The deploy for #143 fails in the Docker build:

```
invalid value for :traces_sampler option: function Elixir.Sanctum.Observability.traces_sampler/1 is not exported
 > [builder 15/21] RUN mix sentry.package_source_code
```

Sentry's config validator checks a `{module, function}` sampler with `function_exported?/3` **without loading the module**. In the `mix sentry.package_source_code` task VM the app's modules are compiled but not loaded, so validation fails and the image build dies. Deterministic — retries fail identically (reproduced locally with `MIX_ENV=prod mix sentry.package_source_code`).

## Fix

Move the `traces_sampler` entry from `config/prod.exs` (compile-time, visible to the packaging task) into the prod block of `config/runtime.exs`. The packaging task now validates a config without the sampler; the release still gets it via the runtime config provider, and at release boot (embedded code loading) all modules are loaded before applications start, so the same validation passes there.

## Verification

- `MIX_ENV=prod mix sentry.package_source_code` — failed before, succeeds after (writes `sentry.map`)
- Built a full prod release locally and started `:sentry` inside it via `bin/sanctum eval` with a dummy DSN — config validates and `Sentry.Config.traces_sampler()` resolves to `{Sanctum.Observability, :traces_sampler}`; the sampler returns 0.0 for an Oban Stager tick
- `mix ck` clean, 175 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)