### PR TITLE
fix(observability): coerce span names to strings in traces_sampler

### DIFF
--- a/lib/sanctum/observability.ex
+++ b/lib/sanctum/observability.ex
@@ -21,6 +21,12 @@ defmodule Sanctum.Observability do
   Everything else (HTTP requests, LiveView, Oban jobs) is sampled at 100%.
   """
   def traces_sampler(%{transaction_context: %{name: name}}) do
+    # OTel span names are chardata, not necessarily binaries — e.g.
+    # opentelemetry_bandit names HTTP request spans with atoms (:GET, :HTTP).
+    # A crash here is worse than it looks: Sentry rescues sampler errors and
+    # samples the span at 0.0, silently dropping the trace.
+    name = to_string(name)
+
     oban_plugin_tick? =
       String.starts_with?(name, "Elixir.Oban.") and String.ends_with?(name, " process")
 

--- a/test/sanctum/observability_test.exs
+++ b/test/sanctum/observability_test.exs
@@ -24,5 +24,11 @@ defmodule Sanctum.ObservabilityTest do
       assert sample("process default") == 1.0
       assert sample("SanctumWeb.GameLive.Show.mount") == 1.0
     end
+
+    test "handles non-binary span names (opentelemetry_bandit uses atoms)" do
+      assert sample(:GET) == 1.0
+      assert sample(:HTTP) == 1.0
+      assert sample(~c"sanctum.repo.query:oban_jobs") == 0.0
+    end
   end
 end


### PR DESCRIPTION
## Problem

Prod logs after #145 deployed:

```
[warning] traces_sampler function failed: %FunctionClauseError{module: String, function: :starts_with?, arity: 2, ...}
```

`opentelemetry_bandit` names HTTP request root spans with **atoms** (`:GET`, `:POST`, `:HTTP` fallback), while the sampler assumed binaries. The real impact is worse than the warning: Sentry rescues sampler crashes and samples the span at **0.0**, so every HTTP request trace was being silently dropped. (Oban/Ecto noise spans have binary names, so their filtering kept working.)

## Fix

Coerce the span name with `to_string/1` (atoms and charlists → binaries; binaries pass through) before pattern-matching. Test added covering atom and charlist names.

## Verification

- 4/4 sampler unit tests pass (incl. new `:GET`/`:HTTP`/charlist cases), `mix ck` clean
- After deploy: the `traces_sampler function failed` warnings stop, and HTTP pageload/request transactions appear in Sentry Performance again

🤖 Generated with [Claude Code](https://claude.com/claude-code)