### PR TITLE
fix(deck-sync): treat MarvelCDB 500 as empty day when endpoint is healthy

### DIFF
--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -10,10 +10,15 @@ defmodule Sanctum.DeckSync do
 
   The cursor is checkpointed at the last day fetched *successfully* — a 404 (no
   decks that day) counts as success, but a transient fetch failure (timeout /
-  5xx / rate-limit) **halts the run** and leaves the cursor at the last good
-  day. `run/1` then returns `{:error, summary}` so the caller (the Oban worker)
-  can fail and retry, resuming from the checkpoint. This keeps a slow or flaky
-  MarvelCDB from silently skipping days.
+  rate-limit / a 5xx that reflects a real outage) **halts the run** and leaves
+  the cursor at the last good day. `run/1` then returns `{:error, summary}` so
+  the caller (the Oban worker) can fail and retry, resuming from the checkpoint.
+  This keeps a slow or flaky MarvelCDB from silently skipping days.
+
+  One wrinkle: MarvelCDB answers `by_date` for a day with no decklists with an
+  HTTP 500 rather than a 404. `sync_date/2` disambiguates that benign case from
+  a genuine outage by canary-probing the endpoint's health, so an empty day
+  doesn't wedge the walk (see `MarvelCdb.decklists_endpoint_healthy?/0`).
 
   Entry points: `mix sanctum.sync_decks` (manual/backfill) and
   `Sanctum.Decks.DecklistSyncWorker` (scheduled via Oban Cron).
@@ -25,12 +30,10 @@ defmodule Sanctum.DeckSync do
   alias Sanctum.MarvelCdb
 
   # MarvelCDB launched in late 2019; used as the backfill floor when no cursor
-  # exists and no `:since` is given. Floored at 2019-11-02 rather than 11-01
-  # because MarvelCDB's `/decklists/by_date/2019-11-01` endpoint permanently
-  # returns HTTP 500 (a server-side bug on that single earliest date). Since a
-  # 5xx halts the run to avoid skipping days, starting on 11-01 wedged the sync
-  # on day one forever; 11-01 holds no fetchable decks anyway.
-  @default_start_date ~D[2019-11-02]
+  # exists and no `:since` is given. (Empty early days that MarvelCDB answers
+  # with a 500 are handled in `sync_date/2`, so the floor no longer needs to
+  # dodge them.)
+  @default_start_date ~D[2019-11-01]
 
   # Re-scan this many days before the cursor each run, so decks published late
   # (or edited on) a day that was already synced still get picked up.
@@ -132,6 +135,27 @@ defmodule Sanctum.DeckSync do
         progress.({:date, %{date: date, imported: 0, failed: 0}})
         Process.sleep(@download_pause_ms)
         {:ok, 0, 0}
+
+      # MarvelCDB returns HTTP 500 (not 404) for dates with no decklists — a
+      # quirk scattered across historical days. Halting on every 500 wedges the
+      # backfill on the first empty day, so disambiguate: if the endpoint is
+      # otherwise healthy (a canary date still serves data), this 500 means "no
+      # decks that day" — treat it as an empty day and advance. Only a 500 that
+      # coincides with an unhealthy endpoint (a real outage) halts the run, so
+      # the cursor never skips days that actually have decks.
+      {:error, {:server_error, status}} ->
+        if MarvelCdb.decklists_endpoint_healthy?() do
+          Logger.info(
+            "Deck sync #{date}: MarvelCDB #{status}, endpoint healthy — treating as empty day"
+          )
+
+          progress.({:date, %{date: date, imported: 0, failed: 0}})
+          Process.sleep(@download_pause_ms)
+          {:ok, 0, 0}
+        else
+          progress.({:date_error, %{date: date, reason: {:server_error, status}}})
+          {:error, "Unexpected status code: #{status}"}
+        end
 
       {:error, reason} ->
         progress.({:date_error, %{date: date, reason: reason}})

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -32,6 +32,14 @@ defmodule Sanctum.MarvelCdb do
   # room to land before treating it as a transient failure.
   @decklist_receive_timeout_ms 20_000
 
+  # MarvelCDB's `/decklists/by_date/<date>` returns HTTP 500 (not 404) for dates
+  # with no decklists — a server-side quirk affecting scattered historical days.
+  # To tell that benign case apart from a real outage, `decklists_endpoint_healthy?/0`
+  # probes this canary: a busy day deep in an active period that reliably serves
+  # data. If the canary 200s the API is up and a date's 500 means "no decks"; if
+  # the canary also fails, MarvelCDB is actually down.
+  @decklists_health_check_date ~D[2024-01-01]
+
   @doc """
   Imports a single deck from a MarvelCDB URL or bare id.
 
@@ -356,15 +364,38 @@ defmodule Sanctum.MarvelCdb do
   Fetches every published decklist created on `date` (a `Date`), as full
   decklist payloads. This is the source for incremental deck sync.
   """
-  @spec get_decklists_by_date(Date.t()) :: {:ok, list(map())} | {:error, term()}
+  @spec get_decklists_by_date(Date.t()) ::
+          {:ok, list(map())}
+          | {:error, :not_found}
+          | {:error, {:server_error, pos_integer()}}
+          | {:error, term()}
   def get_decklists_by_date(%Date{} = date) do
     "#{@base_url}/decklists/by_date/#{Date.to_iso8601(date)}"
     |> Req.get(
       [retry: :transient, max_retries: 2, receive_timeout: @decklist_receive_timeout_ms] ++
         req_options()
     )
-    |> handle_response()
+    |> handle_decklist_response()
   end
+
+  @doc """
+  Cheap liveness probe for the by-date decklist endpoint. Fetches a canary date
+  known to have decklists; returns `true` only if MarvelCDB serves it. Used by
+  the deck sync to decide whether a per-date 500 means "no decks that day"
+  (endpoint healthy) or "MarvelCDB is down" (endpoint unhealthy).
+  """
+  @spec decklists_endpoint_healthy?() :: boolean()
+  def decklists_endpoint_healthy? do
+    match?({:ok, _}, get_decklists_by_date(@decklists_health_check_date))
+  end
+
+  # Like `handle_response/1`, but surfaces a 5xx as a distinct `{:server_error,
+  # status}` so the deck sync can canary-check API health rather than blindly
+  # treating every 500 as a hard failure (MarvelCDB 500s on empty-decklist days).
+  defp handle_decklist_response({:ok, %Req.Response{status: status}}) when status >= 500,
+    do: {:error, {:server_error, status}}
+
+  defp handle_decklist_response(response), do: handle_response(response)
 
   @doc "Fetches every card (player + encounter) as a single payload."
   @spec get_all_cards() :: {:ok, list(map())} | {:error, term()}

--- a/test/sanctum/deck_sync_test.exs
+++ b/test/sanctum/deck_sync_test.exs
@@ -25,8 +25,9 @@ defmodule Sanctum.DeckSyncTest do
   end
 
   # Stub the by-date endpoint, dispatching on the ISO date in the request path.
-  # Values: `{:ok, decks}` -> 200, `:not_found` -> 404, `:timeout` -> transport
-  # error. An un-mapped date flunks so we can assert a date was never fetched.
+  # Values: `{:ok, decks}` -> 200, `:not_found` -> 404, `:server_error` -> 500
+  # (MarvelCDB's empty-day quirk / outage signal), `:timeout` -> transport error.
+  # An un-mapped date flunks so we can assert a date was never fetched.
   defp stub_by_date(responses) do
     Req.Test.stub(Sanctum.MarvelCdb, fn conn ->
       date = conn.request_path |> String.split("/") |> List.last()
@@ -34,6 +35,7 @@ defmodule Sanctum.DeckSyncTest do
       case Map.fetch(responses, date) do
         {:ok, {:ok, decks}} -> Req.Test.json(conn, decks)
         {:ok, :not_found} -> conn |> Plug.Conn.put_status(404) |> Req.Test.json(%{})
+        {:ok, :server_error} -> conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{})
         {:ok, :timeout} -> Req.Test.transport_error(conn, :timeout)
         :error -> flunk("unexpected fetch for #{date}")
       end
@@ -79,6 +81,44 @@ defmodule Sanctum.DeckSyncTest do
     assert summary.processed == 3
     # Cursor advances past the empty (404) day.
     assert cursor() == ~D[2024-01-12]
+  end
+
+  test "treats a 500 as an empty day when the endpoint is otherwise healthy" do
+    set_cursor(~D[2024-01-09])
+
+    # 2024-01-01 is the canary the health probe fetches on each 500; serving it
+    # proves the endpoint is up, so the 500 on 2024-01-11 means "no decks".
+    stub_by_date(%{
+      "2024-01-01" => {:ok, []},
+      "2024-01-10" => {:ok, []},
+      "2024-01-11" => :server_error,
+      "2024-01-12" => {:ok, []}
+    })
+
+    assert {:ok, summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-12])
+    assert summary.halted == nil
+    assert summary.failed == 0
+    assert summary.processed == 3
+    # Cursor advances past the 500 (empty) day rather than wedging on it.
+    assert cursor() == ~D[2024-01-12]
+  end
+
+  test "halts on a 500 when the endpoint itself is unhealthy (real outage)" do
+    set_cursor(~D[2024-01-09])
+
+    # Canary also 500s → the endpoint is down, not just this date. 2024-01-12 is
+    # left unstubbed: reaching it would flunk, proving the walk halted.
+    stub_by_date(%{
+      "2024-01-01" => :server_error,
+      "2024-01-10" => {:ok, []},
+      "2024-01-11" => :server_error
+    })
+
+    assert {:error, summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-12])
+    assert summary.halted.date == ~D[2024-01-11]
+    assert summary.processed == 1
+    # Cursor stops at the last successfully-fetched day so the next run resumes.
+    assert cursor() == ~D[2024-01-10]
   end
 
   test "halts on a transient failure and checkpoints at the last good day" do


### PR DESCRIPTION
## Problem

Deck sync is still failing in prod, now halting on `2019-11-23` (three consecutive Oban attempts):

```
Oban.PerformError: Sanctum.Decks.DecklistSyncWorker failed with
{:error, "deck sync halted at 2019-11-23: \"Unexpected status code: 500\""}
```

PR #141 bumped the backfill floor past `2019-11-01`, but that was whack-a-mole. The real issue is systemic.

## Root cause

**MarvelCDB's `/api/public/decklists/by_date/<date>` returns HTTP 500 (not 404) for dates that have no decklists.** These empty days are scattered all through the game's early history — November 2019 alone has `11-01`, `11-23`, and `11-26`, confirmed directly against the live API (every other date returns 200).

The sync deliberately **halts on any 5xx** so it never silently skips a day during a real outage (`deck_sync.ex` moduledoc). But because these 500s are *permanent per-date*, the walk halts on the first empty day, never advances the cursor, and every scheduled run re-halts on the same day — wedged forever at `0 imported, 0 failed`.

## Fix

A raw 500 is ambiguous: usually "no decks that day", but possibly "MarvelCDB is down". Blindly skipping all 500s would reintroduce silent data loss during a genuine outage (the overlap window is only 1 day, so a skipped real-deck day is lost permanently).

So on a 500 we **canary-probe a known-active date** (`MarvelCdb.decklists_endpoint_healthy?/0`):

- **Canary returns 200** → endpoint is healthy → this date's 500 means "no decks" → treat it as an empty day (like a 404) and advance.
- **Canary also fails** → real outage → halt (unchanged behavior), so the cursor never skips days that actually have decks.

Changes:
- `MarvelCdb.get_decklists_by_date/1` surfaces 5xx as `{:error, {:server_error, status}}` (new `handle_decklist_response/1`) instead of a flat string; the generic `handle_response/1` used by card sync is untouched.
- Adds `MarvelCdb.decklists_endpoint_healthy?/0` (canary date `2024-01-01`).
- `DeckSync.sync_date/2` handles `{:server_error, _}` via the health check, logging skipped empty days.
- Reverts the stopgap `2019-11-02` floor back to `2019-11-01` — empty-day 500s are now handled generally.

Next scheduled worker run picks this up automatically (resumes from the checkpointed cursor) and walks the full history forward, skipping empty-day 500s instead of wedging.

## Test plan

- [x] `mix ck` (format + Credo + Sobelow) clean
- [x] `mix compile --warnings-as-errors` clean
- [x] New tests: 500-with-healthy-canary advances the cursor as an empty day; 500-with-unhealthy-canary halts and checkpoints at the last good day
- [x] `mix test test/sanctum/deck_sync_test.exs test/sanctum/marvel_cdb_test.exs` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)