### PR TITLE
feat(ux): restore scroll position when navigating back

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,6 +28,7 @@ import topbar from "../vendor/topbar"
 import CardDrag from "./hooks/card-drag";
 import DragDrop from "./hooks/drag-drop";
 import LayoutHand from "./hooks/layout-hand";
+import ScrollRestore from "./hooks/scroll-restore";
 
 // Sentry config arrives via meta tags rendered only when a DSN is configured
 // (prod). Kept out of an inline <script> so the prod CSP can leave script-src
@@ -48,7 +49,7 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, CardDrag, DragDrop, LayoutHand},
+  hooks: {...colocatedHooks, CardDrag, DragDrop, LayoutHand, ScrollRestore},
 })
 
 // Uncheck the daisyUI drawer toggle when a sidebar link is clicked, so the

--- a/assets/js/hooks/scroll-restore.js
+++ b/assets/js/hooks/scroll-restore.js
@@ -1,0 +1,96 @@
+// Restores the window scroll position when the user returns to a page (browser
+// back, or an explicit "back to the list" link). LiveView's built-in scroll
+// restoration can't help on these pages: content loads asynchronously after
+// mount — and the infinite-scroll lists only load their first page — so the
+// old scroll height doesn't exist yet when history pops.
+//
+// How it works:
+//   * while mounted, every scroll (rAF-throttled) saves {y, offset} to
+//     sessionStorage keyed by pathname + search; `offset` is the page's
+//     infinite-scroll offset, mirrored via data-offset on the hook element
+//   * on the next mount at the same URL, push "restore-scroll" so the server
+//     can reload pages 0..offset in one query, then scroll back to y when it
+//     confirms with "sanctum:scroll-restore" (after the content has rendered)
+//   * links marked data-scroll-reset (the sidebar nav) clear any saved
+//     position for their target path, so section links always start at the
+//     top while back/return navigation still restores
+//
+// Entries are per-tab (sessionStorage) and are only cleared by
+// data-scroll-reset clicks; a stale entry at worst restores to a position the
+// user last held on that exact URL.
+
+const PREFIX = "sanctum:scroll:"
+
+const storageKey = () => PREFIX + window.location.pathname + window.location.search
+
+// Set when a data-scroll-reset link is clicked, so trailing scroll events
+// (e.g. trackpad inertia, or the browser clamping when the old page's content
+// is torn down) can't re-save a position we just cleared. Lifted again on the
+// next hook mount.
+let suppressSave = false
+
+// Target path of a data-scroll-reset click. LiveView doesn't scroll to top on
+// live navigation, so when the next mount is at this path we force it there —
+// otherwise the browser clamps the old scroll depth against the fresh first
+// page and immediately re-triggers viewport loads.
+let freshNavPath = null
+
+document.addEventListener("click", (e) => {
+  const link = e.target.closest?.("a[data-scroll-reset]")
+  if (!link || !link.href) return
+
+  suppressSave = true
+  freshNavPath = new URL(link.href, window.location.origin).pathname
+  for (let i = sessionStorage.length - 1; i >= 0; i--) {
+    const key = sessionStorage.key(i)
+    if (key === PREFIX + freshNavPath || key?.startsWith(PREFIX + freshNavPath + "?")) {
+      sessionStorage.removeItem(key)
+    }
+  }
+})
+
+export default {
+  mounted() {
+    const fresh = freshNavPath === window.location.pathname
+    freshNavPath = null
+    suppressSave = false
+    if (fresh) window.scrollTo(0, 0)
+    this.ticking = false
+
+    this.onScroll = () => {
+      if (this.ticking) return
+      this.ticking = true
+      requestAnimationFrame(() => {
+        this.ticking = false
+        if (suppressSave) return
+        const offset = parseInt(this.el.dataset.offset ?? "0", 10) || 0
+        sessionStorage.setItem(storageKey(), JSON.stringify({y: window.scrollY, offset}))
+      })
+    }
+    window.addEventListener("scroll", this.onScroll, {passive: true})
+
+    const saved = sessionStorage.getItem(storageKey())
+    if (!saved) return
+
+    let entry
+    try {
+      entry = JSON.parse(saved)
+    } catch {
+      sessionStorage.removeItem(storageKey())
+      return
+    }
+
+    const y = entry.y ?? 0
+    if (y <= 0 && !(entry.offset > 0)) return
+
+    this.handleEvent("sanctum:scroll-restore", () => {
+      // rAF so the scroll lands after the confirming diff has been painted.
+      requestAnimationFrame(() => window.scrollTo(0, y))
+    })
+    this.pushEvent("restore-scroll", {offset: entry.offset ?? 0})
+  },
+
+  destroyed() {
+    window.removeEventListener("scroll", this.onScroll)
+  },
+}

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -151,6 +151,10 @@ defmodule SanctumWeb.Layouts do
   # Block-level nav link used inside the sidebar / slideout drawer. Inactive
   # links are quiet text rows; the active one becomes a comic "caption box" —
   # halftone cardstock, hard offset shadow, and a slight tilt.
+  #
+  # data-scroll-reset marks these as fresh entry points: the ScrollRestore
+  # hook clears any saved scroll position for the target path, so section
+  # links always land at the top (browser back still restores).
   defp sidebar_link(assigns) do
     ~H"""
     <.link
@@ -160,6 +164,7 @@ defmodule SanctumWeb.Layouts do
           "border-transparent text-base-content/55 hover:text-white"
       ]}
       phx-click={close_drawer()}
+      data-scroll-reset
       {@rest}
     >
       {render_slot(@inner_block)}

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -33,10 +33,18 @@ defmodule SanctumWeb.CardLive.Pool do
     {"player_side_scheme", "Side Scheme"}
   ]
 
+  @aspect_keys Enum.map(@aspects, &elem(&1, 0))
+  @type_keys Enum.map(@types, &elem(&1, 0))
+
+  # Deepest infinite-scroll offset a scroll restore will refetch in one query
+  # (limit = offset + page size must stay within Ash's 250 max page size).
+  @max_restore_offset @page_size * 9
+
   @impl true
   def render(assigns) do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:cards}>
+      <div id="scroll-restore" phx-hook="ScrollRestore" data-offset={@offset}></div>
       <.header>
         Card Pool
         <:subtitle>
@@ -173,35 +181,76 @@ defmodule SanctumWeb.CardLive.Pool do
       |> assign(:end_of_timeline?, false)
       |> assign(:req_id, 0)
       |> assign(:loading?, true)
+      |> assign(:scroll_restore_pending?, false)
       |> assign(:hero_colors, %{})
       |> stream(:cards, [])
-
-    # Skip every query on the static (disconnected) render — it exists only to
-    # paint the shell fast. The real data loads asynchronously once the socket
-    # connects, so nothing blocks time-to-first-paint.
-    socket = if connected?(socket), do: start_load(socket, 0, reset: true), else: socket
 
     {:ok, socket}
   end
 
+  # Filters live in the URL (filter events push_patch here) so back/forward
+  # and shared links restore them. The initial data load also starts here —
+  # only on the connected mount (req_id == 0 guards the first pass); the
+  # static render just paints the shell.
+  @impl true
+  def handle_params(params, _uri, socket) do
+    query = params["query"] || ""
+    aspect = if params["aspect"] in @aspect_keys, do: params["aspect"], else: "all"
+    type = if params["type"] in @type_keys, do: params["type"], else: "all"
+
+    changed? =
+      query != socket.assigns.query or aspect != socket.assigns.aspect or
+        type != socket.assigns.type
+
+    socket = assign(socket, query: query, aspect: aspect, type: type)
+
+    socket =
+      if connected?(socket) and (changed? or socket.assigns.req_id == 0),
+        do: reset_and_load(socket),
+        else: socket
+
+    {:noreply, socket}
+  end
+
+  # `replace: true` so typing doesn't spam a history entry per keystroke.
   @impl true
   def handle_event("search", %{"query" => query}, socket) do
-    {:noreply, socket |> assign(:query, query) |> reset_and_load()}
+    {:noreply, push_patch(socket, to: pool_path(socket.assigns, query: query), replace: true)}
   end
 
   def handle_event("filter_aspect", %{"key" => key}, socket) do
-    {:noreply, socket |> assign(:aspect, key) |> reset_and_load()}
+    {:noreply, push_patch(socket, to: pool_path(socket.assigns, aspect: key))}
   end
 
   def handle_event("filter_type", %{"key" => key}, socket) do
-    {:noreply, socket |> assign(:type, key) |> reset_and_load()}
+    {:noreply, push_patch(socket, to: pool_path(socket.assigns, type: key))}
   end
 
   def handle_event("clear", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(query: "", aspect: "all", type: "all")
-     |> reset_and_load()}
+    {:noreply, push_patch(socket, to: ~p"/cards")}
+  end
+
+  # Pushed by the ScrollRestore hook when the user arrives with a saved scroll
+  # position: refetch everything through the saved infinite-scroll offset in
+  # one query, then confirm so the hook can restore the scroll position.
+  def handle_event("restore-scroll", %{"offset" => offset}, socket) do
+    offset = sanitize_offset(offset)
+
+    socket =
+      cond do
+        offset > 0 ->
+          socket
+          |> assign(:scroll_restore_pending?, true)
+          |> start_load(offset, reset: true, restore: true)
+
+        socket.assigns.loading? ->
+          assign(socket, :scroll_restore_pending?, true)
+
+        true ->
+          confirm_scroll_restore(socket)
+      end
+
+    {:noreply, socket}
   end
 
   # Ignore the viewport trigger while a page is already in flight so a burst of
@@ -236,6 +285,11 @@ defmodule SanctumWeb.CardLive.Pool do
           reset: reset?
         )
 
+      socket =
+        if socket.assigns.scroll_restore_pending?,
+          do: confirm_scroll_restore(socket),
+          else: socket
+
       {:noreply, socket}
     else
       {:noreply, socket}
@@ -249,13 +303,25 @@ defmodule SanctumWeb.CardLive.Pool do
      |> put_flash(:error, "Couldn’t load cards: #{inspect(reason)}")}
   end
 
-  defp reset_and_load(socket), do: start_load(socket, 0, reset: true)
+  # A user-initiated reset (filter/search change) cancels any in-flight scroll
+  # restore — the saved position belongs to the previous result set.
+  defp reset_and_load(socket) do
+    socket
+    |> assign(:scroll_restore_pending?, false)
+    |> start_load(0, reset: true)
+  end
 
   # Kick off the browse read off the socket so the connected mount returns the
   # shell immediately. `hero_colors` is fetched only once per LiveView (it's a
   # static per-set palette map) and reused across every subsequent load.
+  #
+  # `restore: true` refetches pages 0..offset in one query (for scroll
+  # restoration) while keeping `offset` as the logical last-page offset so
+  # subsequent viewport loads continue from the right place.
   defp start_load(socket, offset, opts \\ []) do
     reset? = Keyword.get(opts, :reset, false)
+    restore? = Keyword.get(opts, :restore, false)
+    {query_offset, limit} = if restore?, do: {0, offset + @page_size}, else: {offset, @page_size}
     req = socket.assigns.req_id + 1
     filters = filters(socket.assigns)
     actor = socket.assigns[:current_user]
@@ -268,12 +334,41 @@ defmodule SanctumWeb.CardLive.Pool do
       page =
         Sanctum.Games.CardSide
         |> Ash.Query.for_read(:browse, filters, actor: actor)
-        |> Ash.read!(page: [limit: @page_size, offset: offset, count: reset?])
+        |> Ash.read!(page: [limit: limit, offset: query_offset, count: reset?])
 
       colors = if fetch_colors?, do: Sanctum.Heroes.hero_color_map(), else: nil
 
       %{req: req, offset: offset, reset?: reset?, page: page, colors: colors}
     end)
+  end
+
+  defp confirm_scroll_restore(socket) do
+    socket
+    |> assign(:scroll_restore_pending?, false)
+    |> push_event("sanctum:scroll-restore", %{})
+  end
+
+  # Clamp a client-supplied offset to a sane page-aligned value.
+  defp sanitize_offset(offset) when is_integer(offset) do
+    offset
+    |> max(0)
+    |> min(@max_restore_offset)
+    |> then(&(&1 - rem(&1, @page_size)))
+  end
+
+  defp sanitize_offset(_), do: 0
+
+  # /cards path carrying the current (or overridden) filters, omitting defaults.
+  defp pool_path(assigns, overrides) do
+    f = Map.merge(filters(assigns), Map.new(overrides))
+
+    params =
+      Enum.reject(
+        [query: f.query, aspect: f.aspect, type: f.type],
+        fn {k, v} -> if k == :query, do: v == "", else: v == "all" end
+      )
+
+    ~p"/cards?#{params}"
   end
 
   # `page.count` is only queried on reset loads (count: reset?). `total` is the

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -24,10 +24,18 @@ defmodule SanctumWeb.DeckLive.Index do
 
   @sorts [{"new", "Newest"}, {"unique", "Unique"}, {"title", "A–Z"}]
 
+  @aspect_keys Enum.map(@aspects, &elem(&1, 0))
+  @sort_keys Enum.map(@sorts, &elem(&1, 0))
+
+  # Deepest infinite-scroll offset a scroll restore will refetch in one query
+  # (limit = offset + page size must stay within Ash's 250 max page size).
+  @max_restore_offset @page_size * 9
+
   @impl true
   def render(assigns) do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:decks}>
+      <div id="scroll-restore" phx-hook="ScrollRestore" data-offset={@offset}></div>
       <.header>
         Browse Decks
         <:subtitle>
@@ -226,15 +234,45 @@ defmodule SanctumWeb.DeckLive.Index do
       |> assign(:end_of_timeline?, false)
       |> assign(:req_id, 0)
       |> assign(:loading?, true)
+      |> assign(:scroll_restore_pending?, false)
       |> stream(:decks, [])
-
-    # Skip every query on the static (disconnected) render — it exists only to
-    # paint the shell fast. The real data loads asynchronously once the socket
-    # connects, so nothing blocks time-to-first-paint.
-    socket = if connected?(socket), do: start_load(socket, 0, reset: true), else: socket
 
     {:ok, socket}
   end
+
+  # Filters live in the URL (filter events push_patch here) so back/forward
+  # and shared links restore them. The initial data load also starts here —
+  # only on the connected mount (req_id == 0 guards the first pass); the
+  # static render just paints the shell.
+  @impl true
+  def handle_params(params, _uri, socket) do
+    query = params["query"] || ""
+    sort = if params["sort"] in @sort_keys, do: params["sort"], else: "new"
+    aspect = if params["aspect"] in @aspect_keys, do: params["aspect"], else: "all"
+    hero_id = valid_hero_id(params["hero_id"])
+
+    changed? =
+      query != socket.assigns.query or sort != socket.assigns.sort or
+        aspect != socket.assigns.aspect or hero_id != socket.assigns.hero_id
+
+    socket = assign(socket, query: query, sort: sort, aspect: aspect, hero_id: hero_id)
+
+    socket =
+      if connected?(socket) and (changed? or socket.assigns.req_id == 0),
+        do: reset_and_load(socket),
+        else: socket
+
+    {:noreply, socket}
+  end
+
+  defp valid_hero_id(hero_id) when is_binary(hero_id) do
+    case Ecto.UUID.cast(hero_id) do
+      {:ok, _} -> hero_id
+      :error -> "all"
+    end
+  end
+
+  defp valid_hero_id(_), do: "all"
 
   # {id, hero_name} for every hero, sorted by name.
   defp load_hero_options do
@@ -245,28 +283,49 @@ defmodule SanctumWeb.DeckLive.Index do
     |> Enum.map(&{&1.id, &1.hero_name})
   end
 
+  # `replace: true` so typing doesn't spam a history entry per keystroke.
   @impl true
   def handle_event("search", %{"query" => query}, socket) do
-    {:noreply, socket |> assign(:query, query) |> reset_and_load()}
+    {:noreply, push_patch(socket, to: decks_path(socket.assigns, query: query), replace: true)}
   end
 
   def handle_event("sort", %{"key" => key}, socket) do
-    {:noreply, socket |> assign(:sort, key) |> reset_and_load()}
+    {:noreply, push_patch(socket, to: decks_path(socket.assigns, sort: key))}
   end
 
   def handle_event("filter_aspect", %{"key" => key}, socket) do
-    {:noreply, socket |> assign(:aspect, key) |> reset_and_load()}
+    {:noreply, push_patch(socket, to: decks_path(socket.assigns, aspect: key))}
   end
 
   def handle_event("filter_hero", %{"hero_id" => hero_id}, socket) do
-    {:noreply, socket |> assign(:hero_id, hero_id) |> reset_and_load()}
+    {:noreply, push_patch(socket, to: decks_path(socket.assigns, hero_id: hero_id))}
   end
 
   def handle_event("clear", _params, socket) do
-    {:noreply,
-     socket
-     |> assign(query: "", aspect: "all", hero_id: "all", sort: "new")
-     |> reset_and_load()}
+    {:noreply, push_patch(socket, to: ~p"/decks")}
+  end
+
+  # Pushed by the ScrollRestore hook when the user arrives with a saved scroll
+  # position: refetch everything through the saved infinite-scroll offset in
+  # one query, then confirm so the hook can restore the scroll position.
+  def handle_event("restore-scroll", %{"offset" => offset}, socket) do
+    offset = sanitize_offset(offset)
+
+    socket =
+      cond do
+        offset > 0 ->
+          socket
+          |> assign(:scroll_restore_pending?, true)
+          |> start_load(offset, reset: true, restore: true)
+
+        socket.assigns.loading? ->
+          assign(socket, :scroll_restore_pending?, true)
+
+        true ->
+          confirm_scroll_restore(socket)
+      end
+
+    {:noreply, socket}
   end
 
   # Ignore the viewport trigger while a page is already in flight so a burst of
@@ -295,6 +354,11 @@ defmodule SanctumWeb.DeckLive.Index do
         |> maybe_assign_count(reset?, page.count)
         |> stream(:decks, Enum.map(page.results, &deck_view/1), reset: reset?)
 
+      socket =
+        if socket.assigns.scroll_restore_pending?,
+          do: confirm_scroll_restore(socket),
+          else: socket
+
       {:noreply, socket}
     else
       {:noreply, socket}
@@ -308,13 +372,25 @@ defmodule SanctumWeb.DeckLive.Index do
      |> put_flash(:error, "Couldn’t load decks: #{inspect(reason)}")}
   end
 
-  defp reset_and_load(socket), do: start_load(socket, 0, reset: true)
+  # A user-initiated reset (filter/search change) cancels any in-flight scroll
+  # restore — the saved position belongs to the previous result set.
+  defp reset_and_load(socket) do
+    socket
+    |> assign(:scroll_restore_pending?, false)
+    |> start_load(0, reset: true)
+  end
 
   # Kick off the browse read off the socket so the connected mount returns the
   # shell immediately. `hero_options` is fetched only once per LiveView (a
   # static hero list) and reused across every subsequent load.
+  #
+  # `restore: true` refetches pages 0..offset in one query (for scroll
+  # restoration) while keeping `offset` as the logical last-page offset so
+  # subsequent viewport loads continue from the right place.
   defp start_load(socket, offset, opts \\ []) do
     reset? = Keyword.get(opts, :reset, false)
+    restore? = Keyword.get(opts, :restore, false)
+    {query_offset, limit} = if restore?, do: {0, offset + @page_size}, else: {offset, @page_size}
     req = socket.assigns.req_id + 1
     filters = filters(socket.assigns)
     actor = socket.assigns[:current_user]
@@ -327,12 +403,47 @@ defmodule SanctumWeb.DeckLive.Index do
       page =
         Sanctum.Decks.Deck
         |> Ash.Query.for_read(:browse, filters, actor: actor)
-        |> Ash.read!(page: [limit: @page_size, offset: offset, count: reset?])
+        |> Ash.read!(page: [limit: limit, offset: query_offset, count: reset?])
 
       hero_options = if fetch_heroes?, do: load_hero_options(), else: nil
 
       %{req: req, offset: offset, reset?: reset?, page: page, hero_options: hero_options}
     end)
+  end
+
+  defp confirm_scroll_restore(socket) do
+    socket
+    |> assign(:scroll_restore_pending?, false)
+    |> push_event("sanctum:scroll-restore", %{})
+  end
+
+  # Clamp a client-supplied offset to a sane page-aligned value.
+  defp sanitize_offset(offset) when is_integer(offset) do
+    offset
+    |> max(0)
+    |> min(@max_restore_offset)
+    |> then(&(&1 - rem(&1, @page_size)))
+  end
+
+  defp sanitize_offset(_), do: 0
+
+  # /decks path carrying the current (or overridden) filters, omitting defaults.
+  defp decks_path(assigns, overrides) do
+    f = Map.merge(filters(assigns), Map.new(overrides))
+
+    params =
+      Enum.reject(
+        [query: f.query, sort: f.sort, aspect: f.aspect, hero_id: f.hero_id],
+        fn {k, v} ->
+          case k do
+            :query -> v == ""
+            :sort -> v == "new"
+            _ -> v == "all"
+          end
+        end
+      )
+
+    ~p"/decks?#{params}"
   end
 
   defp maybe_assign_hero_options(socket, nil), do: socket

--- a/test/sanctum_web/live/card_live/pool_test.exs
+++ b/test/sanctum_web/live/card_live/pool_test.exs
@@ -70,4 +70,52 @@ defmodule SanctumWeb.CardLive.PoolTest do
     assert html =~ "Spider-Man"
     refute html =~ "Iron Man"
   end
+
+  test "search patches the query into the URL", %{conn: conn} do
+    make_card(%{code: "01001a", name: "Spider-Man", type: :hero})
+
+    {:ok, lv, _html} = live(conn, ~p"/cards")
+    render_async(lv)
+
+    lv |> form("#card-search", query: "spider") |> render_change()
+
+    assert_patch(lv, ~p"/cards?query=spider")
+  end
+
+  test "mounting with filter params applies them", %{conn: conn} do
+    make_card(%{code: "01001a", name: "Spider-Man", type: :hero})
+    make_card(%{code: "01003a", name: "Web Kick", type: :event, ownership: :hero})
+
+    {:ok, lv, _html} = live(conn, ~p"/cards?query=web")
+
+    html = render_async(lv)
+
+    assert html =~ "Web Kick"
+    refute html =~ "Spider-Man"
+  end
+
+  test "unknown filter params fall back to defaults", %{conn: conn} do
+    make_card(%{code: "01001a", name: "Spider-Man", type: :hero})
+
+    {:ok, lv, _html} = live(conn, ~p"/cards?aspect=bogus&type=nope")
+
+    html = render_async(lv)
+
+    assert html =~ "Spider-Man"
+  end
+
+  test "restore-scroll reloads through the saved offset and confirms", %{conn: conn} do
+    make_card(%{code: "01001a", name: "Spider-Man", type: :hero})
+    make_card(%{code: "01002a", name: "Iron Man", type: :hero})
+
+    {:ok, lv, _html} = live(conn, ~p"/cards")
+    render_async(lv)
+
+    render_hook(lv, "restore-scroll", %{"offset" => 24})
+    html = render_async(lv)
+
+    assert_push_event(lv, "sanctum:scroll-restore", %{})
+    assert html =~ "Spider-Man"
+    assert html =~ "Iron Man"
+  end
 end


### PR DESCRIPTION
## What

Returning to the **card pool** or **deck browser** via browser back (or a back-to-list link) now lands where you left off — filters, loaded pages, and scroll position all restored — instead of at the top of a freshly-reset page.

Two pieces make that work:

### Filters move into the URL

Card pool (`?query=&aspect=&type=`) and deck browser (`?query=&sort=&aspect=&hero_id=`) filter events now `push_patch` their state as query params handled in `handle_params`, so back/forward and shared links restore the filter set. Search typing uses `replace: true` to avoid a history entry per keystroke; unknown param values fall back to defaults. The initial data load moves from `mount` to the first connected `handle_params` pass.

### A shared `ScrollRestore` hook

While mounted, the hook records `{scrollY, offset}` to sessionStorage keyed by `pathname + search` (offset is the page's infinite-scroll position, mirrored via `data-offset`). On the next mount at the same URL it pushes `restore-scroll`: the list pages refetch pages `0..offset` in a **single query** (capped at 10 pages, within Ash's 250 max page size) while keeping the logical offset so viewport pagination continues correctly. The server confirms with a `sanctum:scroll-restore` event once content exists at full height, and the hook scrolls back. The existing `req_id` staleness guard covers the restore load racing the initial load.

### Sidebar nav links reset

Sidebar links are marked `data-scroll-reset`: clicking one clears any saved position for the target path and forces the next mount to the top. This also fixes a pre-existing bug — LiveView doesn't scroll to top on live navigation, so clicking "Cards" while deep in the list used to leave you mid-page with the browser clamp re-triggering viewport loads.

## Verification

- Browser-verified on the card pool: 8 pages deep (y=12000) → card detail → back restores y=12000 with all 216 tiles; same flow with a Justice filter active restores URL + pill + scroll; sidebar click lands clean at top with one page loaded.
- New tests: URL params on mount, patch on search, param fallback, and the restore-scroll round-trip (`assert_push_event`).
- `mix ck` clean, full suite 209 tests / 0 failures.

The deck **detail** page wiring rides in a follow-up PR stacked on #198 (its diff is dependency-locked to that branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)