### PR TITLE
feat(decks): restore scroll position on the deck detail page

### DIFF
--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -20,6 +20,7 @@ defmodule SanctumWeb.DeckLive.Show do
   def render(assigns) do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:decks}>
+      <div id="scroll-restore" phx-hook="ScrollRestore"></div>
       <div id="deck-card-view-pref" phx-hook=".CardViewPref"></div>
       <script :type={Phoenix.LiveView.ColocatedHook} name=".CardViewPref">
         const KEY = "sanctum:deck-card-view"
@@ -359,6 +360,7 @@ defmodule SanctumWeb.DeckLive.Show do
       |> assign(:similar, [])
       |> assign(:writeup, nil)
       |> assign(:card_view, "images")
+      |> assign(:scroll_restore_pending?, false)
 
     actor = socket.assigns[:current_user]
 
@@ -387,16 +389,38 @@ defmodule SanctumWeb.DeckLive.Show do
     {:noreply, assign(socket, :card_view, view)}
   end
 
+  # Pushed by the ScrollRestore hook when the user arrives with a saved scroll
+  # position. The page renders asynchronously, so hold the confirmation until
+  # the deck load lands and the content exists at its full height.
+  def handle_event("restore-scroll", _params, socket) do
+    if socket.assigns.deck do
+      {:noreply, push_event(socket, "sanctum:scroll-restore", %{})}
+    else
+      {:noreply, assign(socket, :scroll_restore_pending?, true)}
+    end
+  end
+
   @impl true
   def handle_async(:load_deck, {:ok, {:ok, data}}, socket) do
-    {:noreply,
-     socket
-     |> assign(:page_title, data.deck.title)
-     |> assign(:deck, data.deck)
-     |> assign(:cover, data.cover)
-     |> assign(:groups, data.groups)
-     |> assign(:similar, data.similar)
-     |> assign(:writeup, data.writeup)}
+    socket =
+      socket
+      |> assign(:page_title, data.deck.title)
+      |> assign(:deck, data.deck)
+      |> assign(:cover, data.cover)
+      |> assign(:groups, data.groups)
+      |> assign(:similar, data.similar)
+      |> assign(:writeup, data.writeup)
+
+    socket =
+      if socket.assigns.scroll_restore_pending? do
+        socket
+        |> assign(:scroll_restore_pending?, false)
+        |> push_event("sanctum:scroll-restore", %{})
+      else
+        socket
+      end
+
+    {:noreply, socket}
   end
 
   def handle_async(:load_deck, {:ok, :not_found}, socket) do

--- a/test/sanctum_web/live/deck_live/show_test.exs
+++ b/test/sanctum_web/live/deck_live/show_test.exs
@@ -88,6 +88,17 @@ defmodule SanctumWeb.DeckLive.ShowTest do
     assert html =~ "Thwart twice"
   end
 
+  test "restore-scroll confirms once the deck content has loaded", %{conn: conn} do
+    deck = make_deck_with_card()
+
+    {:ok, view, _html} = live(conn, ~p"/decks/#{deck.id}")
+
+    render_hook(view, "restore-scroll", %{"offset" => 0})
+    render_async(view)
+
+    assert_push_event(view, "sanctum:scroll-restore", %{})
+  end
+
   test "a scored deck shows its uniqueness meter", %{conn: conn} do
     deck = make_deck_with_card()
 


### PR DESCRIPTION
## What

Wires the deck detail page into the `ScrollRestore` hook introduced in #205: the page confirms a pending `restore-scroll` request once its async deck load lands, so returning to a deck via browser back (e.g. from a card page) scrolls to where you left off — after the content exists at its full height, not against the skeleton.

No pagination here, so unlike the list pages there's no offset refetch — just a deferred confirmation (`scroll_restore_pending?`) resolved in `handle_async(:load_deck, ...)`, or immediately if the deck already loaded when the hook checks in.

Depends on #205 for the client-side hook — merge that first.

## Diff note

This branch was stacked on `feat/deck-view-toggle` (#198), which has since been **squash-merged**, so the "Files changed" view temporarily double-shows that PR's `show.ex` changes (`f3a1d23`). The content is identical to what's already on main — merging is a no-op for those lines — and the next GitButler workspace pull will rebase this branch onto main and clean the diff automatically. Only the `12d4cdc` commit is new. (The workspace pull is currently blocked by in-flight uncommitted work from a parallel branch.)

## Verification

Covered by a new test asserting the `sanctum:scroll-restore` push event fires after the async load (`assert_push_event`). Browser verification of this page was blocked by an unrelated broken migration in the shared workspace; the flow is identical to the pool/browser pages verified live in #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
