### PR TITLE
perf(decks): stop starving the DB during deck sync and parallelize imports

### DIFF
--- a/lib/sanctum/deck_sync.ex
+++ b/lib/sanctum/deck_sync.ex
@@ -51,8 +51,20 @@ defmodule Sanctum.DeckSync do
 
   # Brief yield between deck imports so a burst (a busy day, or a backfill)
   # doesn't monopolize the database — on Neon's small shared compute a
-  # back-to-back import stream visibly delays interactive queries.
+  # back-to-back import stream visibly delays interactive queries. Applies
+  # per import lane, so it paces each concurrent importer independently.
   @deck_pause_ms 50
+
+  # A day's decklists arrive in one HTTP payload, so importing them
+  # concurrently multiplies throughput without any extra MarvelCDB load —
+  # the cost is DB round-trips, which are mostly idle network latency.
+  # Kept well below the pool size (10) so interactive queries never starve.
+  @import_concurrency 4
+
+  # Generous per-deck ceiling: an import is normally sub-second, but a slot
+  # code missing from the catalog falls back to live MarvelCDB fetches
+  # (card + full pack listing, with retries), which can take tens of seconds.
+  @import_timeout_ms :timer.minutes(2)
 
   @doc """
   Runs the sync. Options:
@@ -85,9 +97,14 @@ defmodule Sanctum.DeckSync do
     # rewinds it.
     frontier = current_cursor()
 
+    # Run-scoped memo for hero/mcdb_user resolution (see import_decklist's
+    # `:cache`). Public so the concurrent import tasks share it; owned by this
+    # process, so it dies with the run.
+    cache = :ets.new(:deck_sync_cache, [:set, :public])
+
     acc =
       Enum.reduce_while(dates, initial, fn date, acc ->
-        case sync_date(date, progress) do
+        case sync_date(date, progress, cache) do
           {:ok, imported, failed} ->
             # Persist the cursor the moment a day succeeds so an abrupt stop (an
             # orphaned-then-rescued job, a deploy restart, an uncaught crash)
@@ -119,6 +136,8 @@ defmodule Sanctum.DeckSync do
             {:halt, %{acc | halted: %{date: date, reason: reason}}}
         end
       end)
+
+    :ets.delete(cache)
 
     summary = %{
       days: length(dates),
@@ -157,10 +176,10 @@ defmodule Sanctum.DeckSync do
     :ok
   end
 
-  defp sync_date(date, progress) do
+  defp sync_date(date, progress, cache) do
     case MarvelCdb.get_decklists_by_date(date) do
       {:ok, decklists} ->
-        result = import_decklists(decklists, date, progress)
+        result = import_decklists(decklists, date, progress, cache)
         progress.({:date, Map.put(result, :date, date)})
         Process.sleep(@download_pause_ms)
         {:ok, result.imported, result.failed}
@@ -205,28 +224,45 @@ defmodule Sanctum.DeckSync do
     end
   end
 
-  defp import_decklists(decklists, date, progress) do
-    Enum.reduce(decklists, %{imported: 0, failed: 0}, fn decklist, acc ->
-      Process.sleep(@deck_pause_ms)
+  # Imports run concurrently (the day's payload is already fetched, so
+  # parallelism costs only DB round-trips); results stream back here so
+  # progress events and counter updates stay in this process, in one place.
+  defp import_decklists(decklists, date, progress, cache) do
+    decklists
+    |> Task.async_stream(
+      fn decklist ->
+        Process.sleep(@deck_pause_ms)
+        {decklist, import_one(decklist, cache)}
+      end,
+      max_concurrency: @import_concurrency,
+      timeout: @import_timeout_ms,
+      on_timeout: :kill_task,
+      ordered: false
+    )
+    |> Enum.reduce(%{imported: 0, failed: 0}, fn
+      {:ok, {decklist, {:ok, _deck}}}, acc ->
+        progress.({:deck, %{date: date, name: decklist["name"], ok?: true}})
+        Map.update!(acc, :imported, &(&1 + 1))
 
-      case import_one(decklist) do
-        {:ok, _deck} ->
-          progress.({:deck, %{date: date, name: decklist["name"], ok?: true}})
-          Map.update!(acc, :imported, &(&1 + 1))
+      {:ok, {decklist, {:error, reason}}}, acc ->
+        Logger.warning("Failed to import decklist #{decklist["id"]}: #{inspect(reason)}")
+        progress.({:deck, %{date: date, name: decklist["name"], ok?: false}})
+        Map.update!(acc, :failed, &(&1 + 1))
 
-        {:error, reason} ->
-          Logger.warning("Failed to import decklist #{decklist["id"]}: #{inspect(reason)}")
-          progress.({:deck, %{date: date, name: decklist["name"], ok?: false}})
-          Map.update!(acc, :failed, &(&1 + 1))
-      end
+      # A task that blew the per-deck timeout was killed; its decklist isn't
+      # recoverable from the exit tuple, so log it against the day.
+      {:exit, reason}, acc ->
+        Logger.warning("Decklist import task for #{date} exited: #{inspect(reason)}")
+        progress.({:deck, %{date: date, name: nil, ok?: false}})
+        Map.update!(acc, :failed, &(&1 + 1))
     end)
   end
 
   # A single malformed deck must never abort the whole run: import_decklist can
   # raise (e.g. a hero_code whose card isn't in the catalog yet), not just return
   # `{:error, _}`, so rescue and treat any raise as a per-deck failure.
-  defp import_one(decklist) do
-    MarvelCdb.import_decklist(decklist, mcdb_type: :decklist)
+  defp import_one(decklist, cache) do
+    MarvelCdb.import_decklist(decklist, mcdb_type: :decklist, cache: cache)
   rescue
     exception ->
       Sentry.capture_exception(exception, stacktrace: __STACKTRACE__)

--- a/lib/sanctum/decks/deck.ex
+++ b/lib/sanctum/decks/deck.ex
@@ -98,6 +98,14 @@ defmodule Sanctum.Decks.Deck do
       accept [:*]
       argument :slots, {:array, :map}
 
+      # This action is only reached via MarvelCDB imports, where the hero_id
+      # comes from find_or_create_hero on the deck's own hero card — ValidateHero
+      # would re-fetch that hero (with card + sides) per deck only to confirm
+      # what the import just constructed. Skipping also stops rejecting heroes
+      # with no alter-ego flip side (e.g. SP//dr), which the validation requires
+      # but MarvelCDB legitimately publishes.
+      skip_global_validations? true
+
       change fn changeset, _context ->
         slots = Ash.Changeset.get_argument(changeset, :slots) || []
 

--- a/lib/sanctum/decks/decklist_sync_worker.ex
+++ b/lib/sanctum/decks/decklist_sync_worker.ex
@@ -20,14 +20,13 @@ defmodule Sanctum.Decks.DecklistSyncWorker do
     # Route progress into the Monitor so the admin dashboard can watch the run
     # live (and see its outcome afterward); the Monitor also handles logging.
     result = Sanctum.DeckSync.run(progress_fun: &Sanctum.DeckSync.Monitor.report/1)
-    summary = elem(result, 1)
 
-    # New decks shift their heroes' uniqueness rankings; recompute. Do this even
-    # for a halted run — partial progress still imports decks. `unique` on the
-    # worker debounces this against the nightly cron run.
-    if summary.imported > 0 do
-      Sanctum.Decks.ComputeUniquenessWorker.new(%{}) |> Oban.insert()
-    end
+    # Uniqueness recompute is left to the nightly ComputeUniquenessWorker cron:
+    # enqueueing it after every sync run meant the full-library sweep (a
+    # multi-million-row read plus an UPDATE over every deck) ran near-constantly
+    # during the backfill — every halted-and-retried hourly run with any imports
+    # triggered another sweep — saturating the shared database. Newly synced
+    # decks just show as unranked until the next nightly sweep.
 
     case result do
       {:ok, _summary} ->

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -94,27 +94,47 @@ defmodule Sanctum.MarvelCdb do
 
     * `:mcdb_type` — `:decklist` (default) or `:deck`, stored to disambiguate
       the id space.
+    * `:cache` — a public ETS table used to memoize hero and mcdb_user
+      resolution across imports in one sync run (see `Sanctum.DeckSync`).
+      Without it every deck re-resolves its hero (several queries) even though
+      a run only ever touches a few dozen distinct heroes.
   """
   def import_decklist(decklist, opts \\ []) do
     decklist
-    |> prepare_deck_attrs(Keyword.get(opts, :mcdb_type, :decklist))
-    |> Decks.create_with_cards(load: [:cards, hero: [:hero_side, :alter_ego_side]])
+    |> prepare_deck_attrs(Keyword.get(opts, :mcdb_type, :decklist), Keyword.get(opts, :cache))
+    |> Decks.create_with_cards()
   end
 
-  defp prepare_deck_attrs(%{"slots" => cards_map} = decklist, mcdb_type) do
-    alter_ego_code =
-      decklist["hero_code"]
-      |> String.trim()
-      |> String.trim_trailing("a")
-      |> Kernel.<>("b")
+  defp prepare_deck_attrs(%{"slots" => cards_map} = decklist, mcdb_type, cache) do
+    hero =
+      cached(cache, {:hero, decklist["hero_code"]}, fn ->
+        alter_ego_code =
+          decklist["hero_code"]
+          |> String.trim()
+          |> String.trim_trailing("a")
+          |> Kernel.<>("b")
 
-    {:ok, hero_card} = load_card(decklist["hero_code"])
-    {:ok, alter_ego_card} = load_card(alter_ego_code)
+        {:ok, hero_card} = load_card(decklist["hero_code"])
+        # Ensure the alter-ego side's card is in the catalog too (load_card
+        # fetches it from MarvelCDB when missing); the Hero record itself is
+        # built from the hero card's sides.
+        {:ok, _alter_ego_card} = load_card(alter_ego_code)
 
-    # Create or find the Hero record
-    {:ok, hero} = create_or_find_hero(hero_card, alter_ego_card)
+        {:ok, hero} = create_or_find_hero(hero_card)
+        hero
+      end)
 
-    {:ok, mcdb_user} = create_or_find_mcdb_user(decklist["user_id"])
+    mcdb_user =
+      case decklist["user_id"] do
+        nil ->
+          nil
+
+        user_id ->
+          cached(cache, {:mcdb_user, user_id}, fn ->
+            {:ok, mcdb_user} = create_or_find_mcdb_user(user_id)
+            mcdb_user
+          end)
+      end
 
     meta = parse_meta(decklist["meta"])
 
@@ -208,13 +228,28 @@ defmodule Sanctum.MarvelCdb do
     end
   end
 
-  defp create_or_find_mcdb_user(nil), do: {:ok, nil}
+  # Memoize `fun` under `key` in a public ETS table; with no table (nil), just
+  # run it. A lost race on a miss only duplicates idempotent find-or-create
+  # work, so concurrent importers can share the table without coordination.
+  defp cached(nil, _key, fun), do: fun.()
+
+  defp cached(table, key, fun) do
+    case :ets.lookup(table, key) do
+      [{^key, value}] ->
+        value
+
+      [] ->
+        value = fun.()
+        :ets.insert(table, {key, value})
+        value
+    end
+  end
 
   defp create_or_find_mcdb_user(mcdb_user_id) when is_integer(mcdb_user_id) do
     Decks.find_or_create_mcdb_user(%{mcdb_user_id: mcdb_user_id})
   end
 
-  defp create_or_find_hero(hero_card, _alter_ego_card) do
+  defp create_or_find_hero(hero_card) do
     # Load the card with all its sides to get both hero and alter ego names
     card_loaded = Games.get_card!(hero_card.id, load: [:card_sides])
 


### PR DESCRIPTION
## Summary

Follow-up to #184/#185 — the sync was crawling (a few decks/minute) and dragging the whole app with it. Three changes:

### 1. Uniqueness sweep no longer runs after every sync
`DecklistSyncWorker` enqueued `ComputeUniquenessWorker` after every run that imported anything. During the backfill, runs constantly halt on MarvelCDB 500s and retry hourly, so the full-library sweep (~1.5–2M-row read + an `UPDATE` rewriting all 35K decks) ran near-constantly on Neon's shared compute. The nightly 4:30 cron sweep remains; newly synced decks show unranked until then.

### 2. Per-deck query dead weight removed
- **Dropped the post-upsert `load: [:cards, hero: [...]]`** from `import_decklist` (~4–5 queries/deck). Audited all callers: the by-date sync discards the record; the game-setup and admin URL imports read only `deck.title`.
- **`skip_global_validations?` on `:create_with_cards`** — `ValidateHero` re-fetched the hero with card + sides per deck to confirm what `find_or_create_hero` had just constructed in the same import (2–3 queries/deck). Side effect: heroes with no alter-ego flip side (e.g. SP//dr) are no longer rejected on import. Native deck actions keep the validation.
- **Run-scoped ETS memo for hero/mcdb_user resolution** — a run touches ~67 distinct heroes but resolved each from scratch per deck (2 card lookups + a card_sides fetch + find_or_create, ~4–5 queries). Now once per hero per run.

### 3. Per-day imports run concurrently
`Task.async_stream` with `max_concurrency: 4` (pool is 10). A day's decklists arrive in **one** HTTP payload, so parallelism adds zero MarvelCDB load — only overlapping DB round-trips. The 50ms politeness pause now paces each lane; the `unique_mcdb_deck` upsert identity and find-or-create upserts make concurrent imports race-safe, and cache-miss races just duplicate idempotent work. Per-deck timeout of 2 min covers the live-fetch fallback for unknown card codes.

Net effect: ~13–16 queries/deck → ~5, times 4 lanes.

## Verification

- 198 tests green, `mix ck` clean
- Live one-day sync (`2026-07-14`) against real MarvelCDB in dev: 20 decklists re-imported in ~5.5s, 0 failures, deck count unchanged (upsert idempotency intact through the new path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)