### PR TITLE
feat(observability): emit deck sync counters per day instead of per run

### DIFF
--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -95,6 +95,16 @@ defmodule Sanctum.DeckSync do
             # completed run's checkpoint.
             checkpoint_day(date, frontier)
 
+            # Emit counters per day (not once at run end) so a long backfill is
+            # visible in flight and an abrupt stop doesn't lose the whole run's
+            # counts — only the run-level duration/halted metrics wait for the
+            # end (see Observability).
+            :telemetry.execute(
+              [:sanctum, :deck_sync, :day, :stop],
+              %{imported: imported, failed: failed},
+              %{date: date}
+            )
+
             {:cont,
              %{
                acc

--- a/lib/sanctum/observability.ex
+++ b/lib/sanctum/observability.ex
@@ -10,6 +10,7 @@ defmodule Sanctum.Observability do
 
   @metric_events [
     [:sanctum, :deck_sync, :run, :stop],
+    [:sanctum, :deck_sync, :day, :stop],
     [:sanctum, :deck_sync, :empty_day],
     [:sanctum, :marvel_cdb, :request, :stop],
     [:sanctum, :card_sync, :run, :stop],
@@ -73,11 +74,11 @@ defmodule Sanctum.Observability do
   ## Telemetry -> Sentry.Metrics
 
   @doc false
+  # Run-level metrics only — the per-day counters (days_processed,
+  # decks_imported, decks_failed) are emitted from the `:day` event below so
+  # they land incrementally during long backfills.
   def handle_metric_event([:sanctum, :deck_sync, :run, :stop], m, meta, :ok) do
     Sentry.Metrics.distribution("deck_sync.run.duration", m.duration_ms, unit: "millisecond")
-    count_nonzero("deck_sync.days_processed", m.processed, "day")
-    count_nonzero("deck_sync.decks_imported", m.imported, "deck")
-    count_nonzero("deck_sync.decks_failed", m.failed, "deck")
 
     case meta.halted do
       %{date: date, reason: reason} ->
@@ -88,6 +89,12 @@ defmodule Sanctum.Observability do
       nil ->
         :ok
     end
+  end
+
+  def handle_metric_event([:sanctum, :deck_sync, :day, :stop], m, _meta, :ok) do
+    Sentry.Metrics.count("deck_sync.days_processed", 1, unit: "day")
+    count_nonzero("deck_sync.decks_imported", m.imported, "deck")
+    count_nonzero("deck_sync.decks_failed", m.failed, "deck")
   end
 
   def handle_metric_event([:sanctum, :deck_sync, :empty_day], m, meta, :ok) do


### PR DESCRIPTION
## Summary

The `deck_sync.days_processed` / `deck_sync.decks_imported` / `deck_sync.decks_failed` counters were only emitted from the run-level `[:sanctum, :deck_sync, :run, :stop]` event, so a long backfill was invisible in flight and an abrupt stop (Oban timeout, deploy restart, uncaught crash) lost the whole run's counts — the same failure mode the per-day cursor checkpointing already guards against for sync progress.

- `Sanctum.DeckSync.run/1` now emits `[:sanctum, :deck_sync, :day, :stop]` after each successful day (right after the cursor checkpoint), carrying that day's `imported`/`failed` counts.
- `Sanctum.Observability` forwards the new event as the per-day Sentry counters, and the run-level handler now records only the `deck_sync.run.duration` distribution and `deck_sync.halted` count.

Since Sentry counters aggregate by sum, totals are unchanged — they just land incrementally, and an abrupt stop loses at most the in-progress day.

## Testing

- `mix test test/sanctum/deck_sync_test.exs test/sanctum/observability_test.exs` — 13 tests, 0 failures
- `mix ck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)