### PR TITLE
feat(cards): public card detail page with shared dossier tile

### DIFF
--- a/lib/sanctum/heroes.ex
+++ b/lib/sanctum/heroes.ex
@@ -9,4 +9,14 @@ defmodule Sanctum.Heroes do
       define :find_or_create_hero, action: :find_or_create
     end
   end
+
+  @doc """
+  `set -> {primary_color, secondary_color}` for every hero, for resolving card
+  border gradients. Heroes without a stored palette map to `{nil, nil}`.
+  """
+  def hero_color_map do
+    Sanctum.Heroes.Hero
+    |> Ash.read!()
+    |> Map.new(fn h -> {h.set, {h.primary_color, h.secondary_color}} end)
+  end
 end

--- a/lib/sanctum_web/components/card_side_tile.ex
+++ b/lib/sanctum_web/components/card_side_tile.ex
@@ -1,0 +1,386 @@
+defmodule SanctumWeb.Components.CardSideTile do
+  @moduledoc """
+  The dossier tile for a single card face — the `mc_card` art beside the
+  printed name, comic stat badges, threat plate, traits, text, and flavor.
+  Shared by the public Card Pool grid and the public card detail page.
+
+  Consumers build the tile's display map with `side_view/2` from a `CardSide`
+  (with its `card` loaded) and the hero-color palette map
+  (`Sanctum.Heroes.hero_color_map/0`).
+  """
+  use Phoenix.Component
+
+  import SanctumWeb.Components.Card
+  import SanctumWeb.Components.HandSizeBadge
+  import SanctumWeb.Components.HealthBadge
+  import SanctumWeb.Components.StatBadge
+
+  attr :id, :string, default: nil
+  attr :side, :map, required: true, doc: "display map built by side_view/2"
+
+  attr :size, :string,
+    default: "md",
+    values: ~w(md lg),
+    doc: "art size: md = the pool grid tile; lg = 2x art, full-width on mobile (detail page)"
+
+  attr :navigate, :string,
+    default: nil,
+    doc: "card detail path; when set, the art and name link to it"
+
+  def card_side_tile(assigns) do
+    assigns = assign(assigns, :lg?, assigns.size == "lg")
+
+    ~H"""
+    <div
+      id={@id}
+      class={[
+        "mc-tile flex flex-col items-start border-2 border-neutral bg-base-200 shadow-comic sm:flex-row",
+        (@lg? && "gap-6 p-5") || "gap-[13px] p-2"
+      ]}
+    >
+      <.maybe_link
+        navigate={@navigate}
+        class={[
+          "flex-none self-center border-2 border-neutral shadow-comic-sm sm:self-start",
+          art_frame_class(@side.is_landscape, @size)
+        ]}
+      >
+        <.mc_card
+          name={@side.name}
+          type={@side.type}
+          cost={@side.cost}
+          aspect={@side.aspect_key}
+          image_url={@side.image_url}
+          gradient_from={@side.gradient_from}
+          gradient_to={@side.gradient_to}
+          size={@size}
+          show_cost={false}
+        />
+      </.maybe_link>
+
+      <div class="flex min-w-0 flex-1 flex-col">
+        <div class="h-12 flex items-start gap-3">
+          <div
+            :if={@side.show_cost}
+            class="flex flex-none items-center justify-center rounded-full font-elektra-med text-4xl/normal"
+          >
+            {@side.cost}
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class={[
+              "font-ibm-mono text-[9px] uppercase tracking-[0.2em]",
+              @side.aspect_text_class
+            ]}>
+              {@side.type_name} · {@side.aspect_name}
+            </div>
+            <div class="mt-[3px] flex items-baseline gap-2">
+              <div class="min-w-0 flex-1 font-anton text-[22px] uppercase leading-[0.94]">
+                <.link :if={@navigate} navigate={@navigate} class="hover:text-primary">
+                  {@side.name}
+                </.link>
+                <span :if={!@navigate}>{@side.name}</span>
+              </div>
+              <div
+                :if={@side.stage_label}
+                class="flex-none font-elektra-med text-[18px] leading-none text-white"
+              >
+                {@side.stage_label}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div :if={@side.is_ally} class="flex items-start gap-2 w-full">
+          <div class="flex flex-grow items-start justify-start">
+            <.stat_badge
+              stat={:thw}
+              value={@side.thwart}
+              consequential={@side.thwart_consequential}
+              size={64}
+            />
+            <.stat_badge
+              stat={:atk}
+              value={@side.attack}
+              consequential={@side.attack_consequential}
+              size={64}
+            />
+          </div>
+          <div class="flex items-start justify-end">
+            <.health_badge value={@side.health} size={52} />
+          </div>
+        </div>
+
+        <div :if={@side.is_hero} class="flex items-start gap-2 w-full">
+          <div class="flex flex-grow items-start justify-start">
+            <.stat_badge stat={:thw} value={@side.thwart} size={64} hero={true} />
+            <.stat_badge stat={:atk} value={@side.attack} size={64} hero={true} />
+            <.stat_badge stat={:def} value={@side.defense} size={64} hero={true} />
+          </div>
+          <div class="flex items-start justify-end">
+            <.health_badge value={@side.health} size={52} />
+          </div>
+        </div>
+
+        <div :if={@side.is_villain or @side.is_minion} class="flex items-start gap-2 w-full">
+          <div class="flex flex-grow items-start justify-start">
+            <.stat_badge stat={:thw} value={@side.scheme} label="SCH" size={64} />
+            <.stat_badge stat={:atk} value={@side.attack} star={@side.attack_star} size={64} />
+          </div>
+          <div :if={@side.health} class="flex items-start justify-end">
+            <.health_badge value={@side.health} player={@side.health_per_player} size={52} />
+          </div>
+        </div>
+
+        <div
+          :if={@side.is_scheme and (@side.start_threat || @side.escalation_threat)}
+          class="mb-1 w-full"
+        >
+          <div class="inline-flex -skew-x-[9deg] border-2 border-white bg-base-100 shadow-comic-sm">
+            <.scheme_cell value={@side.start_threat} per_player={@side.start_threat_pp} />
+            <div :if={@side.is_main_scheme} class="w-px self-stretch bg-white"></div>
+            <.scheme_cell
+              :if={@side.is_main_scheme}
+              value={@side.escalation_threat}
+              per_player={@side.escalation_threat_pp}
+              sign
+            />
+            <div :if={@side.is_main_scheme} class="w-px self-stretch bg-white"></div>
+            <.scheme_cell
+              :if={@side.is_main_scheme}
+              value={@side.threat_target}
+              per_player={@side.threat_per_player}
+            />
+          </div>
+        </div>
+
+        <div class={["h-px bg-neutral", (@lg? && "my-4") || "my-2"]}></div>
+
+        <div
+          :if={@side.traits != ""}
+          class={[
+            "flex justify-center font-komika text-xs font-semibold uppercase tracking-[0.02em] text-base-content/75",
+            (@lg? && "mb-2.5") || "mb-1"
+          ]}
+        >
+          {@side.traits}
+        </div>
+
+        <div class="font-barlow text-[13.5px] leading-[1.5] text-base-content/85">
+          {Sanctum.CardText.to_html(@side.text)}
+        </div>
+
+        <div
+          :if={@side.flavor}
+          class={[
+            "text-center font-barlow italic text-xs text-base-content/65",
+            (@lg? && "my-3.5") || "my-2"
+          ]}
+        >
+          {Sanctum.CardText.to_html(@side.flavor)}
+        </div>
+
+        <div
+          :if={@side.pips != [] or (@side.is_hero and @side.hand_size)}
+          class={["flex items-center gap-1", (@lg? && "mt-4") || "mt-2.5"]}
+        >
+          <span
+            :for={{color_class, glyph} <- @side.pips}
+            class={["font-champions text-2xl leading-none", color_class]}
+          >
+            {glyph}
+          </span>
+          <.hand_size_badge
+            :if={@side.is_hero and @side.hand_size}
+            value={@side.hand_size}
+            class="ml-auto text-base-content/75"
+          />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # Art frame dimensions. "md" is the fixed pool-grid size; "lg" doubles it on
+  # sm+ screens and stretches to the available width on mobile, with the card's
+  # printed aspect ratio (5/7 portrait, 7/5 landscape) deriving the height.
+  defp art_frame_class(true = _landscape, "lg"), do: "aspect-[7/5] w-full sm:w-[420px]"
+  defp art_frame_class(_portrait, "lg"), do: "aspect-[5/7] w-full sm:w-[300px]"
+  defp art_frame_class(true = _landscape, _md), do: "h-[150px] w-[210px]"
+  defp art_frame_class(_portrait, _md), do: "h-[210px] w-[150px]"
+
+  # A link when a destination is given, otherwise a plain div — so the art
+  # frame keeps identical markup on pages that are already the destination.
+  attr :navigate, :string, default: nil
+  attr :class, :any, default: nil
+  slot :inner_block, required: true
+
+  defp maybe_link(%{navigate: nil} = assigns) do
+    ~H"""
+    <div class={@class}>{render_slot(@inner_block)}</div>
+    """
+  end
+
+  defp maybe_link(assigns) do
+    ~H"""
+    <.link navigate={@navigate} class={@class}>{render_slot(@inner_block)}</.link>
+    """
+  end
+
+  # One segment of the main-scheme threat plate: starting threat, escalation,
+  # then threshold. The ChampionsIcons per-player icon is appended when the value
+  # scales per hero. Counter-skewed so the text stays upright in the comic plate.
+  attr :value, :any, default: nil
+  attr :per_player, :boolean, default: false
+  attr :sign, :boolean, default: false, doc: "prefix positive values with + (escalation threat)"
+
+  defp scheme_cell(assigns) do
+    ~H"""
+    <div class="flex skew-x-[9deg] items-baseline gap-0.5 px-2 font-elektra-med text-2xl/snug">
+      {scheme_value(@value, @sign)}
+      <span :if={@per_player} class="font-champions text-xs leading-none text-white">
+        v
+      </span>
+    </div>
+    """
+  end
+
+  defp scheme_value(nil, _sign), do: "—"
+  defp scheme_value(v, true) when is_integer(v) and v > 0, do: "+#{v}"
+  defp scheme_value(v, _sign), do: v
+
+  @doc """
+  Builds the tile's display map for a single card face. `side` must have its
+  `card` relationship loaded; `hero_colors` is the `set -> {from, to}` palette
+  map from `Sanctum.Heroes.hero_color_map/0`.
+  """
+  def side_view(side, hero_colors) do
+    card = side.card
+    {gradient_from, gradient_to} = hero_gradient(card.set, hero_colors)
+    aspect_key = display_aspect(side)
+
+    resources =
+      [
+        energy: side.resource_energy_count,
+        mental: side.resource_mental_count,
+        physical: side.resource_physical_count,
+        wild: side.resource_wild_count
+      ]
+      |> Enum.flat_map(fn {res, n} -> List.duplicate(res, n || 0) end)
+
+    %{
+      id: side.id,
+      card_id: card.id,
+      name: side.name,
+      type: side.type,
+      is_landscape: landscape_type?(side.type),
+      cost: side.cost,
+      show_cost: side.type != :resource and not is_nil(side.cost),
+      aspect_key: aspect_key,
+      aspect_name: aspect_name(aspect_key, card.set),
+      gradient_from: gradient_from,
+      gradient_to: gradient_to,
+      type_name: type_name(side.type),
+      aspect_text_class: aspect_classes(aspect_key).text,
+      resources: resources,
+      pips: resource_pips(resources),
+      traits: format_traits(side.traits),
+      text: side.text || "",
+      flavor: Map.get(side, :flavor, ""),
+      is_ally: side.type == :ally,
+      is_hero: side.type == :hero,
+      is_villain: side.type == :villain,
+      is_minion: side.type == :minion,
+      is_scheme: side.type in [:main_scheme, :side_scheme, :player_side_scheme],
+      hand_size: side.hand_size,
+      attack: stat_value(side.attack),
+      attack_star: stat_star(side.attack),
+      attack_consequential: stat_consequential(side.attack),
+      thwart: stat_value(side.thwart),
+      thwart_consequential: stat_consequential(side.thwart),
+      defense: stat_value(side.defense),
+      health: stat_value(side.health),
+      health_per_player: stat_per_player(side.health),
+      scheme: side.scheme,
+      is_main_scheme: side.type == :main_scheme,
+      threat_target: threat_target(side),
+      threat_per_player: threat_target_per_player?(side),
+      start_threat: stat_value(side.base_threat),
+      start_threat_pp: stat_per_player(side.base_threat),
+      escalation_threat: stat_value(side.escalation_threat),
+      escalation_threat_pp: stat_per_player(side.escalation_threat),
+      stage_label: stage_label(side),
+      image_url: side.image_url
+    }
+  end
+
+  # Main-scheme stage + side, e.g. "1A"/"2B", from the printed stage number and
+  # side identifier.
+  defp stage_label(%{type: :main_scheme, stage: stage, side_identifier: side})
+       when is_integer(stage) and is_binary(side),
+       do: "#{stage}#{String.upcase(side)}"
+
+  defp stage_label(_), do: nil
+
+  # Resolve a hero's gradient from stored MarvelCDB colors, falling back to a
+  # stable slug-derived gradient for sets with no stored palette.
+  defp hero_gradient(set, hero_colors) do
+    case Map.get(hero_colors, set) do
+      {from, to} when is_binary(from) and is_binary(to) -> {from, to}
+      _ -> fallback_gradient(set)
+    end
+  end
+
+  defp stat_value(nil), do: nil
+  defp stat_value(%{value: value}), do: value
+
+  defp stat_consequential(%{consequential: n}) when is_integer(n), do: n
+  defp stat_consequential(_), do: 0
+
+  defp stat_star(%{star: true}), do: true
+  defp stat_star(_), do: false
+
+  # A per-player-scaling stat (X per hero) is marked with the champions star.
+  defp stat_per_player(%{scaling: scaling}) when scaling in [:per_player, "per_player"], do: true
+  defp stat_per_player(_), do: false
+
+  # A scheme's threat target: main schemes carry it in `max_threat`; side schemes
+  # (and player side schemes) carry it in `base_threat`.
+  defp threat_target(%{max_threat: %{value: v}}), do: v
+  defp threat_target(%{base_threat: %{value: v}}), do: v
+  defp threat_target(_), do: nil
+
+  defp threat_target_per_player?(%{max_threat: stat}) when not is_nil(stat),
+    do: stat_per_player(stat)
+
+  defp threat_target_per_player?(%{base_threat: stat}) when not is_nil(stat),
+    do: stat_per_player(stat)
+
+  defp threat_target_per_player?(_), do: false
+
+  defp format_traits(traits) when is_list(traits), do: Enum.join(traits, " · ")
+  defp format_traits(_), do: ""
+
+  # The display key drives tile color/label: aspect cards (including pool) use
+  # their aspect; every other pool uses its ownership. Encounter and campaign
+  # cards share the encounter accent.
+  defp display_aspect(%{ownership: :player, aspect: aspect}) when not is_nil(aspect), do: aspect
+  defp display_aspect(%{ownership: :hero}), do: :hero
+  defp display_aspect(%{ownership: :basic}), do: :basic
+  defp display_aspect(%{ownership: :encounter}), do: :encounter
+  defp display_aspect(%{ownership: :campaign}), do: :encounter
+  defp display_aspect(%{aspect: aspect}) when not is_nil(aspect), do: aspect
+  defp display_aspect(_), do: :basic
+
+  # Hero signature cards have no aspect; name them after their hero set instead.
+  defp aspect_name(:hero, set), do: hero_name(set)
+  defp aspect_name(:encounter, _set), do: "Encounter"
+  defp aspect_name(aspect, _set), do: aspect |> to_string() |> String.capitalize()
+
+  defp hero_name(set) when is_binary(set) and set != "",
+    do: set |> String.split("_") |> Enum.map_join(" ", &String.capitalize/1)
+
+  defp hero_name(_), do: "Hero"
+
+  defp type_name(nil), do: "Card"
+  defp type_name(type), do: type |> to_string() |> String.replace("_", " ") |> String.capitalize()
+end

--- a/lib/sanctum_web/live/browse_live/show.ex
+++ b/lib/sanctum_web/live/browse_live/show.ex
@@ -29,7 +29,7 @@ defmodule SanctumWeb.BrowseLive.Show do
            load: [:wave, :card_total, card_sets: [cards: [:primary_side, :card_sides]]]
          ) do
       {:ok, %Catalog.Pack{} = pack} ->
-        hero_colors = load_hero_colors()
+        hero_colors = Sanctum.Heroes.hero_color_map()
 
         {:ok,
          socket
@@ -166,8 +166,9 @@ defmodule SanctumWeb.BrowseLive.Show do
       </div>
 
       <div class="flex flex-wrap gap-2.5">
-        <div
+        <.link
           :for={card <- @cards}
+          navigate={~p"/cards/#{card.card_id}"}
           class={
             [
               "h-[210px] flex-none border-2 border-neutral shadow-comic-sm",
@@ -190,7 +191,7 @@ defmodule SanctumWeb.BrowseLive.Show do
             size="md"
             show_cost={false}
           />
-        </div>
+        </.link>
       </div>
     </section>
     """
@@ -337,6 +338,7 @@ defmodule SanctumWeb.BrowseLive.Show do
         |> Enum.flat_map(fn {res, n} -> List.duplicate(res, n || 0) end)
 
       %{
+        card_id: card.id,
         code: side.code,
         # Keep a card's faces adjacent and primary-first, then order cards among
         # themselves by the canonical code.
@@ -358,12 +360,6 @@ defmodule SanctumWeb.BrowseLive.Show do
   end
 
   defp card_views(_card, _hero_colors), do: []
-
-  defp load_hero_colors do
-    Sanctum.Heroes.Hero
-    |> Ash.read!()
-    |> Map.new(fn h -> {h.set, {h.primary_color, h.secondary_color}} end)
-  end
 
   defp hero_gradient(set, hero_colors) do
     case Map.get(hero_colors, set) do

--- a/lib/sanctum_web/live/card_live/detail.ex
+++ b/lib/sanctum_web/live/card_live/detail.ex
@@ -1,0 +1,226 @@
+defmodule SanctumWeb.CardLive.Detail do
+  @moduledoc """
+  Public card detail page — every printed face of a card rendered with the
+  same dossier tile as the Card Pool, a metadata side panel (pack, release,
+  card set, printings), and any alternate printings. Catalog reads are
+  unauthenticated; the admin management view lives at `/admin/cards/:id`.
+  """
+  use SanctumWeb, :live_view
+
+  require Ash.Query
+
+  import SanctumWeb.Components.CardSideTile
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app current_user={@current_user} flash={@flash} active_tab={:cards}>
+      <.header>
+        {@title}
+        <:subtitle>
+          <span class="font-ibm-mono text-[12px] uppercase tracking-[0.16em]">
+            {@card.base_code}
+          </span>
+          <span :if={@card.pack}> · {@card.pack}</span>
+          · {length(@sides)} side{if length(@sides) != 1, do: "s"}
+          <span :if={@card.unique} class="text-base-content/45">· unique</span>
+        </:subtitle>
+
+        <:actions>
+          <.button navigate={~p"/cards"}>
+            <.icon name="hero-arrow-left" /> Card Pool
+          </.button>
+          <.button
+            :if={@current_user && @current_user.admin}
+            variant="primary"
+            navigate={~p"/admin/cards/#{@card}"}
+          >
+            <.icon name="hero-wrench-screwdriver" /> Manage
+          </.button>
+        </:actions>
+      </.header>
+
+      <div class="mx-auto flex max-w-[1240px] flex-col gap-5">
+        <!-- card faces + metadata: equal-height columns (grid stretch); the
+             last tile grows so the column matches the panel when it's taller -->
+        <div class="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+          <div class="flex min-w-0 flex-col gap-[18px] lg:[&>*:last-child]:flex-1">
+            <.card_side_tile :for={side <- @sides} id={"side-#{side.id}"} side={side} size="lg" />
+          </div>
+
+          <!-- metadata side panel -->
+          <.panel class="p-4">
+            <div class="mb-3 border-b-2 border-neutral pb-2 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+              Card File
+            </div>
+
+            <div class="flex flex-col gap-3">
+              <div :if={@pack}>
+                <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+                  Pack
+                </div>
+                <.link
+                  navigate={~p"/browse/#{@pack.code}"}
+                  class="mt-0.5 block font-barlow-condensed text-[15px] font-semibold hover:text-primary"
+                >
+                  {@pack.name || @pack.code}
+                </.link>
+              </div>
+
+              <.meta :if={@pack} label="Product Type" value={product_type_label(@pack.product_type)} />
+              <.meta :if={@pack} label="Released" value={format_date(@pack.released_on)} />
+              <.meta :if={@pack && @pack.wave} label="Wave" value={@pack.wave.name} />
+              <.meta
+                :if={@card.card_set}
+                label="Card Set"
+                value={card_set_label(@card.card_set)}
+              />
+
+              <div class="my-1 h-px bg-neutral"></div>
+
+              <div class="grid grid-cols-2 gap-x-4 gap-y-3">
+                <.meta label="Code" value={@card.base_code} />
+                <.meta label="Printings" value={1 + length(@card.alts)} />
+                <.meta label="Deck Limit" value={@card.deck_limit} />
+                <.meta label="Unique" value={yes_no(@card.unique)} />
+                <.meta label="Permanent" value={yes_no(@card.permanent)} />
+                <.meta label="Multi-sided" value={yes_no(@card.is_multi_sided)} />
+              </div>
+
+              <div class="my-1 h-px bg-neutral"></div>
+
+              <a
+                href={"https://marvelcdb.com/card/#{@card.code}"}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="flex items-center gap-1.5 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/60 hover:text-primary"
+              >
+                <.icon name="hero-arrow-top-right-on-square" class="size-3.5" /> View on MarvelCDB
+              </a>
+            </div>
+          </.panel>
+        </div>
+
+        <!-- alternate printings -->
+        <.panel :if={@alts != []} class="p-4">
+          <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+            Alternate Printings ({length(@alts)})
+          </div>
+          <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+            <figure :for={alt <- @alts} class="flex flex-col gap-1.5">
+              <div class="aspect-[5/7] w-full overflow-hidden border-2 border-neutral shadow-comic">
+                <img
+                  :if={alt.image_url}
+                  src={alt.image_url}
+                  alt={alt.code}
+                  loading="lazy"
+                  class="h-full w-full object-cover"
+                />
+                <div
+                  :if={!alt.image_url}
+                  class="bg-card-hatch flex h-full w-full items-center justify-center"
+                >
+                  <span class="whitespace-nowrap font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-white/[0.32]">
+                    no scan
+                  </span>
+                </div>
+              </div>
+              <figcaption class="font-ibm-mono text-[10px] uppercase tracking-[0.16em] text-base-content/50">
+                {alt.code}<span :if={alt.pack}> · {alt.pack}</span>
+              </figcaption>
+            </figure>
+          </div>
+        </.panel>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :any, required: true
+
+  defp meta(assigns) do
+    ~H"""
+    <div :if={@value not in [nil, ""]}>
+      <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+        {@label}
+      </div>
+      <div class="mt-0.5 font-barlow-condensed text-[15px] font-semibold">{@value}</div>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(%{"id" => id}, _session, socket) do
+    card =
+      Ash.get!(Sanctum.Games.Card, id,
+        actor: socket.assigns[:current_user],
+        load: [:card_sides, :primary_side, :alts, :card_set, pack_ref: [:wave]]
+      )
+
+    hero_colors = Sanctum.Heroes.hero_color_map()
+    title = (card.primary_side && card.primary_side.name) || card.base_code
+
+    # side_view/2 reads `side.card` for set/gradient data; the sides were
+    # loaded through the card, so hand it back rather than re-querying.
+    sides =
+      card.card_sides
+      |> Enum.sort_by(& &1.side_identifier)
+      |> Enum.map(&side_view(%{&1 | card: card}, hero_colors))
+
+    # Every alternate printing. MarvelCDB has no scan for many reprints
+    # (imagesrc is null there, so our mirrored image_url is too) — those render
+    # as placeholders, sorted after the printings that have art. Pack codes
+    # resolve to catalog pack names when the pack has been synced.
+    pack_names = pack_names(card.alts)
+
+    alts =
+      card.alts
+      |> Enum.sort_by(&{is_nil(&1.image_url), &1.code})
+      |> Enum.map(&%{&1 | pack: Map.get(pack_names, &1.pack, &1.pack)})
+
+    {:ok,
+     socket
+     |> assign(:page_title, title)
+     |> assign(:title, title)
+     |> assign(:card, card)
+     |> assign(:pack, card.pack_ref)
+     |> assign(:sides, sides)
+     |> assign(:alts, alts)}
+  end
+
+  # pack code -> pack name for the packs the alternate printings came from.
+  defp pack_names([]), do: %{}
+
+  defp pack_names(alts) do
+    codes = alts |> Enum.map(& &1.pack) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+
+    Sanctum.Catalog.Pack
+    |> Ash.Query.filter(code in ^codes)
+    |> Ash.read!()
+    |> Map.new(fn p -> {p.code, p.name || p.code} end)
+  end
+
+  defp card_set_label(%{name: name, set_type: set_type}) do
+    type =
+      case set_type do
+        nil -> nil
+        t -> t |> to_string() |> String.replace("_", " ") |> String.capitalize()
+      end
+
+    [name, type] |> Enum.reject(&is_nil/1) |> Enum.join(" · ")
+  end
+
+  defp format_date(nil), do: nil
+  defp format_date(%Date{} = date), do: Calendar.strftime(date, "%b %-d, %Y")
+
+  defp product_type_label(:core), do: "Core Set"
+  defp product_type_label(:campaign_expansion), do: "Campaign Expansion"
+  defp product_type_label(:hero_pack), do: "Hero Pack"
+  defp product_type_label(:scenario_pack), do: "Scenario Pack"
+  defp product_type_label(:promo), do: "Promo"
+  defp product_type_label(_), do: "Product"
+
+  defp yes_no(true), do: "Yes"
+  defp yes_no(_), do: "No"
+end

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -8,11 +8,7 @@ defmodule SanctumWeb.CardLive.Pool do
 
   require Ash.Query
 
-  import SanctumWeb.Components.HandSizeBadge
-  import SanctumWeb.Components.HealthBadge
-  import SanctumWeb.Components.StatBadge
-
-  alias SanctumWeb.Components.Card, as: CardComponent
+  import SanctumWeb.Components.CardSideTile
 
   @page_size 24
 
@@ -101,158 +97,12 @@ defmodule SanctumWeb.CardLive.Pool do
         phx-viewport-bottom={!@end_of_timeline? && "next-page"}
         class="grid grid-cols-1 items-start gap-[18px] sm:grid-cols-[repeat(auto-fill,minmax(452px,1fr))]"
       >
-        <div
+        <.card_side_tile
           :for={{dom_id, side} <- @streams.cards}
           id={dom_id}
-          class="mc-tile flex flex-col items-start gap-[13px] border-2 border-neutral bg-base-200 p-2 shadow-comic sm:flex-row"
-        >
-          <div class={[
-            "flex-none self-center border-2 border-neutral shadow-comic-sm sm:self-start",
-            (side.is_landscape && "h-[150px] w-[210px]") || "h-[210px] w-[150px]"
-          ]}>
-            <.mc_card
-              name={side.name}
-              type={side.type}
-              cost={side.cost}
-              aspect={side.aspect_key}
-              image_url={side.image_url}
-              gradient_from={side.gradient_from}
-              gradient_to={side.gradient_to}
-              size="md"
-              show_cost={false}
-            />
-          </div>
-
-          <div class="flex min-w-0 flex-1 flex-col">
-            <div class="h-12 flex items-start gap-3">
-              <div
-                :if={side.show_cost}
-                class="flex flex-none items-center justify-center rounded-full font-elektra-med text-4xl/normal"
-              >
-                {side.cost}
-              </div>
-              <div class="min-w-0 flex-1">
-                <div class={[
-                  "font-ibm-mono text-[9px] uppercase tracking-[0.2em]",
-                  side.aspect_text_class
-                ]}>
-                  {side.type_name} · {side.aspect_name}
-                </div>
-                <div class="mt-[3px] flex items-baseline gap-2">
-                  <div class="min-w-0 flex-1 font-anton text-[22px] uppercase leading-[0.94]">
-                    {side.name}
-                  </div>
-                  <div
-                    :if={side.stage_label}
-                    class="flex-none font-elektra-med text-[18px] leading-none text-white"
-                  >
-                    {side.stage_label}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div :if={side.is_ally} class="flex items-start gap-2 w-full">
-              <div class="flex flex-grow items-start justify-start">
-                <.stat_badge
-                  stat={:thw}
-                  value={side.thwart}
-                  consequential={side.thwart_consequential}
-                  size={64}
-                />
-                <.stat_badge
-                  stat={:atk}
-                  value={side.attack}
-                  consequential={side.attack_consequential}
-                  size={64}
-                />
-              </div>
-              <div class="flex items-start justify-end">
-                <.health_badge value={side.health} size={52} />
-              </div>
-            </div>
-
-            <div :if={side.is_hero} class="flex items-start gap-2 w-full">
-              <div class="flex flex-grow items-start justify-start">
-                <.stat_badge stat={:thw} value={side.thwart} size={64} hero={true} />
-                <.stat_badge stat={:atk} value={side.attack} size={64} hero={true} />
-                <.stat_badge stat={:def} value={side.defense} size={64} hero={true} />
-              </div>
-              <div class="flex items-start justify-end">
-                <.health_badge value={side.health} size={52} />
-              </div>
-            </div>
-
-            <div :if={side.is_villain or side.is_minion} class="flex items-start gap-2 w-full">
-              <div class="flex flex-grow items-start justify-start">
-                <.stat_badge stat={:thw} value={side.scheme} label="SCH" size={64} />
-                <.stat_badge stat={:atk} value={side.attack} star={side.attack_star} size={64} />
-              </div>
-              <div :if={side.health} class="flex items-start justify-end">
-                <.health_badge value={side.health} player={side.health_per_player} size={52} />
-              </div>
-            </div>
-
-            <div
-              :if={side.is_scheme and (side.start_threat || side.escalation_threat)}
-              class="mb-1 w-full"
-            >
-              <div class="inline-flex -skew-x-[9deg] border-2 border-white bg-base-100 shadow-comic-sm">
-                <.scheme_cell value={side.start_threat} per_player={side.start_threat_pp} />
-                <div :if={side.is_main_scheme} class="w-px self-stretch bg-white"></div>
-                <.scheme_cell
-                  :if={side.is_main_scheme}
-                  value={side.escalation_threat}
-                  per_player={side.escalation_threat_pp}
-                  sign
-                />
-                <div :if={side.is_main_scheme} class="w-px self-stretch bg-white"></div>
-                <.scheme_cell
-                  :if={side.is_main_scheme}
-                  value={side.threat_target}
-                  per_player={side.threat_per_player}
-                />
-              </div>
-            </div>
-
-            <div class="my-2 h-px bg-neutral"></div>
-
-            <div
-              :if={side.traits != ""}
-              class="flex justify-center mb-1 font-komika text-xs font-semibold uppercase tracking-[0.02em] text-base-content/75"
-            >
-              {side.traits}
-            </div>
-
-            <div class="font-barlow text-[13.5px] leading-[1.5] text-base-content/85">
-              {Sanctum.CardText.to_html(side.text)}
-            </div>
-
-            <div
-              :if={side.flavor}
-              class="text-center font-barlow italic text-xs text-base-content/65 my-2"
-            >
-              {Sanctum.CardText.to_html(side.flavor)}
-            </div>
-
-            <div
-              :if={side.pips != [] or (side.is_hero and side.hand_size)}
-              class="mt-2.5 flex items-center gap-1"
-            >
-              <span
-                :for={{color_class, glyph} <- side.pips}
-                class={["font-champions text-2xl leading-none", color_class]}
-              >
-                {glyph}
-              </span>
-              <.hand_size_badge
-                :if={side.is_hero and side.hand_size}
-                value={side.hand_size}
-                class="ml-auto text-base-content/75"
-              />
-            </div>
-          </div>
-        </div>
+          side={side}
+          navigate={~p"/cards/#{side.card_id}"}
+        />
       </div>
 
       <!-- empty state -->
@@ -270,28 +120,6 @@ defmodule SanctumWeb.CardLive.Pool do
     """
   end
 
-  # One segment of the main-scheme threat plate: starting threat, escalation,
-  # then threshold. The ChampionsIcons per-player icon is appended when the value
-  # scales per hero. Counter-skewed so the text stays upright in the comic plate.
-  attr :value, :any, default: nil
-  attr :per_player, :boolean, default: false
-  attr :sign, :boolean, default: false, doc: "prefix positive values with + (escalation threat)"
-
-  defp scheme_cell(assigns) do
-    ~H"""
-    <div class="flex skew-x-[9deg] items-baseline gap-0.5 px-2 font-elektra-med text-2xl/snug">
-      {scheme_value(@value, @sign)}
-      <span :if={@per_player} class="font-champions text-xs leading-none text-white">
-        v
-      </span>
-    </div>
-    """
-  end
-
-  defp scheme_value(nil, _sign), do: "—"
-  defp scheme_value(v, true) when is_integer(v) and v > 0, do: "+#{v}"
-  defp scheme_value(v, _sign), do: v
-
   @impl true
   def mount(_params, _session, socket) do
     total = count_cards(socket, %{})
@@ -308,16 +136,9 @@ defmodule SanctumWeb.CardLive.Pool do
      |> assign(:type_options, @types)
      |> assign(:offset, 0)
      |> assign(:end_of_timeline?, false)
-     |> assign(:hero_colors, load_hero_colors())
+     |> assign(:hero_colors, Sanctum.Heroes.hero_color_map())
      |> stream(:cards, [])
      |> load_page(0, reset: true)}
-  end
-
-  # set -> {primary_color, secondary_color} for heroes with a stored palette.
-  defp load_hero_colors do
-    Sanctum.Heroes.Hero
-    |> Ash.read!()
-    |> Map.new(fn h -> {h.set, {h.primary_color, h.secondary_color}} end)
   end
 
   @impl true
@@ -383,136 +204,4 @@ defmodule SanctumWeb.CardLive.Pool do
   defp filters(assigns) do
     %{query: assigns.query, aspect: assigns.aspect, type: assigns.type}
   end
-
-  # Builds the display map for a single card face. Each side is streamed as its
-  # own tile, so multi-sided cards appear as separate cards.
-  defp side_view(side, hero_colors) do
-    card = side.card
-    {gradient_from, gradient_to} = hero_gradient(card.set, hero_colors)
-    aspect_key = display_aspect(side)
-
-    resources =
-      [
-        energy: side.resource_energy_count,
-        mental: side.resource_mental_count,
-        physical: side.resource_physical_count,
-        wild: side.resource_wild_count
-      ]
-      |> Enum.flat_map(fn {res, n} -> List.duplicate(res, n || 0) end)
-
-    %{
-      id: side.id,
-      name: side.name,
-      type: side.type,
-      is_landscape: CardComponent.landscape_type?(side.type),
-      cost: side.cost,
-      show_cost: side.type != :resource and not is_nil(side.cost),
-      aspect_key: aspect_key,
-      aspect_name: aspect_name(aspect_key, card.set),
-      gradient_from: gradient_from,
-      gradient_to: gradient_to,
-      type_name: type_name(side.type),
-      aspect_text_class: CardComponent.aspect_classes(aspect_key).text,
-      resources: resources,
-      pips: CardComponent.resource_pips(resources),
-      traits: format_traits(side.traits),
-      text: side.text || "",
-      flavor: Map.get(side, :flavor, ""),
-      is_ally: side.type == :ally,
-      is_hero: side.type == :hero,
-      is_villain: side.type == :villain,
-      is_minion: side.type == :minion,
-      is_scheme: side.type in [:main_scheme, :side_scheme, :player_side_scheme],
-      hand_size: side.hand_size,
-      attack: stat_value(side.attack),
-      attack_star: stat_star(side.attack),
-      attack_consequential: stat_consequential(side.attack),
-      thwart: stat_value(side.thwart),
-      thwart_consequential: stat_consequential(side.thwart),
-      defense: stat_value(side.defense),
-      health: stat_value(side.health),
-      health_per_player: stat_per_player(side.health),
-      scheme: side.scheme,
-      is_main_scheme: side.type == :main_scheme,
-      threat_target: threat_target(side),
-      threat_per_player: threat_target_per_player?(side),
-      start_threat: stat_value(side.base_threat),
-      start_threat_pp: stat_per_player(side.base_threat),
-      escalation_threat: stat_value(side.escalation_threat),
-      escalation_threat_pp: stat_per_player(side.escalation_threat),
-      stage_label: stage_label(side),
-      image_url: side.image_url
-    }
-  end
-
-  # Main-scheme stage + side, e.g. "1A"/"2B", from the printed stage number and
-  # side identifier.
-  defp stage_label(%{type: :main_scheme, stage: stage, side_identifier: side})
-       when is_integer(stage) and is_binary(side),
-       do: "#{stage}#{String.upcase(side)}"
-
-  defp stage_label(_), do: nil
-
-  # Resolve a hero's gradient from stored MarvelCDB colors, falling back to a
-  # stable slug-derived gradient for sets with no stored palette.
-  defp hero_gradient(set, hero_colors) do
-    case Map.get(hero_colors, set) do
-      {from, to} when is_binary(from) and is_binary(to) -> {from, to}
-      _ -> CardComponent.fallback_gradient(set)
-    end
-  end
-
-  defp stat_value(nil), do: nil
-  defp stat_value(%{value: value}), do: value
-
-  defp stat_consequential(%{consequential: n}) when is_integer(n), do: n
-  defp stat_consequential(_), do: 0
-
-  defp stat_star(%{star: true}), do: true
-  defp stat_star(_), do: false
-
-  # A per-player-scaling stat (X per hero) is marked with the champions star.
-  defp stat_per_player(%{scaling: scaling}) when scaling in [:per_player, "per_player"], do: true
-  defp stat_per_player(_), do: false
-
-  # A scheme's threat target: main schemes carry it in `max_threat`; side schemes
-  # (and player side schemes) carry it in `base_threat`.
-  defp threat_target(%{max_threat: %{value: v}}), do: v
-  defp threat_target(%{base_threat: %{value: v}}), do: v
-  defp threat_target(_), do: nil
-
-  defp threat_target_per_player?(%{max_threat: stat}) when not is_nil(stat),
-    do: stat_per_player(stat)
-
-  defp threat_target_per_player?(%{base_threat: stat}) when not is_nil(stat),
-    do: stat_per_player(stat)
-
-  defp threat_target_per_player?(_), do: false
-
-  defp format_traits(traits) when is_list(traits), do: Enum.join(traits, " · ")
-  defp format_traits(_), do: ""
-
-  # The display key drives tile color/label: aspect cards (including pool) use
-  # their aspect; every other pool uses its ownership. Encounter and campaign
-  # cards share the encounter accent.
-  defp display_aspect(%{ownership: :player, aspect: aspect}) when not is_nil(aspect), do: aspect
-  defp display_aspect(%{ownership: :hero}), do: :hero
-  defp display_aspect(%{ownership: :basic}), do: :basic
-  defp display_aspect(%{ownership: :encounter}), do: :encounter
-  defp display_aspect(%{ownership: :campaign}), do: :encounter
-  defp display_aspect(%{aspect: aspect}) when not is_nil(aspect), do: aspect
-  defp display_aspect(_), do: :basic
-
-  # Hero signature cards have no aspect; name them after their hero set instead.
-  defp aspect_name(:hero, set), do: hero_name(set)
-  defp aspect_name(:encounter, _set), do: "Encounter"
-  defp aspect_name(aspect, _set), do: aspect |> to_string() |> String.capitalize()
-
-  defp hero_name(set) when is_binary(set) and set != "",
-    do: set |> String.split("_") |> Enum.map_join(" ", &String.capitalize/1)
-
-  defp hero_name(_), do: "Hero"
-
-  defp type_name(nil), do: "Card"
-  defp type_name(type), do: type |> to_string() |> String.replace("_", " ") |> String.capitalize()
 end

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -140,7 +140,7 @@ defmodule SanctumWeb.DeckLive.Show do
                 <div class="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
                   <.link
                     :for={c <- g.cards}
-                    navigate={~p"/admin/cards/#{c.card_id}"}
+                    navigate={~p"/cards/#{c.card_id}"}
                     class="h-[101px] border-2 border-neutral shadow-comic-sm"
                   >
                     <.mc_card

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -61,8 +61,9 @@ defmodule SanctumWeb.Router do
       live "/browse", BrowseLive.Index, :index
       live "/browse/:pack", BrowseLive.Show, :show
 
-      # Public card pool (catalog reads are unauthenticated).
+      # Public card pool + card detail (catalog reads are unauthenticated).
       live "/cards", CardLive.Pool, :index
+      live "/cards/:id", CardLive.Detail, :show
 
       # Public deck browser + detail (deck reads are unauthenticated).
       live "/decks", DeckLive.Index, :index

--- a/test/sanctum_web/live/card_live/detail_test.exs
+++ b/test/sanctum_web/live/card_live/detail_test.exs
@@ -1,0 +1,115 @@
+defmodule SanctumWeb.CardLive.DetailTest do
+  @moduledoc false
+
+  use SanctumWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Sanctum.Factory
+
+  defp make_card do
+    card =
+      create(Sanctum.Games.Card,
+        attrs: %{base_code: "01001", code: "01001a", is_multi_sided: true, pack: "core"}
+      )
+
+    hero =
+      create(Sanctum.Games.CardSide,
+        attrs: %{
+          card_id: card.id,
+          name: "Spider-Man",
+          type: :hero,
+          code: "01001a",
+          side_identifier: "A",
+          is_primary_side: true,
+          text: "Spider-sense tingling."
+        }
+      )
+
+    alter_ego =
+      create(Sanctum.Games.CardSide,
+        attrs: %{
+          card_id: card.id,
+          name: "Peter Parker",
+          type: :alter_ego,
+          code: "01001b",
+          side_identifier: "B",
+          is_primary_side: false,
+          text: "Scientist supreme of Queens."
+        }
+      )
+
+    {card, hero, alter_ego}
+  end
+
+  test "renders every side of a card for anonymous visitors", %{conn: conn} do
+    {card, _hero, _alter_ego} = make_card()
+
+    {:ok, _lv, html} = live(conn, ~p"/cards/#{card.id}")
+
+    assert html =~ "Spider-Man"
+    assert html =~ "Peter Parker"
+    assert html =~ "Spider-sense tingling."
+    assert html =~ "Scientist supreme of Queens."
+    assert html =~ "01001"
+    assert html =~ "2 sides"
+  end
+
+  test "shows pack metadata in the card file panel", %{conn: conn} do
+    pack =
+      Sanctum.Catalog.Pack
+      |> Ash.Changeset.for_create(:upsert_from_marvelcdb, %{
+        code: "core",
+        name: "Core Set",
+        released_on: ~D[2019-11-01]
+      })
+      |> Ash.create!(authorize?: false)
+      |> Ash.Changeset.for_update(:set_curated, %{product_type: :core})
+      |> Ash.update!(authorize?: false)
+
+    {card, _hero, _alter_ego} = make_card()
+
+    card
+    |> Ash.Changeset.for_update(:update, %{pack_id: pack.id})
+    |> Ash.update!(authorize?: false)
+
+    {:ok, _lv, html} = live(conn, ~p"/cards/#{card.id}")
+
+    assert html =~ "Card File"
+    assert html =~ "Core Set"
+    assert html =~ "Nov 1, 2019"
+    assert html =~ ~p"/browse/core"
+    assert html =~ "https://marvelcdb.com/card/01001a"
+  end
+
+  test "shows every alternate printing, with a placeholder when there is no scan", %{conn: conn} do
+    {card, _hero, _alter_ego} = make_card()
+
+    for {code, image_url} <- [{"02001a", "https://img.example/02001a.png"}, {"03001a", nil}] do
+      Sanctum.Games.CardAlt
+      |> Ash.Changeset.for_create(:create, %{
+        card_id: card.id,
+        code: code,
+        base_code: String.slice(code, 0..4),
+        side_identifier: "A",
+        pack: "reprint",
+        image_url: image_url
+      })
+      |> Ash.create!(authorize?: false)
+    end
+
+    {:ok, _lv, html} = live(conn, ~p"/cards/#{card.id}")
+
+    assert html =~ "Alternate Printings (2)"
+    assert html =~ "https://img.example/02001a.png"
+    assert html =~ "03001a"
+    assert html =~ "no scan"
+  end
+
+  test "card pool tiles link to the card detail page", %{conn: conn} do
+    {card, _hero, _alter_ego} = make_card()
+
+    {:ok, _lv, html} = live(conn, ~p"/cards")
+
+    assert html =~ ~p"/cards/#{card.id}"
+  end
+end


### PR DESCRIPTION
## What

- **`/cards/:id`** — a public card detail page rendering every printed face of a card with the same dossier tile as the Card Pool, at 2x art size on desktop and full-width art on mobile.
- **`SanctumWeb.Components.CardSideTile`** — the pool's per-side tile extracted into a shared component (markup + `side_view/2` display-map builder), with `size` (md pool grid / lg detail) and `navigate` attrs.
- **Card File panel** — pack (linked to the pack library), product type, release date, wave, card set, deck limit / unique / permanent / multi-sided flags, printings count, and a MarvelCDB link. Equal-height with the tiles column.
- **Alternate printings** — full-width panel showing every reprint; printings MarvelCDB never scanned (`imagesrc: null`) render a hatched "no scan" placeholder, and pack codes resolve to catalog pack names.
- **Links everywhere cards render**: Card Pool tiles, pack-library tiles, and the deck detail grid all navigate to the detail page. The deck grid previously linked to the admin-only `/admin/cards/:id`, which bounced non-admins to the home page.
- `Sanctum.Heroes.hero_color_map/0` replaces the per-LiveView hero-gradient queries.

Flavor Town and the game table intentionally do not link (spoilers / mid-game misclicks).

## Testing

- 198 tests green, `mix ck` clean.
- Verified in-browser: portrait hero (Spider-Man), landscape main scheme (Secret Rendezvous), villain (Rhino), scanless reprint (For Justice!), desktop + 390px mobile widths, pool → detail and pack → detail navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)