### PR TITLE
perf(admin): async-load the admin landing + card table

### DIFF
--- a/lib/sanctum_web/live/admin_live/index.ex
+++ b/lib/sanctum_web/live/admin_live/index.ex
@@ -23,7 +23,10 @@ defmodule SanctumWeb.AdminLive.Index do
         <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
           Catalog
         </h2>
-        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        <div :if={@stats == nil} class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <.stat_skeleton :for={_ <- 1..8} />
+        </div>
+        <div :if={@stats != nil} class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
           <.stat_tile label="Cards" value={@stats.cards} />
           <.stat_tile label="Card Sides" value={@stats.card_sides} />
           <.stat_tile label="Decks" value={@stats.decks} />
@@ -39,7 +42,10 @@ defmodule SanctumWeb.AdminLive.Index do
         <h2 class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
           Background Jobs
         </h2>
-        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <div :if={@jobs == nil} class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+          <.stat_skeleton :for={_ <- 1..6} />
+        </div>
+        <div :if={@jobs != nil} class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
           <.stat_tile label="Available" value={@jobs.available} />
           <.stat_tile label="Executing" value={@jobs.executing} />
           <.stat_tile label="Scheduled" value={@jobs.scheduled} />
@@ -207,6 +213,15 @@ defmodule SanctumWeb.AdminLive.Index do
     """
   end
 
+  defp stat_skeleton(assigns) do
+    ~H"""
+    <div class="border-[3px] border-neutral bg-base-300 px-4 py-3">
+      <div class="h-8 w-10 animate-pulse bg-base-100"></div>
+      <div class="mt-2 h-2.5 w-16 animate-pulse bg-base-100"></div>
+    </div>
+    """
+  end
+
   attr :label, :string, required: true
   attr :value, :integer, required: true
   attr :accent, :boolean, default: false
@@ -274,16 +289,36 @@ defmodule SanctumWeb.AdminLive.Index do
   def mount(_params, _session, socket) do
     if connected?(socket), do: Sanctum.DeckSync.Monitor.subscribe()
 
-    {:ok,
-     socket
-     |> assign(:page_title, "Admin")
-     |> assign(:dev_routes?, Application.get_env(:sanctum, :dev_routes, false))
-     |> assign(:stats, load_stats())
-     |> assign(:jobs, load_job_counts())
-     |> assign(:deck_sync, Sanctum.DeckSync.Monitor.status())
-     |> assign(:deck_health, load_deck_health())
-     |> assign(:deck_import, %{status: :idle, deck: nil, error: nil, url: ""})}
+    socket =
+      socket
+      |> assign(:page_title, "Admin")
+      |> assign(:dev_routes?, Application.get_env(:sanctum, :dev_routes, false))
+      # nil until the async load lands — drives the stat-tile skeletons. The
+      # deck-sync Monitor status is in-memory, so it stays synchronous.
+      |> assign(:stats, nil)
+      |> assign(:jobs, nil)
+      |> assign(:deck_sync, Sanctum.DeckSync.Monitor.status())
+      |> assign(:deck_health, %{cursor: nil, last_run: nil})
+      |> assign(:deck_import, %{status: :idle, deck: nil, error: nil, url: ""})
+
+    # Skip the ~10 count/aggregate queries on the static render; load them
+    # asynchronously once the socket connects so the shell paints immediately.
+    socket =
+      if connected?(socket), do: start_async(socket, :load_admin, &load_admin/0), else: socket
+
+    {:ok, socket}
   end
+
+  # The health snapshot: catalog counts, Oban job tallies, and deck-sync health.
+  defp load_admin do
+    %{stats: load_stats(), jobs: load_job_counts(), deck_health: load_deck_health()}
+  end
+
+  defp zero_stats do
+    %{cards: 0, card_sides: 0, decks: 0, heroes: 0, villains: 0, scenarios: 0, users: 0, games: 0}
+  end
+
+  defp zero_jobs, do: Map.new(@job_states, &{&1, 0})
 
   # Enqueue an ad-hoc deck sync instead of waiting for the hourly cron. The
   # worker's `unique` constraint debounces this against an in-flight run, so a
@@ -323,6 +358,22 @@ defmodule SanctumWeb.AdminLive.Index do
   end
 
   @impl true
+  def handle_async(:load_admin, {:ok, data}, socket) do
+    {:noreply,
+     socket
+     |> assign(:stats, data.stats)
+     |> assign(:jobs, data.jobs)
+     |> assign(:deck_health, data.deck_health)}
+  end
+
+  def handle_async(:load_admin, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> assign(:stats, zero_stats())
+     |> assign(:jobs, zero_jobs())
+     |> put_flash(:error, "Couldn’t load admin stats: #{inspect(reason)}")}
+  end
+
   def handle_async(:import_deck, {:ok, result}, socket) do
     deck_import = socket.assigns.deck_import
 

--- a/lib/sanctum_web/live/card_live/index.ex
+++ b/lib/sanctum_web/live/card_live/index.ex
@@ -17,7 +17,11 @@ defmodule SanctumWeb.CardLive.Index do
         </:actions>
       </.header>
 
-      <div class="w-full overflow-auto">
+      <div :if={!@loaded?} class="mt-4 space-y-2">
+        <div :for={_ <- 1..8} class="h-14 animate-pulse bg-base-300"></div>
+      </div>
+
+      <div :if={@loaded?} class="w-full overflow-auto">
         <.table
           id="cards"
           rows={@streams.cards}
@@ -92,20 +96,29 @@ defmodule SanctumWeb.CardLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok,
-     socket
-     |> assign(:page_title, "Manage Cards")
-     |> assign(:offset, 0)
-     |> assign(:end_of_timeline?, false)
-     |> paginate_cards(0)}
+    socket =
+      socket
+      |> assign(:page_title, "Manage Cards")
+      |> assign(:offset, 0)
+      |> assign(:end_of_timeline?, false)
+      # loaded? gates the skeleton → table swap once the first page arrives.
+      |> assign(:loaded?, false)
+      |> assign(:loading?, true)
+      |> stream(:cards, [])
+
+    # Skip the first-page query on the static render; load asynchronously once
+    # the socket connects so the shell paints immediately.
+    socket = if connected?(socket), do: start_load(socket, 0), else: socket
+
+    {:ok, socket}
   end
 
   @impl true
   def handle_event("next-page", _params, socket) do
-    if socket.assigns.end_of_timeline? do
+    if socket.assigns.end_of_timeline? or socket.assigns.loading? do
       {:noreply, socket}
     else
-      {:noreply, paginate_cards(socket, socket.assigns.offset + @page_size)}
+      {:noreply, start_load(socket, socket.assigns.offset + @page_size)}
     end
   end
 
@@ -116,18 +129,40 @@ defmodule SanctumWeb.CardLive.Index do
     {:noreply, stream_delete(socket, :cards, card)}
   end
 
-  defp paginate_cards(socket, offset) do
-    page =
-      Sanctum.Games.list_cards!(
-        actor: socket.assigns[:current_user],
-        load: [:primary_side, :card_sides],
-        query: [sort: [base_code: :asc]],
-        page: [limit: @page_size, offset: offset]
-      )
+  @impl true
+  def handle_async(:load_cards, {:ok, %{page: page, offset: offset}}, socket) do
+    {:noreply,
+     socket
+     |> assign(:offset, offset)
+     |> assign(:end_of_timeline?, !page.more?)
+     |> assign(:loading?, false)
+     |> assign(:loaded?, true)
+     |> stream(:cards, page.results, at: -1)}
+  end
+
+  def handle_async(:load_cards, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> assign(:loading?, false)
+     |> assign(:loaded?, true)
+     |> put_flash(:error, "Couldn’t load cards: #{inspect(reason)}")}
+  end
+
+  defp start_load(socket, offset) do
+    actor = socket.assigns[:current_user]
 
     socket
-    |> assign(:offset, offset)
-    |> assign(:end_of_timeline?, !page.more?)
-    |> stream(:cards, page.results, at: -1)
+    |> assign(:loading?, true)
+    |> start_async(:load_cards, fn ->
+      page =
+        Sanctum.Games.list_cards!(
+          actor: actor,
+          load: [:primary_side, :card_sides],
+          query: [sort: [base_code: :asc]],
+          page: [limit: @page_size, offset: offset]
+        )
+
+      %{page: page, offset: offset}
+    end)
   end
 end

--- a/test/sanctum_web/live/card_live/form_test.exs
+++ b/test/sanctum_web/live/card_live/form_test.exs
@@ -42,7 +42,7 @@ defmodule SanctumWeb.CardLive.FormTest do
 
       unique_id = :rand.uniform(100_000)
 
-      {:ok, _view, html} =
+      {:ok, index_view, _html} =
         view
         |> form("#card-form", %{
           "card" => %{
@@ -53,8 +53,8 @@ defmodule SanctumWeb.CardLive.FormTest do
         |> render_submit()
         |> follow_redirect(conn)
 
-      # Verify card was created by checking it appears in the index
-      assert html =~ "test#{unique_id}"
+      # Verify card was created by checking it appears in the index (loaded async)
+      assert render_async(index_view) =~ "test#{unique_id}"
     end
 
     test "shows validation errors for invalid card data", %{conn: conn} do
@@ -130,7 +130,7 @@ defmodule SanctumWeb.CardLive.FormTest do
     test "updates existing card basic fields", %{conn: conn, card: card} do
       {:ok, view, _html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
-      {:ok, _view, html} =
+      {:ok, index_view, _html} =
         view
         |> form("#card-form", %{
           "card" => %{"set" => "updated_set"}
@@ -138,13 +138,13 @@ defmodule SanctumWeb.CardLive.FormTest do
         |> render_submit()
         |> follow_redirect(conn)
 
-      assert html =~ "updated_set"
+      assert render_async(index_view) =~ "updated_set"
     end
 
     test "updates card side fields", %{conn: conn, card: card} do
       {:ok, view, _html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
-      {:ok, _view, html} =
+      {:ok, index_view, _html} =
         view
         |> form("#card-form", %{
           "card" => %{
@@ -163,13 +163,13 @@ defmodule SanctumWeb.CardLive.FormTest do
         |> follow_redirect(conn)
 
       # Verify the card side was updated by checking it appears in the response
-      assert html =~ "Updated Card Side Name"
+      assert render_async(index_view) =~ "Updated Card Side Name"
     end
 
     test "updates card side traits", %{conn: conn, card: card} do
       {:ok, view, _html} = live(conn, ~p"/admin/cards/#{card.id}/edit")
 
-      {:ok, _view, html} =
+      {:ok, index_view, _html} =
         view
         |> form("#card-form", %{
           "card" => %{
@@ -184,7 +184,7 @@ defmodule SanctumWeb.CardLive.FormTest do
         |> follow_redirect(conn)
 
       # Verify traits were processed correctly
-      assert html =~ "Avenger, Spy, Guardian"
+      assert render_async(index_view) =~ "Avenger, Spy, Guardian"
     end
 
     test "handles validation errors on update", %{conn: conn, card: card} do
@@ -222,7 +222,7 @@ defmodule SanctumWeb.CardLive.FormTest do
 
       unique_id = :rand.uniform(100_000)
 
-      {:ok, _view, html} =
+      {:ok, index_view, _html} =
         view
         |> form("#card-form", %{
           "card" => %{
@@ -233,7 +233,7 @@ defmodule SanctumWeb.CardLive.FormTest do
         |> render_submit()
         |> follow_redirect(conn)
 
-      assert html =~ "nav#{unique_id}"
+      assert render_async(index_view) =~ "nav#{unique_id}"
     end
   end
 end


### PR DESCRIPTION
Tier 3 (admin) of the LiveView async-mount sweep — follow-up to #189 / #191.

## Problem

Both admin pages ran their queries synchronously in `mount/3` on both renders:
- **AdminLive.Index** — ~10 queries: 8 catalog `count!`s + 2 Oban job-state tallies + deck-sync health.
- **CardLive.Index** — the first 50-card page with `[:primary_side, :card_sides]` loads.

## Changes

- **AdminLive.Index** — stats, job counts, and deck-sync health load in `start_async` behind stat-tile skeletons; on failure they fall back to zeroed tiles. The in-memory deck-sync `Monitor.status()` stays synchronous (no DB).
- **CardLive.Index** — the first page loads in `start_async` behind a table skeleton; infinite-scroll pagination shares the async path with a loading guard.

## Tests

- `card_live/form_test` follows the save-redirect into the (now async) card index, so it awaits with `render_async`.
- Full suite: **204 tests, 0 failures**; `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)