### PR TITLE
feat(deploy): warn connected users before a deploy restarts the app

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -14,6 +14,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      # Tell connected users a deploy is on the way (flash message via PubSub —
+      # see SanctumWeb.DeployNotice). Runs before the image build so people get
+      # a few minutes of lead time before machines restart. Never fails the
+      # deploy: the app may be scaled to zero or the token unset, and deploying
+      # is more important than warning.
+      - name: Warn connected users
+        run: |
+          curl -fsS -m 15 -X POST "https://sanctummc.com/internal/deploy-notice" \
+            -H "Authorization: Bearer $DEPLOY_NOTICE_TOKEN" \
+            || echo "::warning::deploy notice failed; deploying without warning users"
+        env:
+          DEPLOY_NOTICE_TOKEN: ${{ secrets.DEPLOY_NOTICE_TOKEN }}
+
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -69,6 +69,11 @@ config :sanctum, SanctumWeb.Endpoint,
 # Enable dev routes for dashboard and mailbox
 config :sanctum, dev_routes: true, token_signing_secret: "Ng9tUOyxnipHxWoTtOyIQ2F/ZTJ45+Vv"
 
+# Fixed token so the deploy-notice webhook can be exercised locally:
+#   curl -X POST localhost:4150/internal/deploy-notice \
+#     -H "Authorization: Bearer dev-deploy-notice-token"
+config :sanctum, :deploy_notice_token, "dev-deploy-notice-token"
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :default_formatter, format: "[$level] $message\n"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,6 +66,10 @@ if config_env() == :prod do
 
   config :sanctum, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
+  # Shared secret for the CI deploy-notice webhook (POST /internal/deploy-notice).
+  # Unset ⇒ the endpoint responds 404 to everything.
+  config :sanctum, :deploy_notice_token, System.get_env("DEPLOY_NOTICE_TOKEN")
+
   # Pin Oban's node identity to the Fly machine ID: it survives restarts *and*
   # redeploys, unlike the BEAM node name (which embeds the per-deploy image
   # ref). `Sanctum.Oban.BootRescue` relies on this stability to recognize jobs

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,6 +9,7 @@ config :ex_unit, assert_receive_timeout: 2000
 config :sanctum, Oban, testing: :manual
 config :sanctum, :marvel_cdb_req_options, plug: {Req.Test, Sanctum.MarvelCdb}
 config :sanctum, token_signing_secret: "/oZ9ck2w3h4oPYA4x7ZebHnqCh1MKXIp"
+config :sanctum, :deploy_notice_token, "test-deploy-notice-token"
 config :bcrypt_elixir, log_rounds: 1
 config :ash, policies: [show_policy_breakdowns?: true]
 

--- a/lib/sanctum_web/controllers/deploy_notice_controller.ex
+++ b/lib/sanctum_web/controllers/deploy_notice_controller.ex
@@ -1,0 +1,24 @@
+defmodule SanctumWeb.DeployNoticeController do
+  @moduledoc """
+  CI-facing webhook that announces an imminent deploy to connected users.
+
+  Guarded by a shared bearer token (`DEPLOY_NOTICE_TOKEN` in prod); responds
+  404 for missing/invalid tokens and when no token is configured, so the
+  route is invisible to probes.
+  """
+
+  use SanctumWeb, :controller
+
+  def create(conn, _params) do
+    with expected when is_binary(expected) <- configured_token(),
+         ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         true <- Plug.Crypto.secure_compare(token, expected) do
+      SanctumWeb.DeployNotice.broadcast()
+      send_resp(conn, 204, "")
+    else
+      _ -> send_resp(conn, 404, "")
+    end
+  end
+
+  defp configured_token, do: Application.get_env(:sanctum, :deploy_notice_token)
+end

--- a/lib/sanctum_web/deploy_notice.ex
+++ b/lib/sanctum_web/deploy_notice.ex
@@ -1,0 +1,37 @@
+defmodule SanctumWeb.DeployNotice do
+  @moduledoc """
+  Warns connected users that a deploy is about to restart the app.
+
+  CI hits `POST /internal/deploy-notice` (see `DeployNoticeController`) before
+  kicking off `flyctl deploy`, giving users the image-build time (a few
+  minutes) as lead time. The controller broadcasts on a PubSub topic; every
+  LiveView in the router's live sessions runs the `:notify` on_mount hook,
+  which subscribes and surfaces the notice as an info flash. PubSub is
+  cluster-aware (DNSCluster on Fly), so users connected to any machine see it
+  before their socket drops and the page live-reloads into the new version.
+  """
+
+  import Phoenix.LiveView
+
+  @topic "sanctum:deploy_notices"
+  @default_message "A new version of Sanctum is deploying — this page will refresh itself in a few minutes."
+
+  def on_mount(:notify, _params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Sanctum.PubSub, @topic)
+    end
+
+    {:cont, attach_hook(socket, :deploy_notice, :handle_info, &handle_info/2)}
+  end
+
+  @doc "Broadcasts a deploy notice to every connected LiveView across the cluster."
+  def broadcast(message \\ @default_message) do
+    Phoenix.PubSub.broadcast(Sanctum.PubSub, @topic, {:deploy_notice, message})
+  end
+
+  defp handle_info({:deploy_notice, message}, socket) do
+    {:halt, put_flash(socket, :info, message)}
+  end
+
+  defp handle_info(_message, socket), do: {:cont, socket}
+end

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -37,11 +37,20 @@ defmodule SanctumWeb.Router do
     plug :put_oban_csp
   end
 
+  # Minimal stack for CI-driven webhooks — token auth happens in the
+  # controller, so no session/auth plugs are needed.
+  pipeline :deploy_hooks do
+    plug :accepts, ["json"]
+  end
+
   scope "/", SanctumWeb do
     pipe_through :browser
 
     ash_authentication_live_session :authenticated_routes,
-      on_mount: [{SanctumWeb.Presence, :track}] do
+      on_mount: [
+        {SanctumWeb.Presence, :track},
+        {SanctumWeb.DeployNotice, :notify}
+      ] do
       # in each liveview, add one of the following at the top of the module:
       #
       # If an authenticated user must be present:
@@ -79,7 +88,8 @@ defmodule SanctumWeb.Router do
     ash_authentication_live_session :admin_routes,
       on_mount: [
         {SanctumWeb.LiveUserAuth, :live_admin_required},
-        {SanctumWeb.Presence, :track}
+        {SanctumWeb.Presence, :track},
+        {SanctumWeb.DeployNotice, :notify}
       ] do
       # Admin landing page — system health + links to admin surfaces.
       live "/admin", AdminLive.Index, :index
@@ -151,6 +161,14 @@ defmodule SanctumWeb.Router do
   # scope "/api", SanctumWeb do
   #   pipe_through :api
   # end
+
+  # CI-only webhook: announces an imminent deploy to connected users
+  # (bearer-token guarded; see SanctumWeb.DeployNoticeController).
+  scope "/internal", SanctumWeb do
+    pipe_through :deploy_hooks
+
+    post "/deploy-notice", DeployNoticeController, :create
+  end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:sanctum, :dev_routes) do

--- a/test/sanctum_web/controllers/deploy_notice_controller_test.exs
+++ b/test/sanctum_web/controllers/deploy_notice_controller_test.exs
@@ -1,0 +1,41 @@
+defmodule SanctumWeb.DeployNoticeControllerTest do
+  use SanctumWeb.ConnCase, async: true
+
+  # Matches config/test.exs
+  @token "test-deploy-notice-token"
+  @topic "sanctum:deploy_notices"
+
+  test "broadcasts a deploy notice with a valid token", %{conn: conn} do
+    Phoenix.PubSub.subscribe(Sanctum.PubSub, @topic)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{@token}")
+      |> post(~p"/internal/deploy-notice")
+
+    assert response(conn, 204)
+    assert_receive {:deploy_notice, message}
+    assert message =~ "deploying"
+  end
+
+  test "responds 404 and stays silent for an invalid token", %{conn: conn} do
+    Phoenix.PubSub.subscribe(Sanctum.PubSub, @topic)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer wrong-token")
+      |> post(~p"/internal/deploy-notice")
+
+    assert response(conn, 404)
+    refute_receive {:deploy_notice, _message}
+  end
+
+  test "responds 404 and stays silent without an authorization header", %{conn: conn} do
+    Phoenix.PubSub.subscribe(Sanctum.PubSub, @topic)
+
+    conn = post(conn, ~p"/internal/deploy-notice")
+
+    assert response(conn, 404)
+    refute_receive {:deploy_notice, _message}
+  end
+end


### PR DESCRIPTION
## Summary

Users' pages silently reset when a deploy swaps the Fly machines, which reads as a random glitch. This PR makes CI announce the deploy so every connected LiveView shows an info flash with a few minutes' warning before the restart.

- **`SanctumWeb.DeployNotice`** — a `:notify` on_mount hook added to both router live sessions. Every connected LiveView subscribes to a PubSub topic and surfaces `{:deploy_notice, msg}` broadcasts as an info flash. PubSub is cluster-aware (DNSCluster), so users on every machine see it.
- **`POST /internal/deploy-notice`** — CI-facing webhook guarded by a shared bearer token (`DEPLOY_NOTICE_TOKEN`, constant-time compare). Responds 404 to bad/missing tokens *and* when no token is configured, so the route is invisible to probes.
- **`fly-deploy.yml`** — a curl step fires the notice before the image build, so the build time doubles as user lead time. It never fails the deploy: a scaled-to-zero app or unset token just logs a workflow warning.

## Setup required

The feature is dormant until the secret is set in both places:

```bash
TOKEN=$(openssl rand -hex 32)
fly secrets set DEPLOY_NOTICE_TOKEN="$TOKEN"   # restarts machines
gh secret set DEPLOY_NOTICE_TOKEN --body "$TOKEN"
```

## Testing

- 3 controller tests: valid token broadcasts; invalid/missing token → 404 with no broadcast.
- Verified end to end in dev: opened `/cards` in a browser, POSTed the webhook, and the flash rendered on the connected LiveView.
- `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)