### PR TITLE
feat(nav): replace header links with daisyUI drawer sidebar

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -51,6 +51,11 @@ const liveSocket = new LiveSocket("/live", Socket, {
   hooks: {...colocatedHooks, CardDrag, DragDrop, LayoutHand},
 })
 
+// Uncheck the daisyUI drawer toggle when a sidebar link is clicked, so the
+// mobile slideout closes across live navigation (checkbox state survives
+// LiveView DOM patches).
+window.addEventListener("sanctum:close-drawer", e => { e.target.checked = false })
+
 // Show progress bar on live navigation and form submits
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
 window.addEventListener("phx:page-loading-start", _info => topbar.show(300))

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -42,167 +42,116 @@ defmodule SanctumWeb.Layouts do
 
   def app(assigns) do
     ~H"""
-    <div class="relative min-h-screen bg-base-100 text-base-content font-barlow-condensed">
-      <div class="pointer-events-none fixed inset-0 z-0 bg-halftone"></div>
+    <div class="drawer min-h-screen bg-base-100 text-base-content font-barlow-condensed lg:drawer-open">
+      <input id="app-drawer" type="checkbox" class="drawer-toggle" />
 
-      <!-- sticky top bar -->
-      <header class="sticky top-0 z-30 border-b-[3px] border-neutral bg-base-100/90 backdrop-blur">
-        <div class="mx-auto flex max-w-[1480px] items-center gap-3 px-4 py-3.5 sm:gap-6 sm:px-6">
-          <a
-            href="/"
-            class="font-bangers text-[28px] leading-none tracking-wide text-primary sm:text-[34px]"
-          >
-            SANCTUM
-          </a>
-          <nav class="hidden h-[34px] items-end gap-5 sm:flex">
-            <.nav_tab navigate={~p"/browse"} active={@active_tab == :browse}>Browse</.nav_tab>
-            <.nav_tab navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.nav_tab>
-            <.nav_tab navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.nav_tab>
-            <.nav_tab navigate={~p"/flavor-town"} active={@active_tab == :guess}>
+      <div class="drawer-content relative min-h-screen">
+        <div class="pointer-events-none fixed inset-0 z-0 bg-halftone"></div>
+
+        <!-- slim top bar (mobile only) -->
+        <header class="sticky top-0 z-30 border-b-[3px] border-neutral bg-base-100/90 backdrop-blur lg:hidden">
+          <div class="flex items-center justify-between px-4 py-3.5">
+            <a href="/" class="font-bangers text-[28px] leading-none tracking-wide text-primary">
+              SANCTUM
+            </a>
+            <label
+              for="app-drawer"
+              class="drawer-button flex size-11 cursor-pointer items-center justify-center border-2 border-neutral bg-base-300 text-base-content"
+              aria-label="Open menu"
+            >
+              <.icon name="hero-bars-3" class="size-6" />
+            </label>
+          </div>
+        </header>
+
+        <main class="relative z-10 mx-auto max-w-[1480px] px-4 pb-24 pt-7 sm:px-6">
+          {render_slot(@inner_block)}
+        </main>
+      </div>
+
+      <!-- sidebar: fixed on lg+, slideout drawer below -->
+      <div class="drawer-side z-40">
+        <label for="app-drawer" aria-label="Close menu" class="drawer-overlay"></label>
+        <aside class="flex min-h-full w-[260px] max-w-[85vw] flex-col border-r-[3px] border-neutral bg-base-100 px-5 py-5 shadow-comic-lg lg:w-[200px] lg:px-4 lg:py-4 lg:shadow-none">
+          <div class="flex items-center justify-between border-b-2 border-neutral pb-4 lg:pb-3">
+            <a
+              href="/"
+              class="font-bangers text-[28px] leading-none tracking-wide text-primary lg:text-[24px]"
+            >
+              SANCTUM
+            </a>
+            <label
+              for="app-drawer"
+              class="flex size-11 cursor-pointer items-center justify-center border-2 border-neutral bg-base-300 text-base-content lg:hidden"
+              aria-label="Close menu"
+            >
+              <.icon name="hero-x-mark" class="size-6" />
+            </label>
+          </div>
+          <nav class="mt-6 flex flex-col gap-1.5 lg:mt-4 lg:gap-1">
+            <.sidebar_link navigate={~p"/browse"} active={@active_tab == :browse}>
+              Packs
+            </.sidebar_link>
+            <.sidebar_link navigate={~p"/cards"} active={@active_tab == :cards}>
+              Cards
+            </.sidebar_link>
+            <.sidebar_link navigate={~p"/decks"} active={@active_tab == :decks}>
+              Decks
+            </.sidebar_link>
+            <.sidebar_link navigate={~p"/flavor-town"} active={@active_tab == :guess}>
               Flavor Town
-            </.nav_tab>
-            <.nav_tab
+            </.sidebar_link>
+            <.sidebar_link
               :if={@current_user && @current_user.admin}
               navigate={~p"/admin"}
               active={@active_tab == :admin}
             >
               Admin
-            </.nav_tab>
+            </.sidebar_link>
           </nav>
-          <div class="ml-auto hidden items-center gap-4 sm:flex">
+          <div class="mt-auto flex items-center justify-between border-t-2 border-neutral pt-4">
             <span class="font-ibm-mono text-xs text-base-content/40">
               v{Application.spec(:sanctum, :vsn)}
             </span>
-            <.button :if={!@current_user} variant="primary" navigate={~p"/sign-in"}>Sign In</.button>
+            <.button
+              :if={!@current_user}
+              variant="primary"
+              navigate={~p"/sign-in"}
+              phx-click={close_drawer()}
+            >
+              Sign In
+            </.button>
           </div>
-
-          <!-- hamburger (mobile only) -->
-          <button
-            type="button"
-            class="ml-auto flex size-11 items-center justify-center border-2 border-neutral bg-base-300 text-base-content sm:hidden"
-            phx-click={open_drawer()}
-            aria-label="Open menu"
-          >
-            <.icon name="hero-bars-3" class="size-6" />
-          </button>
-        </div>
-      </header>
-
-      <!-- mobile slideout drawer -->
-      <div
-        id="mobile-nav-overlay"
-        class="fixed inset-0 z-40 hidden bg-black/70 sm:hidden"
-        phx-click={close_drawer()}
-        aria-hidden="true"
-      >
+        </aside>
       </div>
-      <div
-        id="mobile-nav-panel"
-        class="fixed inset-y-0 left-0 z-50 hidden w-[80%] max-w-[300px] translate-x-0 flex-col border-r-[3px] border-neutral bg-base-100 px-6 py-5 shadow-comic-lg sm:hidden"
-      >
-        <div class="flex items-center justify-between border-b-2 border-neutral pb-4">
-          <span class="font-bangers text-[28px] leading-none tracking-wide text-primary">
-            SANCTUM
-          </span>
-          <button
-            type="button"
-            class="flex size-11 items-center justify-center border-2 border-neutral bg-base-300 text-base-content"
-            phx-click={close_drawer()}
-            aria-label="Close menu"
-          >
-            <.icon name="hero-x-mark" class="size-6" />
-          </button>
-        </div>
-        <nav class="mt-6 flex flex-col gap-1">
-          <.drawer_link navigate={~p"/browse"} active={@active_tab == :browse}>Browse</.drawer_link>
-          <.drawer_link navigate={~p"/cards"} active={@active_tab == :cards}>Card Pool</.drawer_link>
-          <.drawer_link navigate={~p"/decks"} active={@active_tab == :decks}>Decks</.drawer_link>
-          <.drawer_link navigate={~p"/flavor-town"} active={@active_tab == :guess}>Flavor Town</.drawer_link>
-          <.drawer_link
-            :if={@current_user && @current_user.admin}
-            navigate={~p"/admin"}
-            active={@active_tab == :admin}
-          >
-            Admin
-          </.drawer_link>
-        </nav>
-        <div class="mt-auto flex items-center justify-between border-t-2 border-neutral pt-4">
-          <span class="font-ibm-mono text-xs text-base-content/40">
-            v{Application.spec(:sanctum, :vsn)}
-          </span>
-          <.button :if={!@current_user} variant="primary" navigate={~p"/sign-in"}>Sign In</.button>
-        </div>
-      </div>
-
-      <main class="relative z-10 mx-auto max-w-[1480px] px-4 pb-24 pt-7 sm:px-6">
-        {render_slot(@inner_block)}
-      </main>
     </div>
 
     <.flash_group flash={@flash} />
     """
   end
 
-  # Slide the mobile drawer + overlay in from the left.
-  defp open_drawer(js \\ %JS{}) do
-    js
-    |> JS.show(
-      to: "#mobile-nav-overlay",
-      transition: {"transition-opacity ease-out duration-200", "opacity-0", "opacity-100"}
-    )
-    |> JS.show(
-      to: "#mobile-nav-panel",
-      display: "flex",
-      transition:
-        {"transition-transform ease-out duration-200", "-translate-x-full", "translate-x-0"}
-    )
-  end
-
+  # Unchecks the daisyUI drawer toggle so the slideout closes after
+  # navigating on mobile (handled by a window listener in app.js).
   defp close_drawer(js \\ %JS{}) do
-    js
-    |> JS.hide(
-      to: "#mobile-nav-overlay",
-      transition: {"transition-opacity ease-in duration-150", "opacity-100", "opacity-0"}
-    )
-    |> JS.hide(
-      to: "#mobile-nav-panel",
-      transition:
-        {"transition-transform ease-in duration-150", "translate-x-0", "-translate-x-full"}
-    )
+    JS.dispatch(js, "sanctum:close-drawer", to: "#app-drawer")
   end
 
   attr :active, :boolean, default: false
   attr :rest, :global, include: ~w(href navigate patch)
   slot :inner_block, required: true
 
-  defp nav_tab(assigns) do
+  # Block-level nav link used inside the sidebar / slideout drawer. Inactive
+  # links are quiet text rows; the active one becomes a comic "caption box" —
+  # halftone cardstock, hard offset shadow, and a slight tilt.
+  defp sidebar_link(assigns) do
     ~H"""
     <.link
       class={[
-        "pb-[3px] text-[13px] font-bold uppercase tracking-[0.13em] transition-colors",
-        (@active && "border-b-[3px] border-primary text-primary") ||
-          "text-base-content/55 hover:text-white"
+        "border-2 px-3 py-2 font-barlow-condensed text-[15px] font-bold uppercase tracking-[0.1em] transition-colors lg:px-2.5 lg:py-1.5 lg:text-[13px]",
+        (@active && "-rotate-1 border-neutral bg-base-300 bg-halftone text-primary shadow-comic-sm") ||
+          "border-transparent text-base-content/55 hover:text-white"
       ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </.link>
-    """
-  end
-
-  attr :active, :boolean, default: false
-  attr :rest, :global, include: ~w(href navigate patch)
-  slot :inner_block, required: true
-
-  # Block-level nav link used inside the mobile slideout drawer.
-  defp drawer_link(assigns) do
-    ~H"""
-    <.link
-      class={[
-        "border-2 px-4 py-3 font-barlow-condensed text-[16px] font-bold uppercase tracking-[0.1em] transition-colors",
-        (@active && "border-transparent bg-primary text-primary-content") ||
-          "border-neutral bg-base-300 text-base-content hover:text-white"
-      ]}
+      phx-click={close_drawer()}
       {@rest}
     >
       {render_slot(@inner_block)}


### PR DESCRIPTION
## Summary

Moves primary navigation out of the top header into a daisyUI drawer:

- **Desktop (lg+)**: a fixed, condensed 200px sidebar (`lg:drawer-open`) with the logo, nav links, version stamp, and Sign In. Stays pinned while content scrolls; the content area gains a full card column on the browse grid.
- **Mobile**: collapses to a slim top bar (logo + hamburger) that opens a slideout drawer with roomier touch-friendly links.
- **Active link treatment**: instead of a solid primary slab, the active link is a comic "caption box" — halftone cardstock chip with a hard offset shadow (`shadow-comic-sm`), a slight tilt, and gold text. Inactive links are quiet text rows.
- One `sidebar_link` component serves both breakpoints, replacing `nav_tab`/`drawer_link` and the hand-rolled `JS.show`/`JS.hide` drawer plumbing.
- daisyUI's drawer is checkbox-driven and the checked state survives LiveView DOM patches, so sidebar links dispatch `sanctum:close-drawer` and a listener in `app.js` unchecks the toggle — the mobile drawer closes after live navigation.
- Renames nav labels: Browse → Packs, Card Pool → Cards.

> **Stacked on #128** (`feat/content-taxonomy-browse`) — the layout changes build on the browse nav-tab edits there. Retarget to `main` after #128 merges.

## Test plan

- [x] Desktop 1440px: sidebar fixed, stays pinned while scrolling, active caption-box state renders
- [x] Mobile 390px: hamburger opens drawer, tapping a link navigates and closes the drawer
- [x] `mix ck` (format + Credo + Sobelow) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)