### PR TITLE
fix(sync): demote 'Not loading existing card' log to debug

### DIFF
--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -329,7 +329,7 @@ defmodule Sanctum.MarvelCdb do
     Games.get_card_side_by_code(card_id, load: [:card])
     |> case do
       {:ok, %Games.CardSide{card: %Games.Card{} = card}} ->
-        Logger.info("Not loading existing card #{card_id}")
+        Logger.debug("Not loading existing card #{card_id}")
         {:ok, card}
 
       _ ->


### PR DESCRIPTION
## Summary

The `load_card/1` path logs `Not loading existing card <code>` at **info** for every already-imported card in every synced deck. With Sentry configured to ship info-level logs (`enable_logs: true, logs: [level: :info]`), the ongoing decklist backfill emits this line roughly once per second for hours at a stretch — enough to exhaust the Sentry logs quota and get the whole project rate-limited (the `Failed to send Sentry event ... rate-limited` warnings currently spamming prod logs).

Demote it to **debug** so it stays out of Sentry and out of prod log noise entirely.

## Testing

- `mix ck` passes (format + Credo + Sobelow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)