### PR TITLE
perf(web): async-load the public catalog LiveViews

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,11 @@
 import Config
+
+# LiveView pages load their data in start_async, and `render_async/1` waits up
+# to :assert_receive_timeout (ExUnit default 100ms) for it. The heavier pages
+# (e.g. the deck detail's nested load + similarity query) can exceed that on a
+# cold CI runner, so give async loads generous headroom.
+config :ex_unit, assert_receive_timeout: 2000
+
 config :sanctum, Oban, testing: :manual
 config :sanctum, :marvel_cdb_req_options, plug: {Req.Test, Sanctum.MarvelCdb}
 config :sanctum, token_signing_secret: "/oZ9ck2w3h4oPYA4x7ZebHnqCh1MKXIp"

--- a/lib/sanctum_web.ex
+++ b/lib/sanctum_web.ex
@@ -87,6 +87,7 @@ defmodule SanctumWeb do
       # Core UI components
       import SanctumWeb.CoreComponents
       import SanctumWeb.Components.Card
+      import SanctumWeb.Components.Skeleton
 
       # Common modules used in templates
       alias Phoenix.LiveView.JS

--- a/lib/sanctum_web/components/skeleton.ex
+++ b/lib/sanctum_web/components/skeleton.ex
@@ -1,0 +1,114 @@
+defmodule SanctumWeb.Components.Skeleton do
+  @moduledoc """
+  Loading placeholders for the async-mount pattern. Every LiveView paints its
+  shell on the disconnected render (no DB) and streams real data in once the
+  socket connects; these skeletons hold the layout in the gap so the page
+  doesn't jump when content lands.
+
+  `skeleton/1` is the pulsing-block primitive. The `*_skeleton` helpers compose
+  it into the footprints the catalog pages actually render (card tiles, deck
+  rows, detail panels).
+  """
+  use Phoenix.Component
+
+  @doc "A single pulsing placeholder block. Size it with `class`."
+  attr :class, :string, default: ""
+  attr :rest, :global
+
+  def skeleton(assigns) do
+    ~H"""
+    <div class={["animate-pulse bg-base-300", @class]} {@rest}></div>
+    """
+  end
+
+  @doc """
+  Grid of card-tile placeholders matching `SanctumWeb.Components.CardSideTile`.
+  Used by the card pool and card admin table while the first page loads.
+  """
+  attr :count, :integer, default: 6
+
+  def card_tile_skeleton_grid(assigns) do
+    ~H"""
+    <div class="grid grid-cols-1 items-start gap-[18px] sm:grid-cols-[repeat(auto-fill,minmax(452px,1fr))]">
+      <.card_tile_skeleton :for={_ <- 1..@count} />
+    </div>
+    """
+  end
+
+  @doc "A single card-tile placeholder (landscape art frame + text lines)."
+  def card_tile_skeleton(assigns) do
+    ~H"""
+    <div class="flex animate-pulse gap-[13px] border-2 border-neutral bg-base-200 p-2 shadow-comic">
+      <div class="h-[180px] w-[128px] flex-none border-2 border-neutral bg-base-300"></div>
+      <div class="flex min-w-0 flex-1 flex-col gap-2 py-1">
+        <div class="h-2 w-1/3 bg-base-300"></div>
+        <div class="h-5 w-2/3 bg-base-300"></div>
+        <div class="mt-2 h-3 w-full bg-base-300"></div>
+        <div class="h-3 w-5/6 bg-base-300"></div>
+        <div class="h-3 w-4/6 bg-base-300"></div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc "Grid of deck-row placeholders matching the deck browser feed."
+  attr :count, :integer, default: 6
+
+  def deck_tile_skeleton_grid(assigns) do
+    ~H"""
+    <div class="grid grid-cols-1 items-start gap-3 sm:grid-cols-[repeat(auto-fill,minmax(520px,1fr))]">
+      <div
+        :for={_ <- 1..@count}
+        class="flex animate-pulse items-stretch gap-3 border-2 border-neutral bg-base-200 p-3 shadow-comic sm:gap-4 sm:p-3.5"
+      >
+        <div class="h-[151px] w-[108px] flex-none border-2 border-neutral bg-base-300"></div>
+        <div class="flex min-w-0 flex-1 flex-col gap-2.5 py-1">
+          <div class="h-3 w-24 bg-base-300"></div>
+          <div class="mt-1 h-6 w-2/3 bg-base-300"></div>
+          <div class="h-3 w-full bg-base-300"></div>
+          <div class="h-3 w-1/2 bg-base-300"></div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Generic tile grid placeholder for pack-style card grids (browse pages).
+  Renders `count` portrait art frames.
+  """
+  attr :count, :integer, default: 8
+  attr :class, :string, default: "grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4"
+
+  def art_grid_skeleton(assigns) do
+    ~H"""
+    <div class={@class}>
+      <div
+        :for={_ <- 1..@count}
+        class="aspect-[5/7] animate-pulse border-2 border-neutral bg-base-300 shadow-comic-sm"
+      >
+      </div>
+    </div>
+    """
+  end
+
+  @doc "Full-width detail-panel placeholder for single-record detail pages."
+  def detail_skeleton(assigns) do
+    ~H"""
+    <div class="animate-pulse space-y-4">
+      <div class="flex flex-col gap-6 sm:flex-row">
+        <div class="aspect-[5/7] w-full max-w-[280px] flex-none border-2 border-neutral bg-base-300 shadow-comic">
+        </div>
+        <div class="flex min-w-0 flex-1 flex-col gap-3">
+          <div class="h-4 w-28 bg-base-300"></div>
+          <div class="h-9 w-3/4 bg-base-300"></div>
+          <div class="mt-2 h-3 w-full bg-base-300"></div>
+          <div class="h-3 w-11/12 bg-base-300"></div>
+          <div class="h-3 w-5/6 bg-base-300"></div>
+          <div class="mt-4 h-3 w-2/3 bg-base-300"></div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/sanctum_web/live/browse_live/index.ex
+++ b/lib/sanctum_web/live/browse_live/index.ex
@@ -26,6 +26,41 @@ defmodule SanctumWeb.BrowseLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:page_title, "Browse")
+      # nil until the async load lands — drives the loading/skeleton UI.
+      |> assign(:wave_sections, nil)
+      |> assign(:other_packs, [])
+      |> assign(:covers, %{})
+
+    # Skip every query on the static (disconnected) render; the taxonomy loads
+    # asynchronously once the socket connects so nothing blocks first paint.
+    socket =
+      if connected?(socket), do: start_async(socket, :load_browse, &load_browse/0), else: socket
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_async(:load_browse, {:ok, result}, socket) do
+    {:noreply,
+     socket
+     |> assign(:wave_sections, result.wave_sections)
+     |> assign(:other_packs, result.other_packs)
+     |> assign(:covers, result.covers)}
+  end
+
+  def handle_async(:load_browse, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> assign(:wave_sections, [])
+     |> put_flash(:error, "Couldn’t load the browser: #{inspect(reason)}")}
+  end
+
+  # The full release taxonomy: waves, their packs (with card totals), and one
+  # representative cover image per pack.
+  defp load_browse do
     waves = Ash.read!(Ash.Query.sort(Catalog.Wave, number: :asc))
 
     packs =
@@ -34,7 +69,6 @@ defmodule SanctumWeb.BrowseLive.Index do
       |> Ash.Query.sort(position: :asc)
       |> Ash.read!()
 
-    covers = pack_cover_images()
     by_wave = Enum.group_by(packs, & &1.wave_id)
 
     wave_sections =
@@ -42,15 +76,12 @@ defmodule SanctumWeb.BrowseLive.Index do
         %{wave: wave, packs: sort_packs(Map.get(by_wave, wave.id, []))}
       end)
 
-    # Packs with no wave (e.g. the standalone Ronan Modular Set) render last.
-    other_packs = sort_packs(Map.get(by_wave, nil, []))
-
-    {:ok,
-     socket
-     |> assign(:page_title, "Browse")
-     |> assign(:wave_sections, wave_sections)
-     |> assign(:other_packs, other_packs)
-     |> assign(:covers, covers)}
+    %{
+      wave_sections: wave_sections,
+      # Packs with no wave (e.g. the standalone Ronan Modular Set) render last.
+      other_packs: sort_packs(Map.get(by_wave, nil, [])),
+      covers: pack_cover_images()
+    }
   end
 
   @impl true
@@ -64,7 +95,21 @@ defmodule SanctumWeb.BrowseLive.Index do
         </:subtitle>
       </.header>
 
-      <div class="flex flex-col gap-10">
+      <!-- first-load skeletons -->
+      <div :if={@wave_sections == nil} class="flex flex-col gap-10">
+        <section :for={_ <- 1..2}>
+          <div class="mb-3.5 h-7 w-48 animate-pulse border-b-2 border-neutral bg-base-300 pb-2"></div>
+          <div class="grid grid-cols-2 gap-3.5 sm:grid-cols-[repeat(auto-fill,minmax(220px,1fr))]">
+            <div
+              :for={_ <- 1..6}
+              class="aspect-[3/2] animate-pulse border-2 border-neutral bg-base-300 shadow-comic"
+            >
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div :if={@wave_sections != nil} class="flex flex-col gap-10">
         <section :for={section <- @wave_sections} :if={section.packs != []}>
           <.wave_heading wave={section.wave} packs={section.packs} />
           <.pack_grid packs={section.packs} covers={@covers} />

--- a/lib/sanctum_web/live/browse_live/show.ex
+++ b/lib/sanctum_web/live/browse_live/show.ex
@@ -25,6 +25,58 @@ defmodule SanctumWeb.BrowseLive.Show do
 
   @impl true
   def mount(%{"pack" => code}, _session, socket) do
+    socket =
+      socket
+      |> assign(:page_title, "Browse")
+      # nil until the async load lands — drives the loading/skeleton UI.
+      |> assign(:pack, nil)
+      |> assign(:villain_groups, [])
+      |> assign(:encounter_groups, [])
+      |> assign(:sections, [])
+      |> assign(:modular_groups, [])
+      |> assign(:player_groups, [])
+
+    # Skip the (heavy) product load on the static render; it runs asynchronously
+    # once the socket connects so the shell paints immediately.
+    socket =
+      if connected?(socket),
+        do: start_async(socket, :load_pack, fn -> load_pack(code) end),
+        else: socket
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_async(:load_pack, {:ok, {:ok, data}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, data.page_title)
+     |> assign(:pack, data.pack)
+     |> assign(:villain_groups, data.villain_groups)
+     |> assign(:encounter_groups, data.encounter_groups)
+     |> assign(:sections, data.sections)
+     |> assign(:modular_groups, data.modular_groups)
+     |> assign(:player_groups, data.player_groups)}
+  end
+
+  def handle_async(:load_pack, {:ok, {:error, code}}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Unknown product “#{code}”.")
+     |> push_navigate(to: ~p"/browse")}
+  end
+
+  def handle_async(:load_pack, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Couldn’t load product: #{inspect(reason)}")
+     |> push_navigate(to: ~p"/browse")}
+  end
+
+  # The whole product view: the pack with its nested card sets/sides, plus every
+  # derived section grouping. Returns `{:error, code}` for an unknown code so
+  # handle_async can redirect.
+  defp load_pack(code) do
     case Catalog.get_pack_by_code(code,
            load: [:wave, :card_total, card_sets: [cards: [:primary_side, :card_sides]]]
          ) do
@@ -32,20 +84,18 @@ defmodule SanctumWeb.BrowseLive.Show do
         hero_colors = Sanctum.Heroes.hero_color_map()
 
         {:ok,
-         socket
-         |> assign(:page_title, pack.name || pack.code)
-         |> assign(:pack, pack)
-         |> assign(:villain_groups, villain_groups(pack, hero_colors))
-         |> assign(:encounter_groups, encounter_groups(pack, hero_colors))
-         |> assign(:sections, build_sections(pack, hero_colors))
-         |> assign(:modular_groups, modular_groups(pack, hero_colors))
-         |> assign(:player_groups, player_card_groups(pack, hero_colors))}
+         %{
+           page_title: pack.name || pack.code,
+           pack: pack,
+           villain_groups: villain_groups(pack, hero_colors),
+           encounter_groups: encounter_groups(pack, hero_colors),
+           sections: build_sections(pack, hero_colors),
+           modular_groups: modular_groups(pack, hero_colors),
+           player_groups: player_card_groups(pack, hero_colors)
+         }}
 
       _ ->
-        {:ok,
-         socket
-         |> put_flash(:error, "Unknown product “#{code}”.")
-         |> push_navigate(to: ~p"/browse")}
+        {:error, code}
     end
   end
 
@@ -53,65 +103,76 @@ defmodule SanctumWeb.BrowseLive.Show do
   def render(assigns) do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:browse}>
-      <.header>
-        <.link navigate={~p"/browse"} class="text-base-content/45 hover:text-primary">Browse</.link>
-        <span class="text-base-content/30">/</span>
-        {@pack.name || @pack.code}
-        <:subtitle>
-          {product_type_label(@pack.product_type)}
-          <span :if={@pack.wave}>
-            · {@pack.wave.name}
-          </span><span :if={@pack.released_on}>
-            · {@pack.released_on.year}
-          </span>
-          · {@pack.card_total || 0} cards
-        </:subtitle>
-      </.header>
-
-      <div class="flex flex-col gap-9">
-        <.grouped_section
-          title="Villains"
-          description="Scenario villain sets included in this product."
-          groups={@villain_groups}
-        />
-
-        <.grouped_section
-          title="Encounter Sets"
-          description="Standard, expert, and leader encounter sets included in this product."
-          groups={@encounter_groups}
-        />
-
-        <.card_section
-          :for={section <- @sections}
-          title={section.title}
-          subtitle={section.subtitle}
-          cards={section.cards}
-        />
-
-        <.grouped_section
-          title="Player Cards"
-          description="Aspect and basic cards included in this product."
-          groups={@player_groups}
-        />
-
-        <.grouped_section
-          title="Modular Sets"
-          description="Encounter modules included in this product."
-          groups={@modular_groups}
-        />
+      <!-- first-load skeleton -->
+      <div :if={@pack == nil} class="flex flex-col gap-6">
+        <div class="h-9 w-1/2 max-w-md animate-pulse bg-base-300"></div>
+        <div class="h-4 w-1/3 max-w-xs animate-pulse bg-base-300"></div>
+        <.art_grid_skeleton count={8} />
       </div>
 
-      <.panel
-        :if={
-          @sections == [] and @villain_groups == [] and @encounter_groups == [] and
-            @player_groups == [] and @modular_groups == []
-        }
-        class="mt-2 p-6 text-center"
-      >
-        <p class="font-barlow-condensed text-lg text-base-content/60">
-          No cards have been synced for this product yet.
-        </p>
-      </.panel>
+      <div :if={@pack != nil}>
+        <.header>
+          <.link navigate={~p"/browse"} class="text-base-content/45 hover:text-primary">
+            Browse
+          </.link>
+          <span class="text-base-content/30">/</span>
+          {@pack.name || @pack.code}
+          <:subtitle>
+            {product_type_label(@pack.product_type)}
+            <span :if={@pack.wave}>
+              · {@pack.wave.name}
+            </span><span :if={@pack.released_on}>
+              · {@pack.released_on.year}
+            </span>
+            · {@pack.card_total || 0} cards
+          </:subtitle>
+        </.header>
+
+        <div class="flex flex-col gap-9">
+          <.grouped_section
+            title="Villains"
+            description="Scenario villain sets included in this product."
+            groups={@villain_groups}
+          />
+
+          <.grouped_section
+            title="Encounter Sets"
+            description="Standard, expert, and leader encounter sets included in this product."
+            groups={@encounter_groups}
+          />
+
+          <.card_section
+            :for={section <- @sections}
+            title={section.title}
+            subtitle={section.subtitle}
+            cards={section.cards}
+          />
+
+          <.grouped_section
+            title="Player Cards"
+            description="Aspect and basic cards included in this product."
+            groups={@player_groups}
+          />
+
+          <.grouped_section
+            title="Modular Sets"
+            description="Encounter modules included in this product."
+            groups={@modular_groups}
+          />
+        </div>
+
+        <.panel
+          :if={
+            @sections == [] and @villain_groups == [] and @encounter_groups == [] and
+              @player_groups == [] and @modular_groups == []
+          }
+          class="mt-2 p-6 text-center"
+        >
+          <p class="font-barlow-condensed text-lg text-base-content/60">
+            No cards have been synced for this product yet.
+          </p>
+        </.panel>
+      </div>
     </Layouts.app>
     """
   end

--- a/lib/sanctum_web/live/card_live/detail.ex
+++ b/lib/sanctum_web/live/card_live/detail.ex
@@ -15,122 +15,134 @@ defmodule SanctumWeb.CardLive.Detail do
   def render(assigns) do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:cards}>
-      <.header>
-        {@title}
-        <:subtitle>
-          <span class="font-ibm-mono text-[12px] uppercase tracking-[0.16em]">
-            {@card.base_code}
-          </span>
-          <span :if={@card.pack}> · {@card.pack}</span>
-          · {length(@sides)} side{if length(@sides) != 1, do: "s"}
-          <span :if={@card.unique} class="text-base-content/45">· unique</span>
-        </:subtitle>
+      <!-- first-load skeleton -->
+      <div :if={@card == nil}>
+        <div class="mb-6 h-9 w-1/2 max-w-md animate-pulse bg-base-300"></div>
+        <.detail_skeleton />
+      </div>
 
-        <:actions>
-          <.button navigate={~p"/cards"}>
-            <.icon name="hero-arrow-left" /> Card Pool
-          </.button>
-          <.button
-            :if={@current_user && @current_user.admin}
-            variant="primary"
-            navigate={~p"/admin/cards/#{@card}"}
-          >
-            <.icon name="hero-wrench-screwdriver" /> Manage
-          </.button>
-        </:actions>
-      </.header>
+      <div :if={@card != nil}>
+        <.header>
+          {@title}
+          <:subtitle>
+            <span class="font-ibm-mono text-[12px] uppercase tracking-[0.16em]">
+              {@card.base_code}
+            </span>
+            <span :if={@card.pack}> · {@card.pack}</span>
+            · {length(@sides)} side{if length(@sides) != 1, do: "s"}
+            <span :if={@card.unique} class="text-base-content/45">· unique</span>
+          </:subtitle>
 
-      <div class="mx-auto flex max-w-[1240px] flex-col gap-5">
-        <!-- card faces + metadata: equal-height columns (grid stretch); the
+          <:actions>
+            <.button navigate={~p"/cards"}>
+              <.icon name="hero-arrow-left" /> Card Pool
+            </.button>
+            <.button
+              :if={@current_user && @current_user.admin}
+              variant="primary"
+              navigate={~p"/admin/cards/#{@card}"}
+            >
+              <.icon name="hero-wrench-screwdriver" /> Manage
+            </.button>
+          </:actions>
+        </.header>
+
+        <div class="mx-auto flex max-w-[1240px] flex-col gap-5">
+          <!-- card faces + metadata: equal-height columns (grid stretch); the
              last tile grows so the column matches the panel when it's taller -->
-        <div class="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
-          <div class="flex min-w-0 flex-col gap-[18px] lg:[&>*:last-child]:flex-1">
-            <.card_side_tile :for={side <- @sides} id={"side-#{side.id}"} side={side} size="lg" />
-          </div>
-
-          <!-- metadata side panel -->
-          <.panel class="p-4">
-            <div class="mb-3 border-b-2 border-neutral pb-2 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
-              Card File
+          <div class="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+            <div class="flex min-w-0 flex-col gap-[18px] lg:[&>*:last-child]:flex-1">
+              <.card_side_tile :for={side <- @sides} id={"side-#{side.id}"} side={side} size="lg" />
             </div>
 
-            <div class="flex flex-col gap-3">
-              <div :if={@pack}>
-                <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
-                  Pack
+            <!-- metadata side panel -->
+            <.panel class="p-4">
+              <div class="mb-3 border-b-2 border-neutral pb-2 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+                Card File
+              </div>
+
+              <div class="flex flex-col gap-3">
+                <div :if={@pack}>
+                  <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+                    Pack
+                  </div>
+                  <.link
+                    navigate={~p"/browse/#{@pack.code}"}
+                    class="mt-0.5 block font-barlow-condensed text-[15px] font-semibold hover:text-primary"
+                  >
+                    {@pack.name || @pack.code}
+                  </.link>
                 </div>
-                <.link
-                  navigate={~p"/browse/#{@pack.code}"}
-                  class="mt-0.5 block font-barlow-condensed text-[15px] font-semibold hover:text-primary"
+
+                <.meta
+                  :if={@pack}
+                  label="Product Type"
+                  value={product_type_label(@pack.product_type)}
+                />
+                <.meta :if={@pack} label="Released" value={format_date(@pack.released_on)} />
+                <.meta :if={@pack && @pack.wave} label="Wave" value={@pack.wave.name} />
+                <.meta
+                  :if={@card.card_set}
+                  label="Card Set"
+                  value={card_set_label(@card.card_set)}
+                />
+
+                <div class="my-1 h-px bg-neutral"></div>
+
+                <div class="grid grid-cols-2 gap-x-4 gap-y-3">
+                  <.meta label="Code" value={@card.base_code} />
+                  <.meta label="Printings" value={1 + length(@card.alts)} />
+                  <.meta label="Deck Limit" value={@card.deck_limit} />
+                  <.meta label="Unique" value={yes_no(@card.unique)} />
+                  <.meta label="Permanent" value={yes_no(@card.permanent)} />
+                  <.meta label="Multi-sided" value={yes_no(@card.is_multi_sided)} />
+                </div>
+
+                <div class="my-1 h-px bg-neutral"></div>
+
+                <a
+                  href={"https://marvelcdb.com/card/#{@card.code}"}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="flex items-center gap-1.5 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/60 hover:text-primary"
                 >
-                  {@pack.name || @pack.code}
-                </.link>
+                  <.icon name="hero-arrow-top-right-on-square" class="size-3.5" /> View on MarvelCDB
+                </a>
               </div>
+            </.panel>
+          </div>
 
-              <.meta :if={@pack} label="Product Type" value={product_type_label(@pack.product_type)} />
-              <.meta :if={@pack} label="Released" value={format_date(@pack.released_on)} />
-              <.meta :if={@pack && @pack.wave} label="Wave" value={@pack.wave.name} />
-              <.meta
-                :if={@card.card_set}
-                label="Card Set"
-                value={card_set_label(@card.card_set)}
-              />
-
-              <div class="my-1 h-px bg-neutral"></div>
-
-              <div class="grid grid-cols-2 gap-x-4 gap-y-3">
-                <.meta label="Code" value={@card.base_code} />
-                <.meta label="Printings" value={1 + length(@card.alts)} />
-                <.meta label="Deck Limit" value={@card.deck_limit} />
-                <.meta label="Unique" value={yes_no(@card.unique)} />
-                <.meta label="Permanent" value={yes_no(@card.permanent)} />
-                <.meta label="Multi-sided" value={yes_no(@card.is_multi_sided)} />
-              </div>
-
-              <div class="my-1 h-px bg-neutral"></div>
-
-              <a
-                href={"https://marvelcdb.com/card/#{@card.code}"}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="flex items-center gap-1.5 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/60 hover:text-primary"
-              >
-                <.icon name="hero-arrow-top-right-on-square" class="size-3.5" /> View on MarvelCDB
-              </a>
+          <!-- alternate printings -->
+          <.panel :if={@alts != []} class="p-4">
+            <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+              Alternate Printings ({length(@alts)})
+            </div>
+            <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+              <figure :for={alt <- @alts} class="flex flex-col gap-1.5">
+                <div class="aspect-[5/7] w-full overflow-hidden border-2 border-neutral shadow-comic">
+                  <img
+                    :if={alt.image_url}
+                    src={alt.image_url}
+                    alt={alt.code}
+                    loading="lazy"
+                    class="h-full w-full object-cover"
+                  />
+                  <div
+                    :if={!alt.image_url}
+                    class="bg-card-hatch flex h-full w-full items-center justify-center"
+                  >
+                    <span class="whitespace-nowrap font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-white/[0.32]">
+                      no scan
+                    </span>
+                  </div>
+                </div>
+                <figcaption class="font-ibm-mono text-[10px] uppercase tracking-[0.16em] text-base-content/50">
+                  {alt.code}<span :if={alt.pack}> · {alt.pack}</span>
+                </figcaption>
+              </figure>
             </div>
           </.panel>
         </div>
-
-        <!-- alternate printings -->
-        <.panel :if={@alts != []} class="p-4">
-          <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
-            Alternate Printings ({length(@alts)})
-          </div>
-          <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
-            <figure :for={alt <- @alts} class="flex flex-col gap-1.5">
-              <div class="aspect-[5/7] w-full overflow-hidden border-2 border-neutral shadow-comic">
-                <img
-                  :if={alt.image_url}
-                  src={alt.image_url}
-                  alt={alt.code}
-                  loading="lazy"
-                  class="h-full w-full object-cover"
-                />
-                <div
-                  :if={!alt.image_url}
-                  class="bg-card-hatch flex h-full w-full items-center justify-center"
-                >
-                  <span class="whitespace-nowrap font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-white/[0.32]">
-                    no scan
-                  </span>
-                </div>
-              </div>
-              <figcaption class="font-ibm-mono text-[10px] uppercase tracking-[0.16em] text-base-content/50">
-                {alt.code}<span :if={alt.pack}> · {alt.pack}</span>
-              </figcaption>
-            </figure>
-          </div>
-        </.panel>
       </div>
     </Layouts.app>
     """
@@ -152,41 +164,89 @@ defmodule SanctumWeb.CardLive.Detail do
 
   @impl true
   def mount(%{"id" => id}, _session, socket) do
-    card =
-      Ash.get!(Sanctum.Games.Card, id,
-        actor: socket.assigns[:current_user],
-        load: [:card_sides, :primary_side, :alts, :card_set, pack_ref: [:wave]]
-      )
+    socket =
+      socket
+      |> assign(:page_title, "Card")
+      # nil until the async load lands — drives the loading/skeleton UI.
+      |> assign(:title, nil)
+      |> assign(:card, nil)
+      |> assign(:pack, nil)
+      |> assign(:sides, [])
+      |> assign(:alts, [])
 
-    hero_colors = Sanctum.Heroes.hero_color_map()
-    title = (card.primary_side && card.primary_side.name) || card.base_code
+    actor = socket.assigns[:current_user]
 
-    # side_view/2 reads `side.card` for set/gradient data; the sides were
-    # loaded through the card, so hand it back rather than re-querying.
-    sides =
-      card.card_sides
-      |> Enum.sort_by(& &1.side_identifier)
-      |> Enum.map(&side_view(%{&1 | card: card}, hero_colors))
+    # Skip the card load on the static render; it runs asynchronously once the
+    # socket connects so the shell paints immediately.
+    socket =
+      if connected?(socket),
+        do: start_async(socket, :load_card, fn -> load_card(id, actor) end),
+        else: socket
 
-    # Every alternate printing. MarvelCDB has no scan for many reprints
-    # (imagesrc is null there, so our mirrored image_url is too) — those render
-    # as placeholders, sorted after the printings that have art. Pack codes
-    # resolve to catalog pack names when the pack has been synced.
-    pack_names = pack_names(card.alts)
+    {:ok, socket}
+  end
 
-    alts =
-      card.alts
-      |> Enum.sort_by(&{is_nil(&1.image_url), &1.code})
-      |> Enum.map(&%{&1 | pack: Map.get(pack_names, &1.pack, &1.pack)})
-
-    {:ok,
+  @impl true
+  def handle_async(:load_card, {:ok, {:ok, data}}, socket) do
+    {:noreply,
      socket
-     |> assign(:page_title, title)
-     |> assign(:title, title)
-     |> assign(:card, card)
-     |> assign(:pack, card.pack_ref)
-     |> assign(:sides, sides)
-     |> assign(:alts, alts)}
+     |> assign(:page_title, data.title)
+     |> assign(:title, data.title)
+     |> assign(:card, data.card)
+     |> assign(:pack, data.pack)
+     |> assign(:sides, data.sides)
+     |> assign(:alts, data.alts)}
+  end
+
+  def handle_async(:load_card, {:ok, :not_found}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Card not found.")
+     |> push_navigate(to: ~p"/cards")}
+  end
+
+  def handle_async(:load_card, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Couldn’t load card: #{inspect(reason)}")
+     |> push_navigate(to: ~p"/cards")}
+  end
+
+  # Load the card with every face, its alts, and pack metadata, then build the
+  # display maps. Returns `:not_found` for an unknown id so handle_async can
+  # redirect rather than crash the LiveView.
+  defp load_card(id, actor) do
+    case Ash.get(Sanctum.Games.Card, id,
+           actor: actor,
+           load: [:card_sides, :primary_side, :alts, :card_set, pack_ref: [:wave]]
+         ) do
+      {:ok, card} ->
+        hero_colors = Sanctum.Heroes.hero_color_map()
+        title = (card.primary_side && card.primary_side.name) || card.base_code
+
+        # side_view/2 reads `side.card` for set/gradient data; the sides were
+        # loaded through the card, so hand it back rather than re-querying.
+        sides =
+          card.card_sides
+          |> Enum.sort_by(& &1.side_identifier)
+          |> Enum.map(&side_view(%{&1 | card: card}, hero_colors))
+
+        # Every alternate printing. MarvelCDB has no scan for many reprints
+        # (imagesrc is null there, so our mirrored image_url is too) — those
+        # render as placeholders, sorted after the printings that have art.
+        # Pack codes resolve to catalog pack names when the pack has been synced.
+        pack_names = pack_names(card.alts)
+
+        alts =
+          card.alts
+          |> Enum.sort_by(&{is_nil(&1.image_url), &1.code})
+          |> Enum.map(&%{&1 | pack: Map.get(pack_names, &1.pack, &1.pack)})
+
+        {:ok, %{title: title, card: card, pack: card.pack_ref, sides: sides, alts: alts}}
+
+      {:error, _} ->
+        :not_found
+    end
   end
 
   # pack code -> pack name for the packs the alternate printings came from.

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -51,8 +51,16 @@ defmodule SanctumWeb.DeckLive.Index do
             class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-base text-base-content outline-none focus:border-primary sm:text-[15px]"
           />
         </form>
-        <div class="whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
-          {@count} <span class="text-base-content/45">/ {@total} decks</span>
+        <div class="flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
+          <.icon
+            :if={@loading?}
+            name="hero-arrow-path"
+            class="size-4 animate-spin text-base-content/45"
+          />
+          <span :if={@count == nil} class="text-base-content/45">Loading…</span>
+          <span :if={@count != nil}>
+            {@count} <span class="text-base-content/45">/ {@total} decks</span>
+          </span>
         </div>
       </div>
 
@@ -98,12 +106,18 @@ defmodule SanctumWeb.DeckLive.Index do
         </.filter_pill>
       </div>
 
+      <!-- first-load skeletons: shown until the async load delivers a count -->
+      <.deck_tile_skeleton_grid :if={@count == nil} />
+
       <!-- feed -->
       <div
         id="deck-feed"
         phx-update="stream"
         phx-viewport-bottom={!@end_of_timeline? && "next-page"}
-        class="grid grid-cols-1 items-start gap-3 sm:grid-cols-[repeat(auto-fill,minmax(520px,1fr))]"
+        class={[
+          "grid grid-cols-1 items-start gap-3 sm:grid-cols-[repeat(auto-fill,minmax(520px,1fr))]",
+          @loading? && @count != nil && "opacity-60 transition-opacity"
+        ]}
       >
         <.link
           :for={{dom_id, deck} <- @streams.decks}
@@ -195,24 +209,31 @@ defmodule SanctumWeb.DeckLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    total = count_decks(socket, %{})
+    socket =
+      socket
+      |> assign(:page_title, "Browse Decks")
+      |> assign(:query, "")
+      |> assign(:sort, "new")
+      |> assign(:aspect, "all")
+      |> assign(:hero_id, "all")
+      # nil until the first async load lands — drives the loading/skeleton UI.
+      |> assign(:total, nil)
+      |> assign(:count, nil)
+      |> assign(:aspect_options, @aspects)
+      |> assign(:sort_options, @sorts)
+      |> assign(:hero_options, [])
+      |> assign(:offset, 0)
+      |> assign(:end_of_timeline?, false)
+      |> assign(:req_id, 0)
+      |> assign(:loading?, true)
+      |> stream(:decks, [])
 
-    {:ok,
-     socket
-     |> assign(:page_title, "Browse Decks")
-     |> assign(:query, "")
-     |> assign(:sort, "new")
-     |> assign(:aspect, "all")
-     |> assign(:hero_id, "all")
-     |> assign(:total, total)
-     |> assign(:count, total)
-     |> assign(:aspect_options, @aspects)
-     |> assign(:sort_options, @sorts)
-     |> assign(:hero_options, load_hero_options())
-     |> assign(:offset, 0)
-     |> assign(:end_of_timeline?, false)
-     |> stream(:decks, [])
-     |> load_page(0, reset: true)}
+    # Skip every query on the static (disconnected) render — it exists only to
+    # paint the shell fast. The real data loads asynchronously once the socket
+    # connects, so nothing blocks time-to-first-paint.
+    socket = if connected?(socket), do: start_load(socket, 0, reset: true), else: socket
+
+    {:ok, socket}
   end
 
   # {id, hero_name} for every hero, sorted by name.
@@ -248,40 +269,84 @@ defmodule SanctumWeb.DeckLive.Index do
      |> reset_and_load()}
   end
 
+  # Ignore the viewport trigger while a page is already in flight so a burst of
+  # scroll events can't fan out into overlapping loads.
   def handle_event("next-page", _params, socket) do
-    if socket.assigns.end_of_timeline? do
+    if socket.assigns.end_of_timeline? or socket.assigns.loading? do
       {:noreply, socket}
     else
-      {:noreply, load_page(socket, socket.assigns.offset + @page_size)}
+      {:noreply, start_load(socket, socket.assigns.offset + @page_size)}
     end
   end
 
-  defp reset_and_load(socket), do: load_page(socket, 0, reset: true)
+  @impl true
+  def handle_async(:load_decks, {:ok, result}, socket) do
+    %{req: req, offset: offset, reset?: reset?, page: page, hero_options: hero_options} = result
 
-  defp load_page(socket, offset, opts \\ []) do
-    reset? = Keyword.get(opts, :reset, false)
+    # A newer filter/search/page request has since fired; drop these stale
+    # results so out-of-order completions can't clobber the current view.
+    if req == socket.assigns.req_id do
+      socket =
+        socket
+        |> assign(:offset, offset)
+        |> assign(:end_of_timeline?, !page.more?)
+        |> assign(:loading?, false)
+        |> maybe_assign_hero_options(hero_options)
+        |> maybe_assign_count(reset?, page.count)
+        |> stream(:decks, Enum.map(page.results, &deck_view/1), reset: reset?)
 
-    page =
-      Sanctum.Decks.Deck
-      |> Ash.Query.for_read(:browse, filters(socket.assigns),
-        actor: socket.assigns[:current_user]
-      )
-      |> Ash.read!(page: [limit: @page_size, offset: offset, count: reset?])
-
-    socket
-    |> assign(:offset, offset)
-    |> assign(:end_of_timeline?, !page.more?)
-    |> then(fn s -> if reset?, do: assign(s, :count, page.count), else: s end)
-    |> stream(:decks, Enum.map(page.results, &deck_view/1), reset: reset?)
+      {:noreply, socket}
+    else
+      {:noreply, socket}
+    end
   end
 
-  defp count_decks(socket, extra) do
-    Sanctum.Decks.Deck
-    |> Ash.Query.for_read(:browse, Map.merge(%{sort: "new"}, extra),
-      actor: socket.assigns[:current_user]
-    )
-    |> Ash.read!(page: [limit: 1, offset: 0, count: true])
-    |> Map.get(:count)
+  def handle_async(:load_decks, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> assign(:loading?, false)
+     |> put_flash(:error, "Couldn’t load decks: #{inspect(reason)}")}
+  end
+
+  defp reset_and_load(socket), do: start_load(socket, 0, reset: true)
+
+  # Kick off the browse read off the socket so the connected mount returns the
+  # shell immediately. `hero_options` is fetched only once per LiveView (a
+  # static hero list) and reused across every subsequent load.
+  defp start_load(socket, offset, opts \\ []) do
+    reset? = Keyword.get(opts, :reset, false)
+    req = socket.assigns.req_id + 1
+    filters = filters(socket.assigns)
+    actor = socket.assigns[:current_user]
+    fetch_heroes? = socket.assigns.hero_options == []
+
+    socket
+    |> assign(:req_id, req)
+    |> assign(:loading?, true)
+    |> start_async(:load_decks, fn ->
+      page =
+        Sanctum.Decks.Deck
+        |> Ash.Query.for_read(:browse, filters, actor: actor)
+        |> Ash.read!(page: [limit: @page_size, offset: offset, count: reset?])
+
+      hero_options = if fetch_heroes?, do: load_hero_options(), else: nil
+
+      %{req: req, offset: offset, reset?: reset?, page: page, hero_options: hero_options}
+    end)
+  end
+
+  defp maybe_assign_hero_options(socket, nil), do: socket
+  defp maybe_assign_hero_options(socket, options), do: assign(socket, :hero_options, options)
+
+  # `page.count` is only queried on reset loads (count: reset?). `total` is the
+  # full unfiltered catalog size — set once from the first load (mount always
+  # runs unfiltered) and left untouched as filters narrow the visible count.
+  defp maybe_assign_count(socket, false, _count), do: socket
+
+  defp maybe_assign_count(socket, true, count) do
+    socket
+    |> assign(:count, count)
+    |> then(fn s -> if is_nil(s.assigns.total), do: assign(s, :total, count), else: s end)
   end
 
   defp filters(a) do

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -20,199 +20,207 @@ defmodule SanctumWeb.DeckLive.Show do
   def render(assigns) do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:decks}>
-      <.header>
-        {@deck.title}
-        <:subtitle>
-          {@cover.hero_name}<span :if={@cover.author}> · by {@cover.author}</span>
-        </:subtitle>
-        <:actions>
-          <.button navigate={~p"/decks"}>
-            <.icon name="hero-arrow-left" /> Decks
-          </.button>
-        </:actions>
-      </.header>
+      <!-- first-load skeleton -->
+      <div :if={@deck == nil}>
+        <div class="mb-6 h-9 w-1/2 max-w-md animate-pulse bg-base-300"></div>
+        <.detail_skeleton />
+      </div>
 
-      <div class="space-y-5">
-        <!-- cover -->
-        <.panel class="relative flex flex-col gap-5 overflow-hidden p-4 sm:flex-row sm:items-start">
-          <div
-            class="h-[330px] w-[236px] flex-none self-center border-2 border-neutral shadow-comic sm:self-start"
-            style="transform:rotate(-1.5deg);"
-          >
-            <.mc_card
-              name={@cover.hero_name}
-              aspect={:hero}
-              image_url={@cover.identity_image}
-              gradient_from={@cover.gradient_from}
-              gradient_to={@cover.gradient_to}
-              size="lg"
-              show_cost={false}
-            />
-          </div>
+      <div :if={@deck != nil}>
+        <.header>
+          {@deck.title}
+          <:subtitle>
+            {@cover.hero_name}<span :if={@cover.author}> · by {@cover.author}</span>
+          </:subtitle>
+          <:actions>
+            <.button navigate={~p"/decks"}>
+              <.icon name="hero-arrow-left" /> Decks
+            </.button>
+          </:actions>
+        </.header>
 
-          <div class="flex min-w-0 flex-1 flex-col">
-            <div class="font-ibm-mono text-[11px] uppercase tracking-[0.25em] text-primary">
-              {@cover.source_label} · {@cover.hero_name}
-            </div>
-            <h1 class="mt-1.5 font-anton text-[34px] uppercase leading-[0.9] [text-wrap:balance] sm:text-[46px] sm:leading-[0.88]">
-              {@deck.title}
-            </h1>
-
-            <div class="mt-3 flex flex-wrap items-center gap-1.5">
-              <span
-                :for={a <- @cover.aspects}
-                class={[
-                  "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
-                  a.text,
-                  a.border
-                ]}
-              >
-                {a.label}
-              </span>
+        <div class="space-y-5">
+          <!-- cover -->
+          <.panel class="relative flex flex-col gap-5 overflow-hidden p-4 sm:flex-row sm:items-start">
+            <div
+              class="h-[330px] w-[236px] flex-none self-center border-2 border-neutral shadow-comic sm:self-start"
+              style="transform:rotate(-1.5deg);"
+            >
+              <.mc_card
+                name={@cover.hero_name}
+                aspect={:hero}
+                image_url={@cover.identity_image}
+                gradient_from={@cover.gradient_from}
+                gradient_to={@cover.gradient_to}
+                size="lg"
+                show_cost={false}
+              />
             </div>
 
-            <div class="mt-4 flex flex-wrap items-end gap-x-6 gap-y-3">
-              <div>
-                <div class="font-anton text-[30px] leading-none">{@cover.total_cards}</div>
-                <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
-                  Cards
-                </div>
+            <div class="flex min-w-0 flex-1 flex-col">
+              <div class="font-ibm-mono text-[11px] uppercase tracking-[0.25em] text-primary">
+                {@cover.source_label} · {@cover.hero_name}
               </div>
-              <div>
-                <div class="font-anton text-[30px] leading-none">{@cover.unique_cards}</div>
-                <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
-                  Unique
-                </div>
-              </div>
-              <.uniqueness_meter percentile={@cover.uniqueness} size="lg" class="self-center" />
-              <div :if={@cover.author} class="flex items-center gap-2 self-center">
-                <span class="flex size-[28px] items-center justify-center rounded-full border-2 border-neutral bg-primary font-bangers text-sm text-primary-content">
-                  {@cover.author_initial}
-                </span>
-                <span class="font-barlow-condensed text-[13px] font-bold text-primary">
-                  {@cover.author}
+              <h1 class="mt-1.5 font-anton text-[34px] uppercase leading-[0.9] [text-wrap:balance] sm:text-[46px] sm:leading-[0.88]">
+                {@deck.title}
+              </h1>
+
+              <div class="mt-3 flex flex-wrap items-center gap-1.5">
+                <span
+                  :for={a <- @cover.aspects}
+                  class={[
+                    "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
+                    a.text,
+                    a.border
+                  ]}
+                >
+                  {a.label}
                 </span>
               </div>
-            </div>
-          </div>
-          <div class="absolute inset-x-0 bottom-0 h-1.5" style={"background:#{@cover.gradient_to};"}>
-          </div>
-        </.panel>
 
-        <!-- body: writeup + card list -->
-        <div class="grid items-start gap-5 lg:grid-cols-[1.4fr_1fr]">
-          <.panel class="min-w-0 p-5">
-            <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
-              Deck Notes
-            </div>
-            <div :if={@writeup} class="space-y-4">
-              <div :for={seg <- @writeup}>
-                <div :if={seg.kind == :inline} class="deck-writeup">{seg.html}</div>
-                <iframe
-                  :if={seg.kind == :rich}
-                  title="Deck writeup"
-                  sandbox=""
-                  referrerpolicy="no-referrer"
-                  loading="lazy"
-                  class="deck-writeup-frame"
-                  srcdoc={seg.srcdoc}
-                ></iframe>
+              <div class="mt-4 flex flex-wrap items-end gap-x-6 gap-y-3">
+                <div>
+                  <div class="font-anton text-[30px] leading-none">{@cover.total_cards}</div>
+                  <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                    Cards
+                  </div>
+                </div>
+                <div>
+                  <div class="font-anton text-[30px] leading-none">{@cover.unique_cards}</div>
+                  <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                    Unique
+                  </div>
+                </div>
+                <.uniqueness_meter percentile={@cover.uniqueness} size="lg" class="self-center" />
+                <div :if={@cover.author} class="flex items-center gap-2 self-center">
+                  <span class="flex size-[28px] items-center justify-center rounded-full border-2 border-neutral bg-primary font-bangers text-sm text-primary-content">
+                    {@cover.author_initial}
+                  </span>
+                  <span class="font-barlow-condensed text-[13px] font-bold text-primary">
+                    {@cover.author}
+                  </span>
+                </div>
               </div>
             </div>
-            <div :if={!@writeup} class="font-barlow text-[14px] italic text-base-content/45">
-              No writeup for this deck.
+            <div class="absolute inset-x-0 bottom-0 h-1.5" style={"background:#{@cover.gradient_to};"}>
             </div>
           </.panel>
 
-          <div class="min-w-0 space-y-5">
-            <.panel class="p-4">
-              <div class="mb-3 flex items-baseline gap-2 border-b-2 border-neutral pb-2">
-                <div class="font-anton text-[17px] uppercase tracking-[0.05em]">In This Deck</div>
-                <div class="ml-auto font-ibm-mono text-[11px] text-base-content/45">
-                  {@cover.total_cards} cards
+          <!-- body: writeup + card list -->
+          <div class="grid items-start gap-5 lg:grid-cols-[1.4fr_1fr]">
+            <.panel class="min-w-0 p-5">
+              <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+                Deck Notes
+              </div>
+              <div :if={@writeup} class="space-y-4">
+                <div :for={seg <- @writeup}>
+                  <div :if={seg.kind == :inline} class="deck-writeup">{seg.html}</div>
+                  <iframe
+                    :if={seg.kind == :rich}
+                    title="Deck writeup"
+                    sandbox=""
+                    referrerpolicy="no-referrer"
+                    loading="lazy"
+                    class="deck-writeup-frame"
+                    srcdoc={seg.srcdoc}
+                  ></iframe>
                 </div>
               </div>
+              <div :if={!@writeup} class="font-barlow text-[14px] italic text-base-content/45">
+                No writeup for this deck.
+              </div>
+            </.panel>
 
-              <div :for={g <- @groups} class="mb-4 last:mb-0">
-                <div class="mb-2 font-anton text-[12px] uppercase tracking-[0.06em] text-primary">
-                  {g.name} · {g.count}
+            <div class="min-w-0 space-y-5">
+              <.panel class="p-4">
+                <div class="mb-3 flex items-baseline gap-2 border-b-2 border-neutral pb-2">
+                  <div class="font-anton text-[17px] uppercase tracking-[0.05em]">In This Deck</div>
+                  <div class="ml-auto font-ibm-mono text-[11px] text-base-content/45">
+                    {@cover.total_cards} cards
+                  </div>
                 </div>
-                <div class="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
+
+                <div :for={g <- @groups} class="mb-4 last:mb-0">
+                  <div class="mb-2 font-anton text-[12px] uppercase tracking-[0.06em] text-primary">
+                    {g.name} · {g.count}
+                  </div>
+                  <div class="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
+                    <.link
+                      :for={c <- g.cards}
+                      navigate={~p"/cards/#{c.card_id}"}
+                      class="h-[101px] border-2 border-neutral shadow-comic-sm"
+                    >
+                      <.mc_card
+                        name={c.name}
+                        cost={c.cost}
+                        aspect={c.aspect_key}
+                        image_url={c.image_url}
+                        gradient_from={c.gradient_from}
+                        gradient_to={c.gradient_to}
+                        qty={c.qty}
+                        size="sm"
+                        show_cost={false}
+                      />
+                    </.link>
+                  </div>
+                </div>
+              </.panel>
+
+              <!-- similar decks -->
+              <.panel :if={@similar != []} class="p-4">
+                <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+                  Similar Decks
+                </div>
+                <div class="space-y-2">
                   <.link
-                    :for={c <- g.cards}
-                    navigate={~p"/cards/#{c.card_id}"}
-                    class="h-[101px] border-2 border-neutral shadow-comic-sm"
+                    :for={s <- @similar}
+                    navigate={~p"/decks/#{s.id}"}
+                    class="mc-tile flex items-center gap-3 border-2 border-neutral bg-black p-2.5 shadow-comic-sm"
                   >
-                    <.mc_card
-                      name={c.name}
-                      cost={c.cost}
-                      aspect={c.aspect_key}
-                      image_url={c.image_url}
-                      gradient_from={c.gradient_from}
-                      gradient_to={c.gradient_to}
-                      qty={c.qty}
-                      size="sm"
-                      show_cost={false}
-                    />
+                    <div class="min-w-0 flex-1">
+                      <div class="truncate font-anton text-[16px] uppercase leading-tight">
+                        {s.title}
+                      </div>
+                      <div class="mt-1 flex flex-wrap gap-1">
+                        <span
+                          :for={a <- s.aspects}
+                          class={[
+                            "border bg-base-200 px-1.5 font-barlow-condensed text-[10px] font-bold uppercase tracking-[0.06em]",
+                            a.text,
+                            a.border
+                          ]}
+                        >
+                          {a.label}
+                        </span>
+                      </div>
+                    </div>
+                    <div class="flex-none text-right">
+                      <div class="font-anton text-[20px] leading-none text-primary">{s.match}%</div>
+                      <div class="font-barlow-condensed text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/45">
+                        Match
+                      </div>
+                    </div>
                   </.link>
                 </div>
-              </div>
-            </.panel>
+              </.panel>
 
-            <!-- similar decks -->
-            <.panel :if={@similar != []} class="p-4">
-              <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
-                Similar Decks
-              </div>
-              <div class="space-y-2">
-                <.link
-                  :for={s <- @similar}
-                  navigate={~p"/decks/#{s.id}"}
-                  class="mc-tile flex items-center gap-3 border-2 border-neutral bg-black p-2.5 shadow-comic-sm"
-                >
-                  <div class="min-w-0 flex-1">
-                    <div class="truncate font-anton text-[16px] uppercase leading-tight">
-                      {s.title}
-                    </div>
-                    <div class="mt-1 flex flex-wrap gap-1">
-                      <span
-                        :for={a <- s.aspects}
-                        class={[
-                          "border bg-base-200 px-1.5 font-barlow-condensed text-[10px] font-bold uppercase tracking-[0.06em]",
-                          a.text,
-                          a.border
-                        ]}
-                      >
-                        {a.label}
-                      </span>
-                    </div>
-                  </div>
-                  <div class="flex-none text-right">
-                    <div class="font-anton text-[20px] leading-none text-primary">{s.match}%</div>
-                    <div class="font-barlow-condensed text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/45">
-                      Match
-                    </div>
-                  </div>
-                </.link>
-              </div>
-            </.panel>
-
-            <!-- details -->
-            <.panel class="p-4">
-              <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
-                Details
-              </div>
-              <div class="grid grid-cols-2 gap-x-6 gap-y-3">
-                <.meta label="Source" value={@cover.source_label} />
-                <.meta
-                  :if={@deck.mcdb_id}
-                  label="MarvelCDB"
-                  value={"#{@deck.mcdb_type}/#{@deck.mcdb_id}"}
-                />
-                <.meta :if={@deck.version} label="Version" value={@deck.version} />
-                <.meta :if={@deck.tags} label="Tags" value={@deck.tags} />
-              </div>
-            </.panel>
+              <!-- details -->
+              <.panel class="p-4">
+                <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+                  Details
+                </div>
+                <div class="grid grid-cols-2 gap-x-6 gap-y-3">
+                  <.meta label="Source" value={@cover.source_label} />
+                  <.meta
+                    :if={@deck.mcdb_id}
+                    label="MarvelCDB"
+                    value={"#{@deck.mcdb_type}/#{@deck.mcdb_id}"}
+                  />
+                  <.meta :if={@deck.version} label="Version" value={@deck.version} />
+                  <.meta :if={@deck.tags} label="Tags" value={@deck.tags} />
+                </div>
+              </.panel>
+            </div>
           </div>
         </div>
       </div>
@@ -236,43 +244,98 @@ defmodule SanctumWeb.DeckLive.Show do
 
   @impl true
   def mount(%{"id" => id}, _session, socket) do
-    deck =
-      Sanctum.Decks.get_deck!(id,
-        actor: socket.assigns[:current_user],
-        load: [
-          :card_row_count,
-          :total_card_count,
-          :mcdb_user,
-          :owner,
-          hero: [:hero_side, card: [:primary_side]],
-          deck_cards: [card: [:primary_side]]
-        ]
-      )
+    socket =
+      socket
+      |> assign(:page_title, "Deck")
+      # nil until the async load lands — drives the loading/skeleton UI.
+      |> assign(:deck, nil)
+      |> assign(:cover, nil)
+      |> assign(:groups, [])
+      |> assign(:similar, [])
+      |> assign(:writeup, nil)
 
-    hero_gradient = hero_gradient(deck.hero)
+    actor = socket.assigns[:current_user]
 
-    groups =
-      deck.deck_cards
-      |> Enum.map(&card_view(&1, hero_gradient))
-      |> Enum.group_by(& &1.type)
-      |> Enum.map(fn {type, cards} ->
-        %{
-          type: type,
-          name: type_plural(type),
-          count: Enum.sum(Enum.map(cards, & &1.qty)),
-          cards: Enum.sort_by(cards, &{&1.cost || 99, &1.name})
-        }
-      end)
-      |> Enum.sort_by(&type_rank(&1.type))
+    # Skip the (heavy) deck load on the static render; it runs asynchronously
+    # once the socket connects so the shell paints immediately.
+    socket =
+      if connected?(socket),
+        do: start_async(socket, :load_deck, fn -> load_deck(id, actor) end),
+        else: socket
 
-    {:ok,
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_async(:load_deck, {:ok, {:ok, data}}, socket) do
+    {:noreply,
      socket
-     |> assign(:page_title, deck.title)
-     |> assign(:deck, deck)
-     |> assign(:cover, cover_view(deck, hero_gradient))
-     |> assign(:groups, groups)
-     |> assign(:similar, similar_views(deck))
-     |> assign(:writeup, Sanctum.Decks.Writeup.render(deck.description_md))}
+     |> assign(:page_title, data.deck.title)
+     |> assign(:deck, data.deck)
+     |> assign(:cover, data.cover)
+     |> assign(:groups, data.groups)
+     |> assign(:similar, data.similar)
+     |> assign(:writeup, data.writeup)}
+  end
+
+  def handle_async(:load_deck, {:ok, :not_found}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Deck not found.")
+     |> push_navigate(to: ~p"/decks")}
+  end
+
+  def handle_async(:load_deck, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:error, "Couldn’t load deck: #{inspect(reason)}")
+     |> push_navigate(to: ~p"/decks")}
+  end
+
+  # Load the deck with its cards and derive the cover, grouped card list, similar
+  # decks, and rendered writeup. Returns `:not_found` for an unknown id so
+  # handle_async can redirect rather than crash the LiveView.
+  defp load_deck(id, actor) do
+    case Sanctum.Decks.get_deck(id,
+           actor: actor,
+           load: [
+             :card_row_count,
+             :total_card_count,
+             :mcdb_user,
+             :owner,
+             hero: [:hero_side, card: [:primary_side]],
+             deck_cards: [card: [:primary_side]]
+           ]
+         ) do
+      {:ok, deck} ->
+        hero_gradient = hero_gradient(deck.hero)
+
+        groups =
+          deck.deck_cards
+          |> Enum.map(&card_view(&1, hero_gradient))
+          |> Enum.group_by(& &1.type)
+          |> Enum.map(fn {type, cards} ->
+            %{
+              type: type,
+              name: type_plural(type),
+              count: Enum.sum(Enum.map(cards, & &1.qty)),
+              cards: Enum.sort_by(cards, &{&1.cost || 99, &1.name})
+            }
+          end)
+          |> Enum.sort_by(&type_rank(&1.type))
+
+        {:ok,
+         %{
+           deck: deck,
+           cover: cover_view(deck, hero_gradient),
+           groups: groups,
+           similar: similar_views(deck),
+           writeup: Sanctum.Decks.Writeup.render(deck.description_md)
+         }}
+
+      {:error, _} ->
+        :not_found
+    end
   end
 
   # Same-hero decks that share the most chosen cards with this one.

--- a/lib/sanctum_web/live/guess_live/play.ex
+++ b/lib/sanctum_web/live/guess_live/play.ex
@@ -30,8 +30,17 @@ defmodule SanctumWeb.GuessLive.Play do
         </div>
       </.panel>
 
+      <.panel :if={@status == :loading} class="px-5 py-9 sm:px-6 sm:py-8">
+        <div class="animate-pulse space-y-4">
+          <div class="h-2.5 w-24 bg-base-300"></div>
+          <div class="mt-3 h-6 w-full bg-base-300"></div>
+          <div class="h-6 w-5/6 bg-base-300"></div>
+          <div class="h-6 w-2/3 bg-base-300"></div>
+        </div>
+      </.panel>
+
       <div
-        :if={@status != :empty}
+        :if={@status not in [:empty, :loading]}
         class={["mx-auto max-w-[720px]", @status == :playing && "pb-36 sm:pb-0"]}
       >
         <!-- flavor prompt — the hero of the round -->
@@ -170,7 +179,33 @@ defmodule SanctumWeb.GuessLive.Play do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, socket |> assign(:page_title, "Flavor Town") |> start_round()}
+    socket =
+      socket
+      |> assign(:page_title, "Flavor Town")
+      |> assign(:card, nil)
+      |> assign(:hints, [])
+      |> assign(:revealed_count, 0)
+      |> assign(:guesses, [])
+      # :loading until the async pick lands — drives the loading skeleton.
+      |> assign(:status, :loading)
+
+    # Skip the random-card pick on the static render; it runs asynchronously
+    # once the socket connects so the shell paints immediately.
+    socket = if connected?(socket), do: start_round(socket), else: socket
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_async(:load_round, {:ok, card}, socket) do
+    {:noreply, apply_round(socket, card)}
+  end
+
+  def handle_async(:load_round, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> assign(:status, :empty)
+     |> put_flash(:error, "Couldn’t start a round: #{inspect(reason)}")}
   end
 
   @impl true
@@ -209,24 +244,33 @@ defmodule SanctumWeb.GuessLive.Play do
     end
   end
 
+  # Kick off a fresh round: pick a random card off the socket so the guess UI
+  # never blocks on the DB. Resets the round state up front and shows the
+  # loading skeleton until `handle_async` delivers the card.
   defp start_round(socket) do
-    case CardGuess.random_guessable_card() do
-      nil ->
-        socket
-        |> assign(:card, nil)
-        |> assign(:hints, [])
-        |> assign(:revealed_count, 0)
-        |> assign(:guesses, [])
-        |> assign(:status, :empty)
+    socket
+    |> assign(:status, :loading)
+    |> assign(:revealed_count, 0)
+    |> assign(:guesses, [])
+    |> start_async(:load_round, fn -> CardGuess.random_guessable_card() end)
+  end
 
-      card ->
-        socket
-        |> assign(:card, card)
-        |> assign(:hints, CardGuess.build_hints(card))
-        |> assign(:revealed_count, 0)
-        |> assign(:guesses, [])
-        |> assign(:status, :playing)
-    end
+  defp apply_round(socket, nil) do
+    socket
+    |> assign(:card, nil)
+    |> assign(:hints, [])
+    |> assign(:revealed_count, 0)
+    |> assign(:guesses, [])
+    |> assign(:status, :empty)
+  end
+
+  defp apply_round(socket, card) do
+    socket
+    |> assign(:card, card)
+    |> assign(:hints, CardGuess.build_hints(card))
+    |> assign(:revealed_count, 0)
+    |> assign(:guesses, [])
+    |> assign(:status, :playing)
   end
 
   # Compact HUD counter shown beside the hint pips during play.

--- a/test/sanctum_web/live/browse_live/browse_test.exs
+++ b/test/sanctum_web/live/browse_live/browse_test.exs
@@ -1,0 +1,45 @@
+defmodule SanctumWeb.BrowseLiveTest do
+  @moduledoc false
+
+  use SanctumWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  defp make_pack(code, name) do
+    Sanctum.Catalog.Pack
+    |> Ash.Changeset.for_create(:upsert_from_marvelcdb, %{code: code, name: name})
+    |> Ash.create!(authorize?: false)
+    |> Ash.Changeset.for_update(:set_curated, %{product_type: :hero_pack})
+    |> Ash.update!(authorize?: false)
+  end
+
+  test "the browser paints its shell, then loads products asynchronously", %{conn: conn} do
+    make_pack("spdr", "SP//dr")
+
+    {:ok, view, html} = live(conn, ~p"/browse")
+
+    # Header is on the shell; the product taxonomy loads asynchronously.
+    assert html =~ "Browse"
+
+    html = render_async(view)
+    assert html =~ "SP//dr"
+  end
+
+  test "a product page paints its shell, then loads the pack asynchronously", %{conn: conn} do
+    make_pack("spdr", "SP//dr")
+
+    {:ok, view, _html} = live(conn, ~p"/browse/spdr")
+
+    html = render_async(view)
+    assert html =~ "SP//dr"
+    # No cards synced for this pack yet, so the empty-state panel shows.
+    assert html =~ "No cards have been synced"
+  end
+
+  test "an unknown product code redirects back to the browser", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/browse/nope")
+
+    # The async load resolves to not-found and redirects to /browse.
+    assert_redirect(view, ~p"/browse")
+  end
+end

--- a/test/sanctum_web/live/card_live/detail_test.exs
+++ b/test/sanctum_web/live/card_live/detail_test.exs
@@ -44,7 +44,9 @@ defmodule SanctumWeb.CardLive.DetailTest do
   test "renders every side of a card for anonymous visitors", %{conn: conn} do
     {card, _hero, _alter_ego} = make_card()
 
-    {:ok, _lv, html} = live(conn, ~p"/cards/#{card.id}")
+    # The card detail loads asynchronously after mount; await it.
+    {:ok, lv, _html} = live(conn, ~p"/cards/#{card.id}")
+    html = render_async(lv)
 
     assert html =~ "Spider-Man"
     assert html =~ "Peter Parker"
@@ -72,7 +74,8 @@ defmodule SanctumWeb.CardLive.DetailTest do
     |> Ash.Changeset.for_update(:update, %{pack_id: pack.id})
     |> Ash.update!(authorize?: false)
 
-    {:ok, _lv, html} = live(conn, ~p"/cards/#{card.id}")
+    {:ok, lv, _html} = live(conn, ~p"/cards/#{card.id}")
+    html = render_async(lv)
 
     assert html =~ "Card File"
     assert html =~ "Core Set"
@@ -97,7 +100,8 @@ defmodule SanctumWeb.CardLive.DetailTest do
       |> Ash.create!(authorize?: false)
     end
 
-    {:ok, _lv, html} = live(conn, ~p"/cards/#{card.id}")
+    {:ok, lv, _html} = live(conn, ~p"/cards/#{card.id}")
+    html = render_async(lv)
 
     assert html =~ "Alternate Printings (2)"
     assert html =~ "https://img.example/02001a.png"

--- a/test/sanctum_web/live/deck_live/index_test.exs
+++ b/test/sanctum_web/live/deck_live/index_test.exs
@@ -59,9 +59,12 @@ defmodule SanctumWeb.DeckLive.IndexTest do
     make_deck("Web Warrior", "spider_man", "90001", "Spider-Man", [:justice])
     make_deck("Cosmic Blast", "captain_marvel", "90002", "Captain Marvel", [:aggression])
 
-    {:ok, _view, html} = live(conn, ~p"/decks")
+    {:ok, view, html} = live(conn, ~p"/decks")
 
+    # The header paints on the shell; the deck feed loads asynchronously.
     assert html =~ "Browse Decks"
+
+    html = render_async(view)
     assert html =~ "Web Warrior"
     assert html =~ "Cosmic Blast"
   end
@@ -71,12 +74,13 @@ defmodule SanctumWeb.DeckLive.IndexTest do
     make_deck("Cosmic Blast", "captain_marvel", "90002", "Captain Marvel", [:aggression])
 
     {:ok, view, _html} = live(conn, ~p"/decks")
+    render_async(view)
 
-    html =
-      view
-      |> form("form[phx-change=search]", %{query: "cosmic"})
-      |> render_change()
+    view
+    |> form("#deck-search", %{query: "cosmic"})
+    |> render_change()
 
+    html = render_async(view)
     assert html =~ "Cosmic Blast"
     refute html =~ "Web Warrior"
   end
@@ -94,7 +98,8 @@ defmodule SanctumWeb.DeckLive.IndexTest do
       scored.id
     ])
 
-    {:ok, _view, html} = live(conn, ~p"/decks")
+    {:ok, view, _html} = live(conn, ~p"/decks")
+    html = render_async(view)
 
     assert html =~ "Uniqueness"
     assert html =~ "87"

--- a/test/sanctum_web/live/deck_live/show_test.exs
+++ b/test/sanctum_web/live/deck_live/show_test.exs
@@ -77,7 +77,9 @@ defmodule SanctumWeb.DeckLive.ShowTest do
   test "an anonymous visitor can view a deck's cover, notes, and card list", %{conn: conn} do
     deck = make_deck_with_card()
 
-    {:ok, _view, html} = live(conn, ~p"/decks/#{deck.id}")
+    # The deck detail loads asynchronously after mount; await it.
+    {:ok, view, _html} = live(conn, ~p"/decks/#{deck.id}")
+    html = render_async(view)
 
     assert html =~ "Web Warrior"
     assert html =~ "Spider-Man"
@@ -95,7 +97,8 @@ defmodule SanctumWeb.DeckLive.ShowTest do
       deck.id
     ])
 
-    {:ok, _view, html} = live(conn, ~p"/decks/#{deck.id}")
+    {:ok, view, _html} = live(conn, ~p"/decks/#{deck.id}")
+    html = render_async(view)
 
     assert html =~ "Uniqueness"
     assert html =~ "92"
@@ -109,7 +112,8 @@ defmodule SanctumWeb.DeckLive.ShowTest do
     deck_a = deck_with_hero("Amazing Build", hero, [ally])
     _deck_b = deck_with_hero("Spectacular Build", hero, [ally])
 
-    {:ok, _view, html} = live(conn, ~p"/decks/#{deck_a.id}")
+    {:ok, view, _html} = live(conn, ~p"/decks/#{deck_a.id}")
+    html = render_async(view)
 
     assert html =~ "Similar Decks"
     assert html =~ "Spectacular Build"

--- a/test/sanctum_web/live/guess_live/play_test.exs
+++ b/test/sanctum_web/live/guess_live/play_test.exs
@@ -35,9 +35,11 @@ defmodule SanctumWeb.GuessLive.PlayTest do
   test "shows the flavor text and no answer up front", %{conn: conn} do
     seed_card("Nick Fury", "The ultimate spy.")
 
-    {:ok, _view, html} = live(conn, ~p"/flavor-town")
-
+    # The round's random card is picked asynchronously after mount.
+    {:ok, view, html} = live(conn, ~p"/flavor-town")
     assert html =~ "Flavor Town"
+
+    html = render_async(view)
     assert html =~ "The ultimate spy."
     refute html =~ "You got it!"
   end
@@ -46,6 +48,7 @@ defmodule SanctumWeb.GuessLive.PlayTest do
     seed_card("Nick Fury", "The ultimate spy.")
 
     {:ok, view, _html} = live(conn, ~p"/flavor-town")
+    render_async(view)
 
     html = view |> form("form", %{guess: "Definitely Wrong"}) |> render_submit()
 
@@ -58,6 +61,7 @@ defmodule SanctumWeb.GuessLive.PlayTest do
     seed_card("Nick Fury", "The ultimate spy.")
 
     {:ok, view, _html} = live(conn, ~p"/flavor-town")
+    render_async(view)
 
     html = view |> form("form", %{guess: "nick fury"}) |> render_submit()
 


### PR DESCRIPTION
Follow-up to #189, applying the same async-mount pattern to the rest of the **public** LiveView pages. Best reviewed/merged after #189 (they share a small `detail_test.exs` hunk that merges cleanly).

## Problem

Every public page ran its queries synchronously in `mount/3`, and `mount/3` runs on both the disconnected static render and the connected mount — so DB work gated first paint on each page, just like the card pool did. The detail pages (`browse/show`, `card detail`, `deck show`) do especially heavy nested loads.

## Changes

Each page now **skips all queries on the disconnected render** (it only paints the shell) and loads its data in `start_async`/`handle_async` once the socket connects, showing a skeleton in the gap:

- **Deck browser** (`deck_live/index`) — the direct card-pool twin: drops the redundant count query (derives `total` from the first page's count), fetches hero options once, `req_id` stale-guard, skeleton feed.
- **Browse index** (`browse_live/index`) — waves + packs + cover images load async behind a skeleton.
- **Browse show** (`browse_live/show`) — the heaviest public read (all cards + sides for a product); redirects on unknown code from `handle_async` instead of `mount`.
- **Card detail** (`card_live/detail`) and **Deck show** (`deck_live/show`) — single-record detail pages load async; redirect on not-found instead of raising.
- **Flavor Town** (`guess_live/play`) — picks the random card in `start_async` behind a new `:loading` state.

**Shared component:** new `SanctumWeb.Components.Skeleton` (card-tile, deck-tile, art-grid, and detail placeholders), imported globally so every page draws from one set of loading shapes.

## Tests

- Updated the affected LiveView tests to await the async load with `render_async` (`deck_live/index`, `deck_live/show`, `guess_live/play`, `card_live/detail`).
- Added `browse_live/browse_test.exs` — the browse pages had **no** coverage: asserts shell-then-async for both index and show, plus the unknown-code redirect.
- Full suite: **204 tests, 0 failures**; `mix ck` clean (Credo + Sobelow).

## Not included (per plan)

`game_live/show` (deferred — needs template nil-guarding across a large template), the authenticated `game_live/index` and admin pages (`admin_live/index`, `card_live/index`) land in follow-up PRs, and the 3 trivial pages are intentionally left synchronous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)