### PR TITLE
feat(auth): theme the auth pages with the comic-dossier design

### DIFF
--- a/lib/sanctum_web/auth_overrides.ex
+++ b/lib/sanctum_web/auth_overrides.ex
@@ -1,20 +1,179 @@
 defmodule SanctumWeb.AuthOverrides do
+  @moduledoc """
+  UI overrides mapping the AshAuthentication.Phoenix pages (sign-in, register,
+  reset, confirm, magic link, sign-out) onto the comic-dossier design system:
+  halftone canvas, hard-black-bordered cardstock panel, Bangers wordmark,
+  Anton headings, and the gold offset-shadow CTA.
+
+  Reference: https://hexdocs.pm/ash_authentication_phoenix/ui-overrides.html
+  """
+
   use AshAuthentication.Phoenix.Overrides
 
-  # configure your UI overrides here
+  alias AshAuthentication.Phoenix.{
+    Components,
+    ConfirmLive,
+    MagicSignInLive,
+    ResetLive,
+    SignInLive,
+    SignOutLive
+  }
 
-  # First argument to `override` is the component name you are overriding.
-  # The body contains any number of configurations you wish to override
-  # Below are some examples
+  # Full-page halftone canvas behind the centered auth panel.
+  @page_class "min-h-screen grid place-items-center bg-base-100 bg-halftone px-4 py-12"
 
-  # For a complete reference, see https://hexdocs.pm/ash_authentication_phoenix/ui-overrides.html
+  # The "printed cardstock" panel every auth surface sits on.
+  @panel_class "w-full max-w-sm border-2 border-neutral bg-base-200 shadow-comic px-8 py-10"
 
-  # override AshAuthentication.Phoenix.Components.Banner do
-  #   set :image_url, "https://media.giphy.com/media/g7GKcSzwQfugw/giphy.gif"
-  #   set :text_class, "bg-red-500"
-  # end
+  # Comic button primitives (mirrors CoreComponents.button/1 variants).
+  @button_base "w-full inline-flex min-h-[44px] items-center justify-center gap-2 cursor-pointer " <>
+                 "px-4 py-2.5 font-barlow-condensed font-extrabold uppercase tracking-[0.08em] text-[13px] " <>
+                 "transition-all active:translate-x-px active:translate-y-px disabled:opacity-40 disabled:pointer-events-none"
+  @button_primary @button_base <>
+                    " bg-primary text-primary-content border-2 border-transparent shadow-comic-sm hover:shadow-comic"
+  @button_ghost @button_base <>
+                  " bg-base-300 text-base-content border-2 border-neutral shadow-comic-sm hover:text-white"
 
-  # override AshAuthentication.Phoenix.Components.SignIn do
-  #  set :show_banner, false
-  # end
+  # Form primitives (mirrors CoreComponents.input/1).
+  @heading_class "font-anton text-[24px] uppercase tracking-[0.03em] leading-none text-base-content mt-2 mb-5"
+  @field_label_class "block font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/60 mb-1.5"
+  @input_base "appearance-none block w-full bg-black border-[2.5px] text-base-content font-barlow " <>
+                "px-3.5 py-2.5 text-sm outline-none placeholder:text-base-content/40"
+  @input_class @input_base <> " border-line focus:border-primary"
+  @input_error_class @input_base <> " border-error focus:border-error"
+
+  override SignInLive do
+    set :root_class, @page_class
+  end
+
+  override SignOutLive do
+    set :root_class, @page_class
+  end
+
+  override ResetLive do
+    set :root_class, @page_class
+  end
+
+  override ConfirmLive do
+    set :root_class, @page_class
+  end
+
+  override MagicSignInLive do
+    set :root_class, @page_class
+  end
+
+  override Components.SignIn do
+    set :root_class, @panel_class
+    set :strategy_class, "w-full"
+    set :authentication_error_container_class, "text-center mt-2"
+    set :authentication_error_text_class, "font-barlow text-sm text-error"
+  end
+
+  override Components.SignOut do
+    set :root_class, @panel_class
+    set :h2_class, @heading_class
+    set :info_text_class, "font-barlow text-sm text-base-content/70 mb-5"
+    set :button_class, @button_primary
+  end
+
+  override Components.Reset do
+    set :root_class, @panel_class
+    set :strategy_class, "w-full"
+  end
+
+  override Components.Reset.Form do
+    set :label_class, @heading_class
+  end
+
+  override Components.Confirm do
+    set :root_class, @panel_class
+    set :strategy_class, "w-full"
+  end
+
+  override Components.Confirm.Input do
+    set :submit_class, @button_primary <> " mt-4"
+  end
+
+  # Wordmark in place of the Ash Framework banner.
+  override Components.Banner do
+    set :root_class, "w-full pb-6 mb-6 border-b-2 border-neutral text-center"
+    set :image_url, nil
+    set :dark_image_url, nil
+    set :href_url, "/"
+    set :text, "SANCTUM"
+    set :text_class, "font-bangers text-[40px] leading-none tracking-wide text-primary"
+  end
+
+  override Components.HorizontalRule do
+    set :root_class, "relative my-5"
+    set :hr_inner_class, "w-full border-t-2 border-neutral"
+
+    set :text_inner_class,
+        "px-3 bg-base-200 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50"
+  end
+
+  override Components.MagicLink do
+    set :root_class, "mt-2 mb-2"
+    set :label_class, @heading_class
+  end
+
+  override Components.MagicLink.Input do
+    set :submit_class, @button_primary <> " mt-4"
+    set :remember_me_class, "flex items-center gap-2 mt-3"
+    set :checkbox_class, "checkbox checkbox-sm"
+
+    set :checkbox_label_class,
+        "font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/70"
+  end
+
+  override Components.Password do
+    set :root_class, "mt-2 mb-2"
+    set :interstitial_class, "flex flex-row justify-between content-between mt-3"
+
+    set :toggler_class,
+        "flex-none px-2 first:pl-0 last:pr-0 font-barlow-condensed text-[13px] font-bold " <>
+          "uppercase tracking-[0.06em] text-primary hover:underline underline-offset-4"
+  end
+
+  override Components.Password.SignInForm do
+    set :label_class, @heading_class
+  end
+
+  override Components.Password.RegisterForm do
+    set :label_class, @heading_class
+  end
+
+  override Components.Password.ResetForm do
+    set :label_class, @heading_class
+  end
+
+  override Components.Password.Input do
+    set :field_class, "mt-3"
+    set :label_class, @field_label_class
+    set :input_class, @input_class
+    set :input_class_with_error, @input_error_class
+    set :submit_class, @button_primary <> " mt-5"
+    set :error_ul, "font-barlow text-sm text-error mt-2 space-y-1"
+    set :remember_me_class, "flex items-center gap-2 mt-3"
+    set :checkbox_class, "checkbox checkbox-sm"
+
+    set :checkbox_label_class,
+        "font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/70"
+  end
+
+  override Components.OAuth2 do
+    set :root_class, "w-full mt-2 mb-2"
+    set :link_class, @button_ghost
+    set :icon_class, "size-5 shrink-0"
+  end
+
+  override Components.Flash do
+    set :message_class_info,
+        "fixed top-3 right-3 w-80 sm:w-96 z-50 border-2 border-neutral bg-base-200 shadow-comic " <>
+          "p-3 font-barlow text-sm text-base-content border-l-[6px] border-l-info"
+
+    set :message_class_error,
+        "fixed top-3 right-3 w-80 sm:w-96 z-50 border-2 border-neutral bg-base-200 shadow-comic " <>
+          "p-3 font-barlow text-sm text-base-content border-l-[6px] border-l-error"
+  end
 end

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -121,6 +121,14 @@ defmodule SanctumWeb.Layouts do
             >
               Sign In
             </.button>
+            <.button
+              :if={@current_user}
+              variant="ghost"
+              navigate={~p"/sign-out"}
+              phx-click={close_drawer()}
+            >
+              Sign Out
+            </.button>
           </div>
         </aside>
       </div>

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -113,7 +113,13 @@ defmodule SanctumWeb.Router do
     pipe_through :browser
 
     auth_routes AuthController, Sanctum.Accounts.User, path: "/auth"
-    sign_out_route AuthController
+
+    sign_out_route AuthController,
+                   "/sign-out",
+                   overrides: [
+                     SanctumWeb.AuthOverrides,
+                     AshAuthentication.Phoenix.Overrides.Default
+                   ]
 
     # Remove these if you'd like to use your own authentication views
     sign_in_route register_path: "/register",


### PR DESCRIPTION
## Summary

The auth pages were still stock Ash Framework styling — navy background, Ash logo, rounded blue buttons. This themes every AshAuthentication.Phoenix surface (sign-in, register, reset, confirm, magic link, sign-out) to match the rest of the app, via the [UI overrides](https://ash-authentication-phoenix.hexdocs.pm/ui-overrides.html) mechanism.

- **`SanctumWeb.AuthOverrides`** — full override set replacing the empty stub: halftone canvas, hard-black-bordered cardstock panel (`shadow-comic`), Bangers **SANCTUM** wordmark in place of the Ash banner images, Anton headings, IBM Plex Mono field labels, black inputs with gold focus, and the offset-shadow comic buttons (gold primary CTA, ghost-style Google OAuth link). Password/magic-link form styles are included even though only Google OAuth is currently enabled, so re-enabling those strategies won't regress to stock styling.
- **Router** — `sign_out_route` wasn't passing `overrides` at all, so the sign-out confirmation page ignored the override module; it now uses the same chain as the other auth routes.
- **App shell** — added a **Sign Out** ghost button to the bottom of the sidebar (shown when logged in, mirroring the Sign In button).

Note: explicitly setting `image_url`/`dark_image_url` to `nil` correctly suppresses the default Ash banner because the override chain resolves with `Map.fetch` (first module *defining* the key wins).

## Testing

- Verified in the browser (playwright-cli) at `/sign-in`, `/register`, `/reset`, and `/sign-out` — all render the themed panel. Magic-link sign-in couldn't be visually checked (requires a valid token) but shares the same overridden components.
- `mix ck` (format + Credo + Sobelow) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)