### PR TITLE
fix(decks): stop similar-decks titles forcing horizontal scroll on mobile

### DIFF
--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -101,7 +101,7 @@ defmodule SanctumWeb.DeckLive.Show do
 
         <!-- body: writeup + card list -->
         <div class="grid items-start gap-5 lg:grid-cols-[1.4fr_1fr]">
-          <.panel class="p-5">
+          <.panel class="min-w-0 p-5">
             <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
               Deck Notes
             </div>
@@ -113,7 +113,7 @@ defmodule SanctumWeb.DeckLive.Show do
             </div>
           </.panel>
 
-          <div class="space-y-5">
+          <div class="min-w-0 space-y-5">
             <.panel class="p-4">
               <div class="mb-3 flex items-baseline gap-2 border-b-2 border-neutral pb-2">
                 <div class="font-anton text-[17px] uppercase tracking-[0.05em]">In This Deck</div>


### PR DESCRIPTION
## Summary

On mobile, the deck view page scrolled horizontally (411px of content in a 390px viewport). The cause: similar-deck tile titles use `truncate` (`white-space: nowrap`), which makes each tile's intrinsic min-content width the full one-line title. Since CSS grid children default to `min-width: auto`, that width propagated up through the sidebar and stretched the body grid past the viewport — so `truncate` never actually clipped anything.

Fix: add `min-w-0` to both children of the deck-show body grid (the writeup panel and the sidebar column) so the track can shrink to the viewport and the existing `truncate`/`flex-wrap` guards take effect. The writeup panel is included because it carries the same latent risk with wide writeup content.

## Verification

Reproduced and verified live against the dev server with playwright:
- Before: `document.documentElement.scrollWidth` = 411 at a 390px viewport; hiding only the Similar Decks panel removed the overflow.
- After: no horizontal overflow at 320px or 390px; long titles ellipsize correctly.
- Desktop unchanged: 1.4fr/1fr two-column layout intact at 1440px, no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)