### PR TITLE
fix(oban): scope boot rescue to this machine's own orphaned jobs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,8 +18,9 @@ config :sanctum, Oban,
     # Prune old completed/discarded jobs so the table doesn't grow unbounded.
     Oban.Plugins.Pruner,
     # Backstop for jobs orphaned in the `executing` state. The fast path is
-    # `Sanctum.Oban.BootRescue`, which resets orphans on the next boot; Lifeline
-    # only covers the (single-node) case of a node that stays up but somehow
+    # `Sanctum.Oban.BootRescue`, which resets a machine's own orphans when it
+    # boots; Lifeline covers what BootRescue can't — a machine that is
+    # destroyed and never boots again, or a node that stays up but somehow
     # dropped a job. `rescue_after` stays high so it never clobbers a genuinely
     # long-running job (it rescues purely on elapsed time, not liveness).
     {Oban.Plugins.Lifeline, rescue_after: :timer.hours(24)},

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,6 +66,15 @@ if config_env() == :prod do
 
   config :sanctum, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
+  # Pin Oban's node identity to the Fly machine ID: it survives restarts *and*
+  # redeploys, unlike the BEAM node name (which embeds the per-deploy image
+  # ref). `Sanctum.Oban.BootRescue` relies on this stability to recognize jobs
+  # orphaned by this machine's previous incarnation in `attempted_by` — without
+  # clobbering jobs that are live on another machine.
+  if machine_id = System.get_env("FLY_MACHINE_ID") do
+    config :sanctum, Oban, node: machine_id
+  end
+
   # Let the node stop itself when idle (see `Sanctum.AutoShutdown`) so Fly can
   # scale the machine to zero. Fly's own proxy autostop is disabled in fly.toml
   # (`auto_stop_machines = "off"`) because it can't see in-flight Oban jobs.

--- a/lib/sanctum/oban/boot_rescue.ex
+++ b/lib/sanctum/oban/boot_rescue.ex
@@ -1,7 +1,7 @@
 defmodule Sanctum.Oban.BootRescue do
   @moduledoc """
-  Resets Oban jobs orphaned in the `executing` state by a previous, now-dead
-  node back to `available` at application boot.
+  Resets Oban jobs orphaned in the `executing` state by a previous incarnation
+  of **this machine** back to `available` at application boot.
 
   ## Why
 
@@ -12,12 +12,24 @@ defmodule Sanctum.Oban.BootRescue do
   so it never clobbers a genuinely long-running job, which makes it useless as a
   *fast* recovery path.
 
-  Sanctum runs a **single** Oban node (Fly scale-to-zero: `auto_stop_machines =
-  "off"`, one machine, self-stop when idle). That makes recovery trivial: on
-  boot, nothing else can possibly be running a job, so *every* `executing` row is
-  a corpse from the prior boot and is safe to reset immediately — no
-  node/producer matching required. (Node names embed the image ref and private IP
-  and change across deploys anyway, so matching would be unreliable.)
+  ## Why per-machine
+
+  The app can have more than one machine alive at once (a second Fly machine,
+  autostart racing a self-stop, deploy overlap). A booting machine cannot tell
+  whether another machine is mid-job, and an earlier blanket reset of *all*
+  `executing` rows re-enqueued a job that was still running on the other
+  machine — the same job then executed on both machines concurrently. The one
+  thing a fresh boot *does* know is that nothing from its own machine survived
+  the restart. So rescue is scoped to jobs whose `attempted_by` node matches
+  this machine's Oban node identity.
+
+  That identity must be stable across deploys for the match to work, so prod
+  pins Oban's `:node` to `FLY_MACHINE_ID` (config/runtime.exs) — machine IDs
+  survive restarts and redeploys, unlike the default BEAM node name, which
+  embeds the per-deploy image ref.
+
+  Trade-off: orphans of a machine that is destroyed and never boots again are
+  not rescued here; `Oban.Plugins.Lifeline` remains the backstop for those.
 
   This child is placed **before** the `Oban` child in the supervision tree so the
   reset lands before any queue starts producing — otherwise it could reset a job
@@ -26,12 +38,6 @@ defmodule Sanctum.Oban.BootRescue do
 
   Mirrors Lifeline / Basic-engine semantics: attempts remaining → `available`;
   attempts exhausted → `discarded`.
-
-  > #### Single-node assumption {: .warning}
-  >
-  > This blanket reset is only safe because there is exactly one live Oban node.
-  > If Sanctum ever runs multiple Oban nodes, replace this with producer-aware
-  > rescuing (Oban Pro's `DynamicLifeline`) or it will clobber peers' live jobs.
   """
 
   import Ecto.Query
@@ -51,7 +57,7 @@ defmodule Sanctum.Oban.BootRescue do
   @doc false
   def run do
     # Skipped in test: the app boots outside any Ecto sandbox ownership, so a
-    # boot-time write would fail. Tests exercise `rescue_orphans/0` directly.
+    # boot-time write would fail. Tests exercise `rescue_orphans/1` directly.
     if Application.get_env(:sanctum, :env) != :test do
       rescue_orphans()
     end
@@ -60,13 +66,19 @@ defmodule Sanctum.Oban.BootRescue do
   end
 
   @doc """
-  Resets every job stuck in `executing` back to `available` (or `discarded` when
-  its attempts are exhausted). Returns `{rescued_count, discarded_count}`.
+  Resets this node's jobs stuck in `executing` back to `available` (or
+  `discarded` when their attempts are exhausted). Jobs attempted by other nodes
+  are left alone — they may still be running there. Returns
+  `{rescued_count, discarded_count}`.
   """
-  @spec rescue_orphans() :: {non_neg_integer(), non_neg_integer()}
-  def rescue_orphans do
+  @spec rescue_orphans(String.t()) :: {non_neg_integer(), non_neg_integer()}
+  def rescue_orphans(node \\ oban_node()) do
     now = DateTime.utc_now()
-    base = where(Oban.Job, [j], j.state == "executing")
+
+    base =
+      Oban.Job
+      |> where([j], j.state == "executing")
+      |> where([j], fragment("?[1]", j.attempted_by) == ^node)
 
     {rescued, _} =
       base
@@ -80,11 +92,20 @@ defmodule Sanctum.Oban.BootRescue do
 
     if rescued > 0 or discarded > 0 do
       Logger.info(
-        "[Oban.BootRescue] reset orphaned executing jobs: " <>
+        "[Oban.BootRescue] reset jobs orphaned by #{node}: " <>
           "#{rescued} → available, #{discarded} → discarded"
       )
     end
 
     {rescued, discarded}
+  end
+
+  # The node identity Oban will run under, resolved the same way Oban does:
+  # the configured `:node` (FLY_MACHINE_ID in prod) or Oban's own default.
+  # Read from app env because this runs before the Oban supervisor starts.
+  defp oban_node do
+    :sanctum
+    |> Application.fetch_env!(Oban)
+    |> Keyword.get_lazy(:node, &Oban.Config.node_name/0)
   end
 end

--- a/test/sanctum/oban/boot_rescue_test.exs
+++ b/test/sanctum/oban/boot_rescue_test.exs
@@ -3,8 +3,17 @@ defmodule Sanctum.Oban.BootRescueTest do
 
   alias Sanctum.Oban.BootRescue
 
+  @node "machine-self"
+  @other_node "machine-other"
+
   defp insert_job(attrs) do
-    defaults = %{worker: "Sanctum.FakeWorker", queue: "default", args: %{}, max_attempts: 3}
+    defaults = %{
+      worker: "Sanctum.FakeWorker",
+      queue: "default",
+      args: %{},
+      max_attempts: 3,
+      attempted_by: [@node, Ecto.UUID.generate()]
+    }
 
     %Oban.Job{}
     |> Ecto.Changeset.change(Map.merge(defaults, attrs))
@@ -16,7 +25,7 @@ defmodule Sanctum.Oban.BootRescueTest do
   test "moves an orphaned executing job with attempts remaining back to available" do
     job = insert_job(%{state: "executing", attempt: 1, attempted_at: DateTime.utc_now()})
 
-    assert {1, 0} = BootRescue.rescue_orphans()
+    assert {1, 0} = BootRescue.rescue_orphans(@node)
     assert reload(job).state == "available"
   end
 
@@ -29,19 +38,32 @@ defmodule Sanctum.Oban.BootRescueTest do
         attempted_at: DateTime.utc_now()
       })
 
-    assert {0, 1} = BootRescue.rescue_orphans()
+    assert {0, 1} = BootRescue.rescue_orphans(@node)
 
     reloaded = reload(job)
     assert reloaded.state == "discarded"
     assert reloaded.discarded_at
   end
 
+  test "leaves executing jobs attempted by other nodes untouched" do
+    foreign =
+      insert_job(%{
+        state: "executing",
+        attempt: 1,
+        attempted_at: DateTime.utc_now(),
+        attempted_by: [@other_node, Ecto.UUID.generate()]
+      })
+
+    assert {0, 0} = BootRescue.rescue_orphans(@node)
+    assert reload(foreign).state == "executing"
+  end
+
   test "leaves jobs in non-executing states untouched" do
-    available = insert_job(%{state: "available"})
+    available = insert_job(%{state: "available", attempted_by: nil})
     scheduled = insert_job(%{state: "scheduled", scheduled_at: DateTime.utc_now()})
     completed = insert_job(%{state: "completed", completed_at: DateTime.utc_now()})
 
-    assert {0, 0} = BootRescue.rescue_orphans()
+    assert {0, 0} = BootRescue.rescue_orphans(@node)
 
     assert reload(available).state == "available"
     assert reload(scheduled).state == "scheduled"
@@ -49,6 +71,24 @@ defmodule Sanctum.Oban.BootRescueTest do
   end
 
   test "returns zero counts when nothing is executing" do
-    assert {0, 0} = BootRescue.rescue_orphans()
+    assert {0, 0} = BootRescue.rescue_orphans(@node)
+  end
+
+  test "defaults to the node identity Oban will run under" do
+    # No :node is configured in test, so resolution falls through to Oban's
+    # own default — the same value a real Oban instance here would stamp
+    # into attempted_by.
+    default_node = Oban.Config.node_name()
+
+    job =
+      insert_job(%{
+        state: "executing",
+        attempt: 1,
+        attempted_at: DateTime.utc_now(),
+        attempted_by: [default_node, Ecto.UUID.generate()]
+      })
+
+    assert {1, 0} = BootRescue.rescue_orphans()
+    assert reload(job).state == "available"
   end
 end


### PR DESCRIPTION
## Problem

A single Oban job was observed running on **both** machines of the app simultaneously.

Root cause: `Sanctum.Oban.BootRescue` blanket-resets every `executing` job to `available` at boot, under an explicit single-node assumption (its moduledoc even carried a warning about this). That assumption no longer holds — the app currently has two started machines (`56839494f29238` and `9080509ece19e8`, the latter created 2026-07-14). When one machine booted, it reset a job still live on the other machine; the fresh queue then picked it up, so the same job executed on both machines — racing the shared deck-sync cursor and doubling MarvelCDB load. The worker's `unique` constraint can't help because no new job is inserted; the same row is re-run.

## Fix

A booting machine can't know whether another machine is mid-job — but it *does* know nothing from its own machine survived the restart. So rescue is now scoped to jobs whose `attempted_by` node matches this machine's own Oban node identity ("rescue your own corpses only"):

- **`config/runtime.exs`**: pin Oban's `:node` to `FLY_MACHINE_ID` in prod. Machine IDs are stable across restarts *and* redeploys, unlike the default BEAM node name (`RELEASE_NODE` embeds the per-deploy image ref), so the prior incarnation's `attempted_by` stamp still matches after a deploy.
- **`BootRescue.rescue_orphans/1`**: filter on `attempted_by[1] = <node>`; jobs executing on other nodes are left alone. Node resolution mirrors Oban's own (`configured :node` → `Oban.Config.node_name/0`) since BootRescue runs before the Oban supervisor starts.
- Moduledoc rewritten around the per-machine model; Lifeline comment updated — it remains the 24h backstop for orphans of a machine that is destroyed and never boots again.

## Caveats

- Jobs stamped with a pre-change node identity (old `sanctum-<image-ref>@<ip>` names) won't match after this deploys — any such stuck rows fall through to Lifeline once, then everything uses machine IDs.
- Worth deciding separately whether the second machine should exist at all: `fly.toml` (`min_machines_running = 0`, AutoShutdown self-stop) was designed around a single machine. This fix makes BootRescue safe either way.

## Testing

- New test: executing job attempted by a foreign node is untouched.
- New test: default node resolution matches what Oban would stamp.
- Existing rescue/discard semantics unchanged (attempts remaining → `available`, exhausted → `discarded`).
- `mix test` + `mix ck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)