### PR TITLE
fix(observability): drop LiveView longpoll traces from Sentry

### DIFF
--- a/lib/sanctum/observability.ex
+++ b/lib/sanctum/observability.ex
@@ -183,10 +183,14 @@ defmodule Sanctum.Observability do
     * Bare `sanctum.repo.query:*` roots — queries with no surrounding trace
       (oban_met sampling, peer election, card/deck sync tasks). Queries inside
       request, LiveView, and Oban job traces are children and are unaffected.
+    * LiveView longpoll transport requests (`/live/longpoll`) — fallback-
+      transport polling fires every few seconds per client and each poll is
+      its own root trace. Matched via the root span's `url.path` attribute,
+      since opentelemetry_bandit names the span before routing (just `:GET`).
 
   Everything else (HTTP requests, LiveView, Oban jobs) is sampled at 100%.
   """
-  def traces_sampler(%{transaction_context: %{name: name}}) do
+  def traces_sampler(%{transaction_context: %{name: name} = transaction_context}) do
     # OTel span names are chardata, not necessarily binaries — e.g.
     # opentelemetry_bandit names HTTP request spans with atoms (:GET, :HTTP).
     # A crash here is worse than it looks: Sentry rescues sampler errors and
@@ -198,6 +202,12 @@ defmodule Sanctum.Observability do
 
     orphan_query? = String.starts_with?(name, "sanctum.repo.query")
 
-    if oban_plugin_tick? or orphan_query?, do: 0.0, else: 1.0
+    if oban_plugin_tick? or orphan_query? or longpoll?(transaction_context), do: 0.0, else: 1.0
   end
+
+  defp longpoll?(%{attributes: %{:"url.path" => path}}) when is_binary(path) do
+    String.starts_with?(path, "/live/longpoll")
+  end
+
+  defp longpoll?(_transaction_context), do: false
 end

--- a/test/sanctum/observability_test.exs
+++ b/test/sanctum/observability_test.exs
@@ -5,6 +5,12 @@ defmodule Sanctum.ObservabilityTest do
 
   defp sample(name), do: Observability.traces_sampler(%{transaction_context: %{name: name}})
 
+  defp sample(name, path) do
+    Observability.traces_sampler(%{
+      transaction_context: %{name: name, attributes: %{:"url.path" => path}}
+    })
+  end
+
   describe "traces_sampler/1" do
     test "drops Oban plugin ticks" do
       assert sample("Elixir.Oban.Stager process") == 0.0
@@ -23,6 +29,13 @@ defmodule Sanctum.ObservabilityTest do
       # opentelemetry_oban names job spans "process <queue>"
       assert sample("process default") == 1.0
       assert sample("SanctumWeb.GameLive.Show.mount") == 1.0
+    end
+
+    test "drops LiveView longpoll transport requests by url.path" do
+      assert sample(:GET, "/live/longpoll") == 0.0
+      assert sample(:POST, "/live/longpoll") == 0.0
+      assert sample(:GET, "/games/abc123") == 1.0
+      assert sample(:GET, "/live/websocket") == 1.0
     end
 
     test "handles non-binary span names (opentelemetry_bandit uses atoms)" do


### PR DESCRIPTION
## Summary

LiveView's longpoll fallback transport fires a request every few seconds per connected client, and each poll becomes its own root trace in Sentry — flooding the transaction quota with noise ([example trace](https://jwstovergmailcom.sentry.io/explore/traces/trace/aa98a8c833af4bd29af634077c06eb35/?environment=production)).

This extends the existing custom `traces_sampler` (`Sanctum.Observability.traces_sampler/1`) — which already drops Oban plugin ticks and orphan repo-query roots — to also drop longpoll traces.

## How

The sampling decision happens when the request span starts, **before** Phoenix routing, so the span name is just `:GET` and can't identify longpoll. Instead the sampler matches the root span's `url.path` attribute (set by `opentelemetry_bandit` at span start, passed through by Sentry's OTel sampler in `transaction_context.attributes`) and returns `0.0` for any path under `/live/longpoll`. Dropping the root drops the whole trace, including child spans.

The websocket path (`/live/websocket`) is untouched — it's a single long-lived connection, not per-poll noise. Everything else still samples at 100%.

## Testing

- Added coverage in `test/sanctum/observability_test.exs`: longpoll GET/POST dropped; normal routes and the websocket path kept.
- `mix test test/sanctum/observability_test.exs` — 5 tests, 0 failures; `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)