### PR TITLE
feat(observability): track active sessions as a Sentry gauge

### DIFF
--- a/lib/sanctum/application.ex
+++ b/lib/sanctum/application.ex
@@ -23,6 +23,7 @@ defmodule Sanctum.Application do
          Application.fetch_env!(:sanctum, Oban)
        )},
       {Phoenix.PubSub, name: Sanctum.PubSub},
+      SanctumWeb.Presence,
       {Task.Supervisor, name: Sanctum.TaskSupervisor},
       Sanctum.CardSync.Server,
       Sanctum.DeckSync.Monitor,

--- a/lib/sanctum/observability.ex
+++ b/lib/sanctum/observability.ex
@@ -17,7 +17,8 @@ defmodule Sanctum.Observability do
     [:sanctum, :deck, :user_import],
     [:sanctum, :game, :created],
     [:sanctum, :game, :action],
-    [:sanctum, :auth, :sign_in]
+    [:sanctum, :auth, :sign_in],
+    [:sanctum, :sessions, :active]
   ]
 
   @doc """
@@ -146,6 +147,11 @@ defmodule Sanctum.Observability do
 
   def handle_metric_event([:sanctum, :game, :action], m, meta, :ok) do
     Sentry.Metrics.count("game.action", m.count, attributes: %{action: to_string(meta.action)})
+  end
+
+  # Zero is meaningful for this gauge (nobody online), so it is always emitted.
+  def handle_metric_event([:sanctum, :sessions, :active], m, _meta, :ok) do
+    Sentry.Metrics.gauge("sessions.active", m.count, unit: "session")
   end
 
   def handle_metric_event([:sanctum, :auth, :sign_in], m, meta, :ok) do

--- a/lib/sanctum_web/presence.ex
+++ b/lib/sanctum_web/presence.ex
@@ -1,0 +1,56 @@
+defmodule SanctumWeb.Presence do
+  @moduledoc """
+  Tracks connected LiveView sessions for the active-sessions metric.
+
+  Every LiveView in the router's live sessions runs the `:track` on_mount
+  hook, which registers the LiveView process under a per-person key —
+  the user id when signed in, the socket id otherwise — so one person with
+  several tabs counts once. Presence is cluster-aware (nodes cluster via
+  DNSCluster on Fly), so counts cover all machines.
+
+  `emit_active_sessions/0` is invoked by a telemetry poller
+  (`SanctumWeb.Telemetry`) and emits `[:sanctum, :sessions, :active]`,
+  which `Sanctum.Observability` forwards to Sentry as a gauge.
+  """
+
+  use Phoenix.Presence, otp_app: :sanctum, pubsub_server: Sanctum.PubSub
+
+  @topic "sanctum:active_sessions"
+
+  def on_mount(:track, _params, _session, socket) do
+    if Phoenix.LiveView.connected?(socket) do
+      {:ok, _ref} = track(self(), @topic, session_key(socket), %{})
+    end
+
+    {:cont, socket}
+  end
+
+  @doc "Number of distinct people (presence keys) currently connected."
+  def active_sessions_count do
+    @topic |> list() |> map_size()
+  end
+
+  @doc false
+  def emit_active_sessions do
+    :telemetry.execute(
+      [:sanctum, :sessions, :active],
+      %{count: active_sessions_count()},
+      %{}
+    )
+  rescue
+    # If Presence isn't running (boot race, crash-restart window), skip the
+    # tick — telemetry_poller permanently drops a measurement that raises.
+    # A missing tracker surfaces as ArgumentError (ETS lookup on the
+    # tracker's table) from list/1.
+    ArgumentError -> :ok
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp session_key(socket) do
+    case socket.assigns[:current_user] do
+      %{id: id} -> "user:#{id}"
+      _anonymous -> "anon:#{socket.id}"
+    end
+  end
+end

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -40,7 +40,8 @@ defmodule SanctumWeb.Router do
   scope "/", SanctumWeb do
     pipe_through :browser
 
-    ash_authentication_live_session :authenticated_routes do
+    ash_authentication_live_session :authenticated_routes,
+      on_mount: [{SanctumWeb.Presence, :track}] do
       # in each liveview, add one of the following at the top of the module:
       #
       # If an authenticated user must be present:
@@ -75,7 +76,10 @@ defmodule SanctumWeb.Router do
     end
 
     ash_authentication_live_session :admin_routes,
-      on_mount: [{SanctumWeb.LiveUserAuth, :live_admin_required}] do
+      on_mount: [
+        {SanctumWeb.LiveUserAuth, :live_admin_required},
+        {SanctumWeb.Presence, :track}
+      ] do
       # Admin landing page — system health + links to admin surfaces.
       live "/admin", AdminLive.Index, :index
 

--- a/lib/sanctum_web/telemetry.ex
+++ b/lib/sanctum_web/telemetry.ex
@@ -11,7 +11,16 @@ defmodule SanctumWeb.Telemetry do
     children = [
       # Telemetry poller will execute the given period measurements
       # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics
-      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
+      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000},
+      # Active-sessions gauge on its own slower cadence — every emission is a
+      # metric row in Sentry, so once a minute is plenty. init_delay: this
+      # supervisor starts before Presence, and telemetry_poller permanently
+      # drops a measurement whose first run crashes.
+      {:telemetry_poller,
+       measurements: [{SanctumWeb.Presence, :emit_active_sessions, []}],
+       period: :timer.minutes(1),
+       init_delay: :timer.seconds(15),
+       name: :sanctum_sessions_poller}
       # Add reporters as children of your supervision tree.
       # {Telemetry.Metrics.ConsoleReporter, metrics: metrics()}
     ]

--- a/test/sanctum_web/presence_test.exs
+++ b/test/sanctum_web/presence_test.exs
@@ -1,0 +1,29 @@
+defmodule SanctumWeb.PresenceTest do
+  @moduledoc false
+
+  # Not async: presence state is global, and other async LiveView tests
+  # would bleed connected sessions into the counts asserted here.
+  use SanctumWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias SanctumWeb.Presence
+
+  test "connected LiveViews are tracked and counted", %{conn: conn} do
+    base = Presence.active_sessions_count()
+
+    {:ok, _view, _html} = live(conn, ~p"/decks")
+
+    assert Presence.active_sessions_count() == base + 1
+  end
+
+  test "emit_active_sessions/0 emits the gauge telemetry event" do
+    ref =
+      :telemetry_test.attach_event_handlers(self(), [[:sanctum, :sessions, :active]])
+
+    Presence.emit_active_sessions()
+
+    assert_receive {[:sanctum, :sessions, :active], ^ref, %{count: count}, %{}}
+    assert is_integer(count) and count >= 0
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `sessions.active` gauge to Sentry so we can see how many people are using the app at any time.

- **`SanctumWeb.Presence`** (Phoenix.Presence) tracks every connected LiveView via a session-level `on_mount` hook in both router `live_session`s. The presence key is the user id when signed in — one person with several tabs counts once — and the socket id for anonymous visitors. Presence is cluster-aware via DNSCluster, so the count spans all Fly machines.
- A dedicated telemetry poller emits `[:sanctum, :sessions, :active]` **once a minute** (deliberately slower than the default 10s poller to keep Sentry metric-row volume down), and `Sanctum.Observability` forwards it as the `sessions.active` gauge. Zero is emitted too — "nobody online" is meaningful for a gauge.

## Boot-safety details

- `SanctumWeb.Telemetry` starts before Presence in the supervision tree, and `telemetry_poller` **permanently drops** a measurement whose run crashes — so the poller gets a 15s `init_delay`.
- `emit_active_sessions/0` swallows both the `ArgumentError` (missing ETS table) and `:exit` a stopped tracker can surface, so a crash-restart window can't kill the measurement either.

## Testing

- `test/sanctum_web/presence_test.exs`: a connected LiveView mount increments the count; the telemetry event emits with a non-negative integer.
- Verified end-to-end against the dev server: mounted `/decks` in a headless browser and confirmed the presence list showed distinct anonymous + signed-in sessions.
- Full suite passes (188 tests); `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)