### PR TITLE
fix(deck-sync): checkpoint cursor after each successful day

### DIFF
--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -8,12 +8,19 @@ defmodule Sanctum.DeckSync do
   run also re-scans a small trailing window to catch late-arriving decks before
   advancing the cursor.
 
-  The cursor is checkpointed at the last day fetched *successfully* — a 404 (no
-  decks that day) counts as success, but a transient fetch failure (timeout /
+  The cursor is checkpointed *after every day that succeeds* — a 404 (no decks
+  that day) counts as success, but a transient fetch failure (timeout /
   rate-limit / a 5xx that reflects a real outage) **halts the run** and leaves
   the cursor at the last good day. `run/1` then returns `{:error, summary}` so
   the caller (the Oban worker) can fail and retry, resuming from the checkpoint.
   This keeps a slow or flaky MarvelCDB from silently skipping days.
+
+  Checkpointing per day (rather than once at the end of the run) is what makes an
+  *abrupt* stop recoverable: an Oban timeout, a deploy restart, or an uncaught
+  crash bypasses any end-of-run bookkeeping, so a run that only persisted its
+  progress at the finish line would resume from where it *started*. Persisting
+  each successful day means a killed backfill resumes within one day of where it
+  died instead of re-walking years of history.
 
   One wrinkle: MarvelCDB answers `by_date` for a day with no decklists with an
   HTTP 500 rather than a 404. `sync_date/2` disambiguates that benign case from
@@ -68,19 +75,31 @@ defmodule Sanctum.DeckSync do
     dates = date_range(start_date, until)
     progress.({:started, %{from: start_date, to: until, days: length(dates)}})
 
-    initial = %{imported: 0, failed: 0, processed: 0, last_ok: nil, halted: nil}
+    initial = %{imported: 0, failed: 0, processed: 0, halted: nil}
+
+    # Snapshot the cursor once, up front. The worker's `unique` lock means no
+    # other run can move it underneath us, and days are walked in increasing
+    # order — so any day past this frontier is a genuine advance we checkpoint
+    # immediately, while a historical `--since` backfill of older days never
+    # rewinds it.
+    frontier = current_cursor()
 
     acc =
       Enum.reduce_while(dates, initial, fn date, acc ->
         case sync_date(date, progress) do
           {:ok, imported, failed} ->
+            # Persist the cursor the moment a day succeeds so an abrupt stop (an
+            # orphaned-then-rescued job, a deploy restart, an uncaught crash)
+            # resumes within a day of here instead of re-walking from the last
+            # completed run's checkpoint.
+            checkpoint_day(date, frontier)
+
             {:cont,
              %{
                acc
                | imported: acc.imported + imported,
                  failed: acc.failed + failed,
-                 processed: acc.processed + 1,
-                 last_ok: date
+                 processed: acc.processed + 1
              }}
 
           {:error, reason} ->
@@ -89,8 +108,6 @@ defmodule Sanctum.DeckSync do
             {:halt, %{acc | halted: %{date: date, reason: reason}}}
         end
       end)
-
-    checkpoint_cursor(acc.last_ok)
 
     summary = %{
       days: length(dates),
@@ -105,19 +122,15 @@ defmodule Sanctum.DeckSync do
     if acc.halted, do: {:error, summary}, else: {:ok, summary}
   end
 
-  # Advance the cursor to the last day we successfully fetched, but never rewind
-  # it: a halted run or a historical `--since` backfill of old dates must not
-  # drag the frontier backward. Nothing fetched (nil) leaves the cursor as-is.
-  defp checkpoint_cursor(nil), do: :ok
+  # Advance the cursor to a day we just fetched successfully, but never rewind
+  # it: a historical `--since` backfill of old dates (behind `frontier`) must not
+  # drag the frontier backward. `frontier` is the run-start cursor; a nil frontier
+  # means no cursor existed yet, so every synced day advances it.
+  defp checkpoint_day(%Date{} = date, frontier) do
+    if frontier == nil or Date.compare(date, frontier) == :gt do
+      {:ok, _state} = Decks.set_last_synced_date(date)
+    end
 
-  defp checkpoint_cursor(%Date{} = last_ok) do
-    advance? =
-      case current_cursor() do
-        %Date{} = cursor -> Date.compare(last_ok, cursor) == :gt
-        nil -> true
-      end
-
-    if advance?, do: {:ok, _state} = Decks.set_last_synced_date(last_ok)
     :ok
   end
 

--- a/test/sanctum/deck_sync_test.exs
+++ b/test/sanctum/deck_sync_test.exs
@@ -151,6 +151,25 @@ defmodule Sanctum.DeckSyncTest do
     assert cursor() == ~D[2024-01-11]
   end
 
+  test "checkpoints the cursor after each successful day, not just at the end" do
+    set_cursor(~D[2024-01-09])
+
+    # Assert the cursor is already at 2024-01-11 by the time 2024-01-12 is
+    # fetched — proving each day is persisted as it succeeds rather than in a
+    # single write once the whole run finishes. An abrupt stop after 2024-01-11
+    # would therefore still leave the cursor advanced.
+    Req.Test.stub(Sanctum.MarvelCdb, fn conn ->
+      date = conn.request_path |> String.split("/") |> List.last()
+
+      if date == "2024-01-12", do: assert(cursor() == ~D[2024-01-11])
+
+      Req.Test.json(conn, [])
+    end)
+
+    assert {:ok, _summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-12])
+    assert cursor() == ~D[2024-01-12]
+  end
+
   test "never rewinds the cursor on a historical backfill of older dates" do
     set_cursor(~D[2024-06-01])
 


### PR DESCRIPTION
## Problem

The decklist sync (`Sanctum.DeckSync.run/1`) persisted its cursor **only once**, after the entire day-walk finished. That covers a graceful `{:error, reason}` halt, but any *abrupt* stop bypasses the end-of-run write entirely:

- an Oban job orphaned by a Fly deploy restart and later rescued by `Oban.Plugins.Lifeline`, or
- an uncaught crash escaping the per-deck rescue.

In those cases the whole run's progress is discarded and the retry re-walks from the last *completed-run* checkpoint. On the initial multi-year backfill, that effectively starts over.

There is no per-job execution timeout (the worker's `timeout/1` defaults to `:infinity` and nothing overrides it), so the real interruption risk is process death, not a timeout — exactly the class that skips the end-of-run checkpoint.

## Change

Checkpoint the cursor the moment each day succeeds:

- Snapshot the cursor once at run start as `frontier`. The worker's `unique` lock means no concurrent run can move it underneath us.
- After each successful day, write the cursor when the day is past the `frontier`. Days are walked in increasing order, so this advances monotonically **and** never rewinds a historical `--since` backfill of older dates — no per-day DB read required.
- Drop the now-redundant end-of-run checkpoint and the unused `last_ok` accumulator.

A rescued/retried run now resumes within a day of where it died instead of re-walking years of history.

## Testing

- All existing deck-sync tests pass unchanged (halt/rewind/404/500 behavior is preserved).
- Added a test asserting the cursor is already advanced **mid-run** (before the final day is fetched) — which the old end-of-run write would have failed.
- `mix ck` clean (format, Credo, Sobelow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)