### PR TITLE
perf(decks): stop loading every deck to build the hero filter

### DIFF
--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -215,16 +215,12 @@ defmodule SanctumWeb.DeckLive.Index do
      |> load_page(0, reset: true)}
   end
 
-  # {id, hero_name} for every hero that has at least one deck, sorted by name.
-  # TODO: optimize with a distinct query if the deck count grows large.
+  # {id, hero_name} for every hero, sorted by name.
   defp load_hero_options do
-    Sanctum.Decks.Deck
-    |> Ash.Query.load(:hero)
+    Sanctum.Heroes.Hero
+    |> Ash.Query.select([:id, :hero_name])
+    |> Ash.Query.sort(hero_name: :asc)
     |> Ash.read!()
-    |> Enum.map(& &1.hero)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq_by(& &1.id)
-    |> Enum.sort_by(& &1.hero_name)
     |> Enum.map(&{&1.id, &1.hero_name})
   end
 


### PR DESCRIPTION
## Summary

`DeckLive.Index` built its hero-filter dropdown by reading the **entire decks table** — every row, including the heavy `description_md`/`meta` columns — and deduping heroes in Elixir. At ~35K decks that query takes 17s+ in prod ([trace](https://jwstovergmailcom.sentry.io/explore/traces/trace/3f0187b0fd31a3e6ae7c76abdf4f3e66/?environment=production&node=span-61e3da0f768a008d)), blowing past the 15s DBConnection timeout on every `/decks` mount and surfacing as `DBConnection.ConnectionError: ssl recv: closed` (SANCTUM-7).

Every hero has decks, so query the 67-row `heroes` table directly, selecting only `id` + `hero_name` and sorting in SQL.

Fixes SANCTUM-7

## Verification

Ran the new query against the dev server via tidewave: returns all 67 heroes, sorted by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)