### PR TITLE
feat(oban): reset orphaned executing jobs on boot

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,8 +17,11 @@ config :sanctum, Oban,
   plugins: [
     # Prune old completed/discarded jobs so the table doesn't grow unbounded.
     Oban.Plugins.Pruner,
-    # Rescue jobs orphaned in the `executing` state (e.g. a hard node kill during
-    # a Fly restart) back to `available` so they run again instead of hanging.
+    # Backstop for jobs orphaned in the `executing` state. The fast path is
+    # `Sanctum.Oban.BootRescue`, which resets orphans on the next boot; Lifeline
+    # only covers the (single-node) case of a node that stays up but somehow
+    # dropped a job. `rescue_after` stays high so it never clobbers a genuinely
+    # long-running job (it rescues purely on elapsed time, not liveness).
     {Oban.Plugins.Lifeline, rescue_after: :timer.hours(24)},
     {Oban.Plugins.Cron,
      crontab: [

--- a/lib/sanctum/application.ex
+++ b/lib/sanctum/application.ex
@@ -14,6 +14,9 @@ defmodule Sanctum.Application do
       SanctumWeb.Telemetry,
       Sanctum.Repo,
       {DNSCluster, query: Application.get_env(:sanctum, :dns_cluster_query) || :ignore},
+      # Must precede Oban: resets jobs orphaned `executing` by the prior boot
+      # before any queue starts producing (see Sanctum.Oban.BootRescue).
+      Sanctum.Oban.BootRescue,
       {Oban,
        AshOban.config(
          Application.fetch_env!(:sanctum, :ash_domains),

--- a/lib/sanctum/oban/boot_rescue.ex
+++ b/lib/sanctum/oban/boot_rescue.ex
@@ -1,0 +1,90 @@
+defmodule Sanctum.Oban.BootRescue do
+  @moduledoc """
+  Resets Oban jobs orphaned in the `executing` state by a previous, now-dead
+  node back to `available` at application boot.
+
+  ## Why
+
+  When a Fly machine restarts (redeploy, crash, OOM, or a `Sanctum.AutoShutdown`
+  self-stop followed by autostart), any job the old node was running is abandoned
+  mid-flight and left stuck in `executing`. `Oban.Plugins.Lifeline` eventually
+  rescues these, but purely on a timer (`rescue_after`) — we keep that high (24h)
+  so it never clobbers a genuinely long-running job, which makes it useless as a
+  *fast* recovery path.
+
+  Sanctum runs a **single** Oban node (Fly scale-to-zero: `auto_stop_machines =
+  "off"`, one machine, self-stop when idle). That makes recovery trivial: on
+  boot, nothing else can possibly be running a job, so *every* `executing` row is
+  a corpse from the prior boot and is safe to reset immediately — no
+  node/producer matching required. (Node names embed the image ref and private IP
+  and change across deploys anyway, so matching would be unreliable.)
+
+  This child is placed **before** the `Oban` child in the supervision tree so the
+  reset lands before any queue starts producing — otherwise it could reset a job
+  the fresh node just picked up. It runs its work synchronously in `run/0` and
+  returns `:ignore`, so no long-lived process remains.
+
+  Mirrors Lifeline / Basic-engine semantics: attempts remaining → `available`;
+  attempts exhausted → `discarded`.
+
+  > #### Single-node assumption {: .warning}
+  >
+  > This blanket reset is only safe because there is exactly one live Oban node.
+  > If Sanctum ever runs multiple Oban nodes, replace this with producer-aware
+  > rescuing (Oban Pro's `DynamicLifeline`) or it will clobber peers' live jobs.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  @doc false
+  def child_spec(_opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :run, []},
+      type: :worker,
+      restart: :temporary
+    }
+  end
+
+  @doc false
+  def run do
+    # Skipped in test: the app boots outside any Ecto sandbox ownership, so a
+    # boot-time write would fail. Tests exercise `rescue_orphans/0` directly.
+    if Application.get_env(:sanctum, :env) != :test do
+      rescue_orphans()
+    end
+
+    :ignore
+  end
+
+  @doc """
+  Resets every job stuck in `executing` back to `available` (or `discarded` when
+  its attempts are exhausted). Returns `{rescued_count, discarded_count}`.
+  """
+  @spec rescue_orphans() :: {non_neg_integer(), non_neg_integer()}
+  def rescue_orphans do
+    now = DateTime.utc_now()
+    base = where(Oban.Job, [j], j.state == "executing")
+
+    {rescued, _} =
+      base
+      |> where([j], j.attempt < j.max_attempts)
+      |> Sanctum.Repo.update_all(set: [state: "available"])
+
+    {discarded, _} =
+      base
+      |> where([j], j.attempt >= j.max_attempts)
+      |> Sanctum.Repo.update_all(set: [state: "discarded", discarded_at: now])
+
+    if rescued > 0 or discarded > 0 do
+      Logger.info(
+        "[Oban.BootRescue] reset orphaned executing jobs: " <>
+          "#{rescued} → available, #{discarded} → discarded"
+      )
+    end
+
+    {rescued, discarded}
+  end
+end

--- a/test/sanctum/oban/boot_rescue_test.exs
+++ b/test/sanctum/oban/boot_rescue_test.exs
@@ -1,0 +1,54 @@
+defmodule Sanctum.Oban.BootRescueTest do
+  use Sanctum.DataCase, async: true
+
+  alias Sanctum.Oban.BootRescue
+
+  defp insert_job(attrs) do
+    defaults = %{worker: "Sanctum.FakeWorker", queue: "default", args: %{}, max_attempts: 3}
+
+    %Oban.Job{}
+    |> Ecto.Changeset.change(Map.merge(defaults, attrs))
+    |> Repo.insert!()
+  end
+
+  defp reload(job), do: Repo.get!(Oban.Job, job.id)
+
+  test "moves an orphaned executing job with attempts remaining back to available" do
+    job = insert_job(%{state: "executing", attempt: 1, attempted_at: DateTime.utc_now()})
+
+    assert {1, 0} = BootRescue.rescue_orphans()
+    assert reload(job).state == "available"
+  end
+
+  test "discards an orphaned executing job that has exhausted its attempts" do
+    job =
+      insert_job(%{
+        state: "executing",
+        attempt: 3,
+        max_attempts: 3,
+        attempted_at: DateTime.utc_now()
+      })
+
+    assert {0, 1} = BootRescue.rescue_orphans()
+
+    reloaded = reload(job)
+    assert reloaded.state == "discarded"
+    assert reloaded.discarded_at
+  end
+
+  test "leaves jobs in non-executing states untouched" do
+    available = insert_job(%{state: "available"})
+    scheduled = insert_job(%{state: "scheduled", scheduled_at: DateTime.utc_now()})
+    completed = insert_job(%{state: "completed", completed_at: DateTime.utc_now()})
+
+    assert {0, 0} = BootRescue.rescue_orphans()
+
+    assert reload(available).state == "available"
+    assert reload(scheduled).state == "scheduled"
+    assert reload(completed).state == "completed"
+  end
+
+  test "returns zero counts when nothing is executing" do
+    assert {0, 0} = BootRescue.rescue_orphans()
+  end
+end


### PR DESCRIPTION
## Problem

When a Fly machine restarts — redeploy, crash, OOM, or a `Sanctum.AutoShutdown` self-stop followed by autostart — any Oban job the dead node was running is abandoned mid-flight and left stuck in `executing`. `Oban.Plugins.Lifeline` rescues these, but purely on a timer (`rescue_after`), and we keep that at **24h** so it never clobbers a genuinely long-running job. That made real recovery from a restart effectively 24 hours.

## Approach

Add `Sanctum.Oban.BootRescue`: a one-shot supervision child, slotted **before** the `Oban` child so it runs before any queue starts producing, that resets every `executing` job to `available` (or `discarded` when its attempts are exhausted, mirroring `Oban.Engines.Basic` semantics).

This blanket reset is safe **because Sanctum runs a single Oban node** (Fly scale-to-zero: `auto_stop_machines = "off"`, one machine, self-stop when idle). On boot, nothing else can be running a job, so any `executing` row is a corpse from the prior boot — no node/producer matching needed. (Node names embed the image ref + private IP and change across deploys, so matching would be unreliable anyway.) A `.warning` admonition in the moduledoc flags that this must be replaced with producer-aware rescuing — Oban Pro's `DynamicLifeline` — if Sanctum ever runs multiple Oban nodes.

Lifeline stays as a backstop at `rescue_after: 24h`; `BootRescue` is now the fast path.

## Changes

- `lib/sanctum/oban/boot_rescue.ex` — new module.
- `lib/sanctum/application.ex` — wire the child in immediately before `{Oban, ...}`.
- `config/config.exs` — document Lifeline's new backstop role.
- `test/sanctum/oban/boot_rescue_test.exs` — 4 tests (available / discarded / other-states-untouched / zero-counts). Skipped at boot in `:test`; `rescue_orphans/0` is exercised directly.

## Verification

- `mix test` on the new file: 4/4 pass.
- `mix compile --warnings-as-errors` clean; `mix credo` clean.
- Booted the dev app: confirmed both resets run at startup **before** Oban and the supervisor comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)