### PR TITLE
fix(heroes): resolve hero_side has_one deterministically for dual-form heroes

### DIFF
--- a/lib/sanctum/heroes/hero.ex
+++ b/lib/sanctum/heroes/hero.ex
@@ -61,10 +61,15 @@ defmodule Sanctum.Heroes.Hero do
       allow_nil? false
     end
 
+    # Size-changing heroes (Ant-Man, Wasp, Angel/Archangel) have two `:hero`
+    # sides — a primary form and an alternate form. Sort primary-first so this
+    # `has_one` resolves deterministically to the canonical hero side (and to
+    # satisfy Ash's `from_many?`/`sort` requirement for multi-match has_one).
     has_one :hero_side, Sanctum.Games.CardSide do
       source_attribute :card_id
       destination_attribute :card_id
       filter expr(type == :hero)
+      sort is_primary_side: :desc
     end
 
     has_one :alter_ego_side, Sanctum.Games.CardSide do


### PR DESCRIPTION
## Problem

Loading `Sanctum.Heroes.Hero.hero_side` intermittently logged:

```
[warning] Got more than one result while loading relationship `Sanctum.Heroes.Hero.hero_side`.
```

**Root cause:** the size/form-changing heroes — **Ant-Man** (`12001`), **Wasp** (`13001`), and **Angel/Archangel** (`42001`) — are modeled in MarvelCDB with **two `:hero`-type card sides** (a primary form and an alternate form). `hero_side` is a `has_one` filtered on `type == :hero` with no `sort`/`from_many?`, so for those three heroes it matched two rows and Ash had no deterministic pick — triggering the warning (a future hard error). It reproduces any time one of those heroes is loaded with `:hero_side` (deck show/index, uniqueness computation, `set_health`, etc.).

## Fix

Add `sort is_primary_side: :desc` to the `hero_side` relationship. This resolves it deterministically to the canonical (primary, side `a`) hero form and, per Ash's own guidance, implicitly sets `from_many? true` — satisfying the requirement and silencing the warning.

## Notes

- No migration needed — relationships aren't part of the data-layer schema.
- Health is identical across both forms for all three heroes, so starting-HP behavior (`set_health`) is unchanged; the pick is simply now deterministic (and correct — primary form) for stats/hand-size/image.
- `alter_ego_side` is left as-is: those heroes have a single `:alter_ego` side, so it never matches more than one.

Verified in dev: after the change, loading Wasp (`13001`) with `:hero_side` returns `13001a` (`is_primary_side: true`) with no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)