### PR TITLE
feat(decks): extend decklist sync retries to 5 attempts

### DIFF
--- a/lib/sanctum/decks/decklist_sync_worker.ex
+++ b/lib/sanctum/decks/decklist_sync_worker.ex
@@ -12,7 +12,7 @@ defmodule Sanctum.Decks.DecklistSyncWorker do
 
   use Oban.Worker,
     queue: :default,
-    max_attempts: 3,
+    max_attempts: 5,
     unique: [period: :infinity, states: :incomplete]
 
   @impl Oban.Worker


### PR DESCRIPTION
Give the decklist sync worker two more retries (`max_attempts: 3` → `5`) before Oban discards a failed job.

MarvelCDB fetches can flake for longer than the previous 3-attempt window covered. The sync checkpoints its cursor at the last successfully processed day, so extra retries are cheap resumes rather than full re-walks. With Oban's default backoff, attempts 4 and 5 land roughly 4 and 10 minutes after failure — still well inside the hourly cron cadence, and the worker's `unique` constraint keeps retrying jobs from overlapping with fresh cron enqueues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)