### PR TITLE
feat(observability): custom Sentry metrics via telemetry events

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -44,3 +44,8 @@ config :phoenix_live_view,
 # Spans only go to Sentry in prod; stop the OTLP exporter from retrying
 # a nonexistent localhost collector.
 config :opentelemetry, traces_exporter: :none
+
+# The metrics telemetry handler is attached in every env; keep tests from
+# buffering metrics in Sentry's TelemetryProcessor (nothing sends without a
+# DSN, but there's no reason to accumulate them either).
+config :sentry, enable_metrics: false

--- a/lib/sanctum/application.ex
+++ b/lib/sanctum/application.ex
@@ -8,6 +8,7 @@ defmodule Sanctum.Application do
   @impl true
   def start(_type, _args) do
     setup_opentelemetry()
+    Sanctum.Observability.attach_metrics_handlers()
 
     children = [
       SanctumWeb.Telemetry,

--- a/lib/sanctum/card_sync/server.ex
+++ b/lib/sanctum/card_sync/server.ex
@@ -65,6 +65,7 @@ defmodule Sanctum.CardSync.Server do
   def handle_info({ref, result}, %{task_ref: ref} = state) do
     Process.demonitor(ref, [:flush])
     sync = finish_sync(state.sync, result)
+    emit_run_metrics(sync)
     {:noreply, broadcast(%{state | task_ref: nil, sync: sync}, :force)}
   end
 
@@ -80,6 +81,7 @@ defmodule Sanctum.CardSync.Server do
         failures: add_failure(state.sync.failures, "sync crashed: #{inspect(reason)}")
     }
 
+    emit_run_metrics(sync)
     {:noreply, broadcast(%{state | task_ref: nil, sync: sync}, :force)}
   end
 
@@ -213,6 +215,30 @@ defmodule Sanctum.CardSync.Server do
   end
 
   defp add_failure(failures, message), do: Enum.take([message | failures], @max_failures_kept)
+
+  # One summary event per finished (or crashed) run, from the accumulated
+  # snapshot. Wall-clock duration is fine here — runs are minutes long.
+  defp emit_run_metrics(sync) do
+    duration_ms =
+      if sync.started_at && sync.finished_at do
+        DateTime.diff(sync.finished_at, sync.started_at, :millisecond)
+      else
+        0
+      end
+
+    :telemetry.execute(
+      [:sanctum, :card_sync, :run, :stop],
+      %{
+        duration_ms: duration_ms,
+        synced: sync.data.synced,
+        data_failed: sync.data.failed,
+        uploaded: sync.images.uploaded,
+        skipped: sync.images.skipped,
+        images_failed: sync.images.failed
+      },
+      %{status: sync.status}
+    )
+  end
 
   defp broadcast_mode({:card, _}), do: :throttled
   defp broadcast_mode({:image, _}), do: :throttled

--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -68,6 +68,7 @@ defmodule Sanctum.DeckSync do
   `%{date, reason}`.
   """
   def run(opts \\ []) do
+    started_at = System.monotonic_time(:millisecond)
     progress = Keyword.get(opts, :progress_fun, &log_progress/1)
     start_date = start_date(opts)
     until = Keyword.get(opts, :until, Date.utc_today())
@@ -119,6 +120,18 @@ defmodule Sanctum.DeckSync do
 
     progress.({:done, summary})
 
+    :telemetry.execute(
+      [:sanctum, :deck_sync, :run, :stop],
+      %{
+        duration_ms: System.monotonic_time(:millisecond) - started_at,
+        days: summary.days,
+        processed: summary.processed,
+        imported: summary.imported,
+        failed: summary.failed
+      },
+      %{halted: summary.halted}
+    )
+
     if acc.halted, do: {:error, summary}, else: {:ok, summary}
   end
 
@@ -160,6 +173,12 @@ defmodule Sanctum.DeckSync do
         if MarvelCdb.decklists_endpoint_healthy?() do
           Logger.info(
             "Deck sync #{date}: MarvelCDB #{status}, endpoint healthy — treating as empty day"
+          )
+
+          :telemetry.execute(
+            [:sanctum, :deck_sync, :empty_day],
+            %{count: 1},
+            %{date: date, status: status}
           )
 
           progress.({:date, %{date: date, imported: 0, failed: 0}})

--- a/lib/sanctum/decks/compute_uniqueness_worker.ex
+++ b/lib/sanctum/decks/compute_uniqueness_worker.ex
@@ -11,7 +11,19 @@ defmodule Sanctum.Decks.ComputeUniquenessWorker do
 
   @impl Oban.Worker
   def perform(_job) do
-    with {:ok, _summary} <- Sanctum.Decks.Uniqueness.recompute_all() do
+    started_at = System.monotonic_time(:millisecond)
+
+    with {:ok, %{decks: decks, ranked: ranked}} <- Sanctum.Decks.Uniqueness.recompute_all() do
+      :telemetry.execute(
+        [:sanctum, :uniqueness, :recompute, :stop],
+        %{
+          duration_ms: System.monotonic_time(:millisecond) - started_at,
+          decks: decks,
+          ranked: ranked
+        },
+        %{}
+      )
+
       :ok
     end
   end

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -66,13 +66,24 @@ defmodule Sanctum.MarvelCdb do
   defp fetch_and_import(mcdb_type, mcdb_deck_id) do
     endpoint = if mcdb_type == :deck, do: "deck", else: "decklist"
 
-    "#{@base_url}/#{endpoint}/#{mcdb_deck_id}"
-    |> Req.get([max_retries: 1] ++ req_options())
-    |> handle_response()
-    |> case do
-      {:ok, decklist} -> import_decklist(decklist, mcdb_type: mcdb_type)
-      err -> err
-    end
+    result =
+      "#{@base_url}/#{endpoint}/#{mcdb_deck_id}"
+      |> http_get(mcdb_type, max_retries: 1)
+      |> handle_response()
+      |> case do
+        {:ok, decklist} -> import_decklist(decklist, mcdb_type: mcdb_type)
+        err -> err
+      end
+
+    # load_deck/1 is only reached from user-initiated imports (game setup,
+    # admin) — the scheduled by-date sync calls import_decklist/2 directly.
+    :telemetry.execute(
+      [:sanctum, :deck, :user_import],
+      %{count: 1},
+      %{result: if(match?({:ok, _}, result), do: :ok, else: :error), mcdb_type: mcdb_type}
+    )
+
+    result
   end
 
   @doc """
@@ -363,7 +374,7 @@ defmodule Sanctum.MarvelCdb do
   @spec get_cards_by_pack(String.t()) :: {:ok, list(map())} | {:error, term()}
   def get_cards_by_pack(pack_code) when is_binary(pack_code) do
     "#{@base_url}/cards/#{pack_code}"
-    |> Req.get([max_retries: 1] ++ req_options())
+    |> http_get(:cards_by_pack, max_retries: 1)
     |> handle_response()
   end
 
@@ -378,9 +389,10 @@ defmodule Sanctum.MarvelCdb do
           | {:error, term()}
   def get_decklists_by_date(%Date{} = date) do
     "#{@base_url}/decklists/by_date/#{Date.to_iso8601(date)}"
-    |> Req.get(
-      [retry: :transient, max_retries: 2, receive_timeout: @decklist_receive_timeout_ms] ++
-        req_options()
+    |> http_get(:decklists_by_date,
+      retry: :transient,
+      max_retries: 2,
+      receive_timeout: @decklist_receive_timeout_ms
     )
     |> handle_decklist_response()
   end
@@ -408,7 +420,7 @@ defmodule Sanctum.MarvelCdb do
   @spec get_all_cards() :: {:ok, list(map())} | {:error, term()}
   def get_all_cards do
     "#{@base_url}/cards/?encounter=1"
-    |> Req.get([max_retries: 1] ++ req_options())
+    |> http_get(:all_cards, max_retries: 1)
     |> handle_response()
   end
 
@@ -416,7 +428,7 @@ defmodule Sanctum.MarvelCdb do
   @spec get_packs() :: {:ok, list(map())} | {:error, term()}
   def get_packs do
     "#{@base_url}/packs/"
-    |> Req.get([max_retries: 1] ++ req_options())
+    |> http_get(:packs, max_retries: 1)
     |> handle_response()
   end
 
@@ -553,7 +565,7 @@ defmodule Sanctum.MarvelCdb do
   # retry treats as transient — never retry single-card fetches.
   defp fetch_card(card_id) do
     "#{@base_url}/card/#{card_id}"
-    |> Req.get([retry: false] ++ req_options())
+    |> http_get(:card, retry: false)
     |> handle_response()
   end
 
@@ -1144,6 +1156,29 @@ defmodule Sanctum.MarvelCdb do
       {:ok, %Req.Response{status: status}} -> {:error, "Unexpected status code: #{status}"}
       {:error, exception} -> {:error, exception}
     end
+  end
+
+  # Every MarvelCDB request funnels through here so a single telemetry event
+  # covers per-endpoint request counts, status classes, and latency. The
+  # duration spans Req's internal retries; `status` is the final outcome
+  # (an HTTP status, or `:error` when no response came back at all).
+  defp http_get(url, endpoint, extra_opts) do
+    started_at = System.monotonic_time(:millisecond)
+    result = Req.get(url, extra_opts ++ req_options())
+
+    status =
+      case result do
+        {:ok, %Req.Response{status: status}} -> status
+        {:error, _} -> :error
+      end
+
+    :telemetry.execute(
+      [:sanctum, :marvel_cdb, :request, :stop],
+      %{duration_ms: System.monotonic_time(:millisecond) - started_at},
+      %{endpoint: endpoint, status: status}
+    )
+
+    result
   end
 
   defp req_options, do: Application.get_env(:sanctum, :marvel_cdb_req_options, [])

--- a/lib/sanctum/observability.ex
+++ b/lib/sanctum/observability.ex
@@ -1,7 +1,173 @@
 defmodule Sanctum.Observability do
   @moduledoc """
-  Sentry tracing hooks. See `traces_sampler/1`.
+  Sentry hooks: trace sampling (`traces_sampler/1`) and custom metrics.
+
+  Domain code stays Sentry-agnostic by emitting `:telemetry` events (either
+  directly or through the small emit helpers here); `handle_metric_event/4`
+  is the single place that translates them into `Sentry.Metrics` calls.
+  Attached at boot via `attach_metrics_handlers/0`.
   """
+
+  @metric_events [
+    [:sanctum, :deck_sync, :run, :stop],
+    [:sanctum, :deck_sync, :empty_day],
+    [:sanctum, :marvel_cdb, :request, :stop],
+    [:sanctum, :card_sync, :run, :stop],
+    [:sanctum, :uniqueness, :recompute, :stop],
+    [:sanctum, :deck, :user_import],
+    [:sanctum, :game, :created],
+    [:sanctum, :game, :action],
+    [:sanctum, :auth, :sign_in]
+  ]
+
+  @doc """
+  Attaches the Sentry-metrics forwarder for all `@metric_events`. Idempotent
+  per handler id; called once from `Sanctum.Application.start/2`. Safe in
+  every env — without a DSN (dev) Sentry sends nothing, and test disables
+  metrics via `:enable_metrics`.
+  """
+  def attach_metrics_handlers do
+    :telemetry.attach_many(
+      "sanctum-sentry-metrics",
+      @metric_events,
+      &__MODULE__.handle_metric_event/4,
+      :ok
+    )
+  end
+
+  ## Emit helpers (for call sites where an inline :telemetry.execute would
+  ## drown the surrounding code, i.e. LiveView event handlers).
+
+  @doc "Counts a created game."
+  def game_created do
+    :telemetry.execute([:sanctum, :game, :created], %{count: 1}, %{})
+  end
+
+  @doc """
+  Counts a discrete in-game user action (`:draw`, `:move`, `:flip_card`, …).
+  `count` is the batch size (cards drawn/dealt), so sums stay meaningful.
+  """
+  def game_action(action, count \\ 1) when is_atom(action) do
+    :telemetry.execute([:sanctum, :game, :action], %{count: count}, %{action: action})
+  end
+
+  @doc "Counts a successful sign-in (AshAuthentication `activity` tuple)."
+  def auth_success(activity) do
+    :telemetry.execute(
+      [:sanctum, :auth, :sign_in],
+      %{count: 1},
+      %{result: :success, activity: activity, reason: nil}
+    )
+  end
+
+  @doc "Counts a failed sign-in with a compact `reason` tag."
+  def auth_failure(activity, reason) do
+    :telemetry.execute(
+      [:sanctum, :auth, :sign_in],
+      %{count: 1},
+      %{result: :failure, activity: activity, reason: reason}
+    )
+  end
+
+  ## Telemetry -> Sentry.Metrics
+
+  @doc false
+  def handle_metric_event([:sanctum, :deck_sync, :run, :stop], m, meta, :ok) do
+    Sentry.Metrics.distribution("deck_sync.run.duration", m.duration_ms, unit: "millisecond")
+    count_nonzero("deck_sync.days_processed", m.processed, "day")
+    count_nonzero("deck_sync.decks_imported", m.imported, "deck")
+    count_nonzero("deck_sync.decks_failed", m.failed, "deck")
+
+    case meta.halted do
+      %{date: date, reason: reason} ->
+        Sentry.Metrics.count("deck_sync.halted", 1,
+          attributes: %{date: to_string(date), reason: safe_string(reason)}
+        )
+
+      nil ->
+        :ok
+    end
+  end
+
+  def handle_metric_event([:sanctum, :deck_sync, :empty_day], m, meta, :ok) do
+    Sentry.Metrics.count("deck_sync.empty_day_reclassified", m.count,
+      attributes: %{date: to_string(meta.date), status: to_string(meta.status)}
+    )
+  end
+
+  def handle_metric_event([:sanctum, :marvel_cdb, :request, :stop], m, meta, :ok) do
+    endpoint = to_string(meta.endpoint)
+
+    Sentry.Metrics.count("marvelcdb.request", 1,
+      attributes: %{
+        endpoint: endpoint,
+        status: to_string(meta.status),
+        status_class: status_class(meta.status)
+      }
+    )
+
+    Sentry.Metrics.distribution("marvelcdb.request.duration", m.duration_ms,
+      unit: "millisecond",
+      attributes: %{endpoint: endpoint}
+    )
+  end
+
+  def handle_metric_event([:sanctum, :card_sync, :run, :stop], m, meta, :ok) do
+    Sentry.Metrics.distribution("card_sync.run.duration", m.duration_ms,
+      unit: "millisecond",
+      attributes: %{status: to_string(meta.status)}
+    )
+
+    count_nonzero("card_sync.cards_synced", m.synced, "card")
+    count_nonzero("card_sync.cards_failed", m.data_failed, "card")
+    count_nonzero("card_sync.images_uploaded", m.uploaded, "image")
+    count_nonzero("card_sync.images_skipped", m.skipped, "image")
+    count_nonzero("card_sync.images_failed", m.images_failed, "image")
+  end
+
+  def handle_metric_event([:sanctum, :uniqueness, :recompute, :stop], m, _meta, :ok) do
+    Sentry.Metrics.distribution("uniqueness.recompute.duration", m.duration_ms,
+      unit: "millisecond"
+    )
+
+    Sentry.Metrics.gauge("uniqueness.decks", m.decks, unit: "deck")
+    Sentry.Metrics.gauge("uniqueness.decks_ranked", m.ranked, unit: "deck")
+  end
+
+  def handle_metric_event([:sanctum, :deck, :user_import], m, meta, :ok) do
+    Sentry.Metrics.count("deck.user_import", m.count,
+      attributes: %{result: to_string(meta.result), mcdb_type: to_string(meta.mcdb_type)}
+    )
+  end
+
+  def handle_metric_event([:sanctum, :game, :created], m, _meta, :ok) do
+    Sentry.Metrics.count("game.created", m.count, unit: "game")
+  end
+
+  def handle_metric_event([:sanctum, :game, :action], m, meta, :ok) do
+    Sentry.Metrics.count("game.action", m.count, attributes: %{action: to_string(meta.action)})
+  end
+
+  def handle_metric_event([:sanctum, :auth, :sign_in], m, meta, :ok) do
+    attributes = %{result: to_string(meta.result), activity: safe_string(meta.activity)}
+
+    attributes =
+      if meta.reason, do: Map.put(attributes, :reason, to_string(meta.reason)), else: attributes
+
+    Sentry.Metrics.count("auth.sign_in", m.count, attributes: attributes)
+  end
+
+  # A zero-valued counter is pure noise (counters aggregate by sum) — only the
+  # nonzero occurrences carry signal, and absence reads correctly as zero.
+  defp count_nonzero(_name, 0, _unit), do: :ok
+  defp count_nonzero(name, value, unit), do: Sentry.Metrics.count(name, value, unit: unit)
+
+  defp status_class(status) when is_integer(status), do: "#{div(status, 100)}xx"
+  defp status_class(_other), do: "error"
+
+  defp safe_string(value) when is_binary(value), do: value
+  defp safe_string(value) when is_atom(value), do: to_string(value)
+  defp safe_string(value), do: inspect(value)
 
   @doc """
   Root-span sampling decision for Sentry tracing (`:traces_sampler` in

--- a/lib/sanctum_web/controllers/auth_controller.ex
+++ b/lib/sanctum_web/controllers/auth_controller.ex
@@ -3,6 +3,7 @@ defmodule SanctumWeb.AuthController do
   use AshAuthentication.Phoenix.Controller
 
   def success(conn, activity, user, _token) do
+    Sanctum.Observability.auth_success(activity)
     return_to = get_session(conn, :return_to) || ~p"/"
 
     message =
@@ -22,7 +23,7 @@ defmodule SanctumWeb.AuthController do
   end
 
   def failure(conn, activity, reason) do
-    message =
+    {message, reason_tag} =
       case {activity, reason} do
         {_,
          %AshAuthentication.Errors.AuthenticationFailed{
@@ -30,14 +31,16 @@ defmodule SanctumWeb.AuthController do
              errors: [%AshAuthentication.Errors.CannotConfirmUnconfirmedUser{}]
            }
          }} ->
-          """
-          You have already signed in another way, but have not confirmed your account.
-          You can confirm your account using the link we sent to you, or by resetting your password.
-          """
+          {"""
+           You have already signed in another way, but have not confirmed your account.
+           You can confirm your account using the link we sent to you, or by resetting your password.
+           """, :unconfirmed_user}
 
         _ ->
-          "Incorrect email or password"
+          {"Incorrect email or password", :invalid_credentials}
       end
+
+    Sanctum.Observability.auth_failure(activity, reason_tag)
 
     conn
     |> put_flash(:error, message)

--- a/lib/sanctum_web/live/game_live/new.ex
+++ b/lib/sanctum_web/live/game_live/new.ex
@@ -20,6 +20,7 @@ defmodule SanctumWeb.GameLive.New do
 
     case Games.create_game(game_params, actor: current_user) do
       {:ok, game} ->
+        Sanctum.Observability.game_created()
         {:noreply, push_navigate(socket, to: ~p"/games/#{game.id}")}
 
       {:error, changeset} ->

--- a/lib/sanctum_web/live/game_live/show.ex
+++ b/lib/sanctum_web/live/game_live/show.ex
@@ -10,6 +10,7 @@ defmodule SanctumWeb.GameLive.Show do
   alias Sanctum.Games.GamePlayer
   alias Sanctum.Games
   alias Sanctum.Games.Game
+  alias Sanctum.Observability
   alias SanctumWeb.Components.Card
 
   on_mount {SanctumWeb.LiveUserAuth, :live_user_required}
@@ -109,6 +110,8 @@ defmodule SanctumWeb.GameLive.Show do
         actor: user
       )
 
+    Observability.game_action(:move)
+
     # Remove from source stream
     socket =
       case source_zone do
@@ -172,6 +175,8 @@ defmodule SanctumWeb.GameLive.Show do
         actor: socket.assigns.current_user
       )
 
+    Observability.game_action(:deal_encounter, length(cards))
+
     {:noreply, stream(socket, :facedown_encounters, cards)}
   end
 
@@ -179,6 +184,7 @@ defmodule SanctumWeb.GameLive.Show do
     game_player = socket.assigns.game_player
 
     Games.draw_cards(game_player.id, 1, actor: socket.assigns.current_user)
+    Observability.game_action(:draw)
 
     {:noreply,
      socket
@@ -195,6 +201,7 @@ defmodule SanctumWeb.GameLive.Show do
 
     if count > 0 do
       Games.draw_cards(game_player.id, count, actor: socket.assigns.current_user)
+      Observability.game_action(:draw, count)
 
       {:noreply,
        socket
@@ -210,6 +217,7 @@ defmodule SanctumWeb.GameLive.Show do
     game_player = socket.assigns.game_player
 
     Games.flip_identity(game_player)
+    Observability.game_action(:flip_identity)
 
     {:noreply, socket |> assign_game_player() |> assign_hand_sizes()}
   end
@@ -219,6 +227,7 @@ defmodule SanctumWeb.GameLive.Show do
     amount = String.to_integer(amount_str)
 
     Games.change_health(game_player, %{amount: amount}, actor: socket.assigns.current_user)
+    Observability.game_action(:change_health)
 
     {:noreply, socket |> assign_game_player()}
   end
@@ -231,6 +240,8 @@ defmodule SanctumWeb.GameLive.Show do
       actor: socket.assigns.current_user
     )
 
+    Observability.game_action(:change_villain_health)
+
     {:noreply, socket |> assign_game()}
   end
 
@@ -241,6 +252,8 @@ defmodule SanctumWeb.GameLive.Show do
         actor: socket.assigns.current_user
       )
       |> Games.flip_card()
+
+    Observability.game_action(:flip_card)
 
     zone =
       case card.zone do
@@ -282,6 +295,8 @@ defmodule SanctumWeb.GameLive.Show do
       |> Ash.Changeset.for_update(:update_counters, args)
       |> Ash.update!(actor: socket.assigns.current_user)
 
+    Observability.game_action(:update_counters)
+
     socket = maybe_update_selected_card(socket, card)
 
     zone =
@@ -299,6 +314,7 @@ defmodule SanctumWeb.GameLive.Show do
         %{"delta" => delta, "game_card_id" => game_card_id},
         socket
       ) do
+    Observability.game_action(:update_scheme_counters)
     {:noreply, update_scheme_counters(socket, game_card_id, %{threat_delta: delta})}
   end
 
@@ -307,6 +323,7 @@ defmodule SanctumWeb.GameLive.Show do
         %{"delta" => delta, "game_card_id" => game_card_id},
         socket
       ) do
+    Observability.game_action(:update_scheme_counters)
     {:noreply, update_scheme_counters(socket, game_card_id, %{counter_delta: delta})}
   end
 
@@ -314,6 +331,8 @@ defmodule SanctumWeb.GameLive.Show do
     {:ok, scheme} =
       Games.get_game_card!(game_card_id, actor: socket.assigns.current_user)
       |> Games.flip_scheme_card(load: [:active_side], actor: socket.assigns.current_user)
+
+    Observability.game_action(:flip_scheme)
 
     socket =
       socket


### PR DESCRIPTION
## Summary

Adds product/ops metrics on the flows that matter, keeping domain code Sentry-agnostic: modules emit `:telemetry` events and a single handler in `Sanctum.Observability` (attached at boot) forwards them to `Sentry.Metrics`.

- **Deck sync** — run summary (days/imported/failed + duration distribution), halt events tagged with date/reason, and canary empty-day reclassification counts (follows up on #149's canary probe).
- **MarvelCDB HTTP** — all `Req` call sites funnel through a new `http_get/3`, emitting per-endpoint request counts (tagged with status + status class) and latency distributions. Single external dependency → single degraded-dependency signal.
- **Card sync** — one run-summary event (cards synced/failed, images uploaded/skipped/failed + duration) from `CardSync.Server`, on both task finish and crash.
- **Uniqueness recompute** — decks/ranked gauges + duration (the worker previously discarded `recompute_all`'s summary).
- **User deck imports** — success/failure counter on the `load_deck/1` path only (the scheduled by-date sync bypasses it), tagged by mcdb_type.
- **Games** — `game.created` counter plus a `game.action` counter tagged by action (`draw`, `move`, `flip_card`, …) with batch-size values for draws/deals.
- **Auth** — `auth.sign_in` counter tagged result/activity, with a compact failure reason (`unconfirmed_user` / `invalid_credentials`).

## Design notes

- Domain code emits plain telemetry; only the Observability handler knows about Sentry. Events are also consumable by LiveDashboard later.
- Zero-valued counters are skipped — counters aggregate by sum, so absence reads correctly as zero and the nonzero occurrences carry the signal.
- `deck_sync.decks_imported` counts upserts; it does not distinguish created from updated.
- Test env sets `enable_metrics: false` so nothing buffers in Sentry's TelemetryProcessor during tests; dev has no DSN so nothing sends.

## Testing

- `mix ck` clean, 179 tests passing.
- Booted the app and fired every event shape (halted-run tuple reasons, `:error` HTTP status, tuple auth activities) through the live handler — telemetry silently detaches a crashing handler, and it survived all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)