### PR TITLE
fix(decks): stack deck header buttons above the title on mobile

### DIFF
--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -43,25 +43,31 @@ defmodule SanctumWeb.DeckLive.Show do
       </div>
 
       <div :if={@deck != nil}>
-        <.header>
-          {@deck.title}
-          <:subtitle>
-            {@cover.hero_name}<span :if={@cover.author}> · by {@cover.author}</span>
-          </:subtitle>
-          <:actions>
-            <.button
-              :if={mcdb_url(@deck)}
-              href={mcdb_url(@deck)}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <.icon name="hero-arrow-top-right-on-square" /> MarvelCDB
-            </.button>
-            <.button navigate={~p"/decks"}>
-              <.icon name="hero-arrow-left" /> Decks
-            </.button>
-          </:actions>
-        </.header>
+        <header class="mb-6 border-b-[3px] border-neutral pb-4">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
+            <div class="order-2 min-w-0 sm:order-1">
+              <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-[42px]">
+                {@deck.title}
+              </h1>
+              <p class="mt-2 font-barlow text-[15px] text-base-content/60">
+                {@cover.hero_name}<span :if={@cover.author}> · by {@cover.author}</span>
+              </p>
+            </div>
+            <div class="order-1 flex flex-none items-center gap-2.5 sm:order-2">
+              <.button
+                :if={mcdb_url(@deck)}
+                href={mcdb_url(@deck)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <.icon name="hero-arrow-top-right-on-square" /> MarvelCDB
+              </.button>
+              <.button navigate={~p"/decks"}>
+                <.icon name="hero-arrow-left" /> Decks
+              </.button>
+            </div>
+          </div>
+        </header>
 
         <div class="space-y-5">
           <!-- cover -->


### PR DESCRIPTION
## What

On the deck detail page, the title was being squashed into a thin, word-by-word-wrapping column on narrow screens.

## Why

The shared `.header` component keeps the title and action buttons in a side-by-side row at every breakpoint. On mobile the two buttons (MarvelCDB / Decks) claimed enough width to crush the title.

## Fix

Replace the `.header` usage on the deck detail page with inline responsive markup:

- **Mobile:** stacks vertically with the buttons ordered *above* the title, so the title gets full width and flows naturally.
- **`sm:` and up:** keeps the original title-left / buttons-right layout, unchanged.

The shared `.header` component is left alone so no other page is affected.

## Verification

Screenshotted the deck page at mobile (390px) and desktop (1280px) widths against the running dev server — mobile stacks with buttons on top, desktop is visually identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)