### PR TITLE
style(components): enlarge and recenter the health badge number

### DIFF
--- a/lib/sanctum_web/components/health_badge.ex
+++ b/lib/sanctum_web/components/health_badge.ex
@@ -88,9 +88,9 @@ defmodule SanctumWeb.Components.HealthBadge do
     # inside the disc.
     font_size =
       case value |> IO.iodata_to_binary() |> String.length() do
-        n when n <= 1 -> 170
-        2 -> 135
-        _ -> 110
+        n when n <= 1 -> 180
+        2 -> 145
+        _ -> 120
       end
 
     assigns =
@@ -132,7 +132,7 @@ defmodule SanctumWeb.Components.HealthBadge do
 
       <text
         x={if @player, do: "156", else: "160"}
-        y="122"
+        y="135"
         text-anchor="middle"
         dominant-baseline="central"
         fill="#fff"


### PR DESCRIPTION
## Summary

- Bumps the hit-point number's size-tiered font sizes on the SVG health badge (170/135/110 → 180/145/120 for 1/2/3+ digit values).
- Moves the number's y position from 122 to 135 so it sits better centered in the badge disc.

Small visual tweak only — no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)