### PR TITLE
feat(search): advanced query language for cards and decks

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -764,3 +764,74 @@ textarea::placeholder {
 }
 
 /* This file is for your main application CSS */
+
+/* ── Advanced-search query input (QueryInput hook) ────────────────────
+   Token colors for the syntax-highlighting mirror and the autocomplete
+   listbox. Colors alias existing theme tokens so the query bar reads as
+   part of the comic-dossier palette. */
+.qi-field {
+  color: var(--color-primary);
+}
+.qi-unknown {
+  text-decoration: underline wavy var(--color-error);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+.qi-op {
+  color: color-mix(in srgb, var(--color-base-content) 50%, transparent);
+}
+.qi-paren {
+  color: color-mix(in srgb, var(--color-base-content) 65%, transparent);
+}
+.qi-value {
+  color: var(--color-info);
+}
+.qi-number {
+  color: var(--color-aspect-encounter);
+}
+.qi-string {
+  color: var(--color-aspect-protection);
+}
+.qi-keyword {
+  color: var(--color-aspect-pool);
+  font-weight: 600;
+}
+
+.qi-option {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+  font-family: var(--font-barlow, 'Barlow Condensed', sans-serif);
+  font-size: 0.9rem;
+  border-bottom: 1px solid var(--color-line);
+}
+.qi-option:last-child {
+  border-bottom: none;
+}
+.qi-option.qi-active {
+  background: var(--color-base-300);
+  box-shadow: inset 3px 0 0 var(--color-primary);
+}
+.qi-option-label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.qi-kind-field {
+  color: var(--color-primary);
+}
+.qi-kind-value {
+  color: var(--color-info);
+}
+.qi-kind-keyword {
+  color: var(--color-aspect-pool);
+}
+.qi-option-detail {
+  color: color-mix(in srgb, var(--color-base-content) 50%, transparent);
+  font-size: 0.8rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,6 +28,7 @@ import topbar from "../vendor/topbar"
 import CardDrag from "./hooks/card-drag";
 import DragDrop from "./hooks/drag-drop";
 import LayoutHand from "./hooks/layout-hand";
+import QueryInput from "./hooks/query-input";
 import ScrollRestore from "./hooks/scroll-restore";
 
 // Sentry config arrives via meta tags rendered only when a DSN is configured
@@ -49,7 +50,7 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, CardDrag, DragDrop, LayoutHand, ScrollRestore},
+  hooks: {...colocatedHooks, CardDrag, DragDrop, LayoutHand, QueryInput, ScrollRestore},
 })
 
 // Uncheck the daisyUI drawer toggle when a sidebar link is clicked, so the

--- a/assets/js/hooks/query-input.js
+++ b/assets/js/hooks/query-input.js
@@ -1,0 +1,271 @@
+// Advanced-search query input: syntax highlighting + autocomplete.
+//
+// Follows GitHub's QueryBuilder pattern (their engineering blog documents why
+// contenteditable was rejected as inaccessible): the real <input> renders its
+// text transparent (caret/selection still visible) and an aria-hidden mirror
+// <div> behind it repeats the text as colored spans. A W3C-combobox-style
+// listbox offers suggestions computed *server-side* (`Sanctum.Search.Suggest`)
+// — the client only tokenizes for instant colors; the server owns the
+// grammar, the field registry, and value completion.
+//
+// The tokenizer must stay in sync with Sanctum.Search.Lexer: quoted strings,
+// operators (<= >= != < > = : !), parens, pipe, `-` negation, words.
+
+const TOKEN_RE = /(\s+)|("(?:[^"]*)"?)|(<=|>=|!=|[<>=:!])|([()])|(\|)|([^\s"()|:<>=!]+)/g
+
+const KEYWORDS = new Set(["and", "or", "not"])
+
+function tokenize(text) {
+  const tokens = []
+  let match
+  TOKEN_RE.lastIndex = 0
+  while ((match = TOKEN_RE.exec(text)) !== null) {
+    const [full, ws, str, op, paren, pipe, word] = match
+    if (ws != null) tokens.push({type: "ws", text: full})
+    else if (str != null) tokens.push({type: "string", text: full})
+    else if (op != null) tokens.push({type: "op", text: full})
+    else if (paren != null) tokens.push({type: "paren", text: full})
+    else if (pipe != null) tokens.push({type: "pipe", text: full})
+    else if (word != null) tokens.push({type: "word", text: full})
+  }
+  return tokens
+}
+
+// Second pass: words become field / keyword / number / value / plain text.
+function classify(tokens, knownFields) {
+  const out = []
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i]
+    if (t.type !== "word") {
+      out.push({cls: clsFor(t.type), text: t.text})
+      continue
+    }
+
+    const next = nextNonWs(tokens, i)
+    const prev = prevNonWs(tokens, i)
+    const lower = t.text.toLowerCase()
+
+    if (next && next.type === "op" && next.text !== "!") {
+      const known = knownFields.has(lower.replace(/-/g, "_"))
+      out.push({cls: known ? "qi-field" : "qi-field qi-unknown", text: t.text})
+    } else if (prev && (prev.type === "op" || prev.type === "pipe")) {
+      out.push({cls: /^\d+$/.test(t.text) ? "qi-number" : "qi-value", text: t.text})
+    } else if (KEYWORDS.has(lower)) {
+      out.push({cls: "qi-keyword", text: t.text})
+    } else {
+      out.push({cls: null, text: t.text})
+    }
+  }
+  return out
+}
+
+function clsFor(type) {
+  switch (type) {
+    case "string": return "qi-string"
+    case "op": return "qi-op"
+    case "paren": return "qi-paren"
+    case "pipe": return "qi-op"
+    default: return null
+  }
+}
+
+function nextNonWs(tokens, i) {
+  for (let j = i + 1; j < tokens.length; j++) if (tokens[j].type !== "ws") return tokens[j]
+  return null
+}
+
+function prevNonWs(tokens, i) {
+  for (let j = i - 1; j >= 0; j--) if (tokens[j].type !== "ws") return tokens[j]
+  return null
+}
+
+export default {
+  mounted() {
+    this.input = this.el.querySelector("input")
+    this.mirror = document.getElementById(`${this.el.id}-mirror`)
+    this.listbox = document.getElementById(`${this.el.id}-listbox`)
+    this.knownFields = new Set(JSON.parse(this.el.dataset.fields || "[]"))
+    this.items = []
+    this.active = -1
+    this.suggestTimer = null
+
+    this.paint()
+
+    this.onInput = () => { this.paint(); this.queueSuggest() }
+    this.onScroll = () => { this.mirror.scrollLeft = this.input.scrollLeft }
+    this.onFocus = () => this.queueSuggest()
+    this.onClick = () => this.queueSuggest()
+    this.onBlur = () => setTimeout(() => this.close(), 120)
+    this.onKeydown = (e) => this.handleKey(e)
+
+    this.input.addEventListener("input", this.onInput)
+    this.input.addEventListener("scroll", this.onScroll)
+    this.input.addEventListener("focus", this.onFocus)
+    this.input.addEventListener("click", this.onClick)
+    this.input.addEventListener("blur", this.onBlur)
+    this.input.addEventListener("keydown", this.onKeydown)
+  },
+
+  // Server patches (e.g. "Clear filters") change the input value outside of
+  // typing; repaint the mirror to match.
+  updated() {
+    this.paint()
+  },
+
+  destroyed() {
+    clearTimeout(this.suggestTimer)
+  },
+
+  paint() {
+    const spans = classify(tokenize(this.input.value), this.knownFields)
+    this.mirror.textContent = ""
+    for (const {cls, text} of spans) {
+      if (cls) {
+        const span = document.createElement("span")
+        span.className = cls
+        span.textContent = text
+        this.mirror.appendChild(span)
+      } else {
+        this.mirror.appendChild(document.createTextNode(text))
+      }
+    }
+    this.mirror.scrollLeft = this.input.scrollLeft
+  },
+
+  queueSuggest() {
+    clearTimeout(this.suggestTimer)
+    this.suggestTimer = setTimeout(() => {
+      this.pushEvent(
+        "suggest",
+        {value: this.input.value, cursor: this.input.selectionStart ?? 0},
+        (reply) => this.showSuggestions(reply)
+      )
+    }, 120)
+  },
+
+  showSuggestions(reply) {
+    if (document.activeElement !== this.input) return
+    this.items = reply.items || []
+    this.replaceStart = reply.start
+    this.replaceLength = reply.length
+    this.active = -1
+
+    if (this.items.length === 0) return this.close()
+
+    this.listbox.textContent = ""
+    this.items.forEach((item, i) => {
+      const li = document.createElement("div")
+      li.id = `${this.el.id}-opt-${i}`
+      li.setAttribute("role", "option")
+      li.className = "qi-option"
+      li.dataset.index = i
+
+      const label = document.createElement("span")
+      label.className = `qi-option-label qi-kind-${item.kind}`
+      label.textContent = item.label
+      li.appendChild(label)
+
+      if (item.detail) {
+        const detail = document.createElement("span")
+        detail.className = "qi-option-detail"
+        detail.textContent = item.detail
+        li.appendChild(detail)
+      }
+
+      // mousedown (not click) so the input never loses focus.
+      li.addEventListener("mousedown", (e) => {
+        e.preventDefault()
+        this.accept(i)
+      })
+      li.addEventListener("mousemove", () => this.setActive(i))
+
+      this.listbox.appendChild(li)
+    })
+
+    this.listbox.classList.remove("hidden")
+    this.input.setAttribute("aria-expanded", "true")
+  },
+
+  close() {
+    this.listbox.classList.add("hidden")
+    this.listbox.textContent = ""
+    this.input.setAttribute("aria-expanded", "false")
+    this.input.removeAttribute("aria-activedescendant")
+    this.items = []
+    this.active = -1
+  },
+
+  isOpen() {
+    return !this.listbox.classList.contains("hidden") && this.items.length > 0
+  },
+
+  setActive(i) {
+    this.active = i
+    for (const li of this.listbox.children) {
+      li.classList.toggle("qi-active", Number(li.dataset.index) === i)
+    }
+    if (i >= 0) {
+      this.input.setAttribute("aria-activedescendant", `${this.el.id}-opt-${i}`)
+      this.listbox.children[i]?.scrollIntoView({block: "nearest"})
+    }
+  },
+
+  accept(i) {
+    const item = this.items[i]
+    if (!item) return
+
+    const v = this.input.value
+    const before = v.slice(0, this.replaceStart)
+    const after = v.slice(this.replaceStart + this.replaceLength)
+    this.input.value = before + item.insert + after
+
+    const caret = this.replaceStart + item.insert.length
+    this.input.setSelectionRange(caret, caret)
+    this.paint()
+    this.close()
+
+    // Bubble a real input event so the surrounding form's phx-change fires
+    // (LiveView's debounced search) — then immediately offer the next step
+    // (a field was just completed → its values; a value → next term).
+    this.input.dispatchEvent(new Event("input", {bubbles: true}))
+  },
+
+  handleKey(e) {
+    if (!this.isOpen()) {
+      if (e.key === "ArrowDown" && (e.altKey || this.input.value === "")) this.queueSuggest()
+      return
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault()
+        this.setActive((this.active + 1) % this.items.length)
+        break
+      case "ArrowUp":
+        e.preventDefault()
+        this.setActive((this.active - 1 + this.items.length) % this.items.length)
+        break
+      case "Enter":
+        if (this.active >= 0) {
+          e.preventDefault()
+          this.accept(this.active)
+        } else {
+          this.close()
+        }
+        break
+      case "Tab":
+        if (this.active >= 0) {
+          e.preventDefault()
+          this.accept(this.active)
+        } else if (this.items.length > 0) {
+          e.preventDefault()
+          this.accept(0)
+        }
+        break
+      case "Escape":
+        e.preventDefault()
+        this.close()
+        break
+    }
+  },
+}

--- a/lib/sanctum/decks/deck.ex
+++ b/lib/sanctum/decks/deck.ex
@@ -62,8 +62,12 @@ defmodule Sanctum.Decks.Deck do
 
         query =
           if is_binary(search) and String.trim(search) != "" do
-            pattern = "%" <> String.trim(search) <> "%"
-            Ash.Query.filter(query, ilike(title, ^pattern) or ilike(hero.hero_name, ^pattern))
+            # Bare words search title/hero name; `field op value` terms filter
+            # any registered deck field (see Sanctum.Search.DeckFields).
+            case Sanctum.Search.compile(search, Sanctum.Search.DeckFields) do
+              %{expr: nil} -> query
+              %{expr: filter} -> Ash.Query.filter(query, ^filter)
+            end
           else
             query
           end

--- a/lib/sanctum/games/card_side.ex
+++ b/lib/sanctum/games/card_side.ex
@@ -14,7 +14,8 @@ defmodule Sanctum.Games.CardSide do
     defaults [:read, :destroy]
 
     # Public card pool browsing: every card face — player *and* encounter —
-    # filtered by name/aspect/type. Each side is its own row so multi-sided
+    # filtered by an advanced search query (see Sanctum.Search) plus the
+    # aspect/type filter pills. Each side is its own row so multi-sided
     # cards surface every face, and searching an alternate title (e.g. "Peter
     # Parker") ranks that face first. Backs SanctumWeb.CardLive.Pool.
     read :browse do
@@ -40,8 +41,13 @@ defmodule Sanctum.Games.CardSide do
 
         query =
           if is_binary(search) and String.trim(search) != "" do
-            pattern = "%" <> String.trim(search) <> "%"
-            Ash.Query.filter(query, ilike(name, ^pattern))
+            # Bare words search name/subname; `field op value` terms filter
+            # any registered card field. Malformed input degrades gracefully
+            # (diagnostics are surfaced by the LiveView, not here).
+            case Sanctum.Search.compile(search, Sanctum.Search.CardFields) do
+              %{expr: nil} -> query
+              %{expr: filter} -> Ash.Query.filter(query, ^filter)
+            end
           else
             query
           end

--- a/lib/sanctum/search.ex
+++ b/lib/sanctum/search.ex
@@ -1,0 +1,51 @@
+defmodule Sanctum.Search do
+  @moduledoc """
+  The advanced search query language for cards and decks.
+
+  Users type Scryfall-style queries — `aspect = aggression AND cost <= 2 AND
+  type = ally`, or the terse MarvelCDB-flavored `a:aggression c<=2 t:ally` —
+  and this module turns them into Ash filter expressions.
+
+  Language summary:
+
+    * `field op value` terms; `:` and `=` both mean equals; `!=` `<` `>` `<=`
+      `>=` where the field supports them
+    * space between terms is an implicit AND; `or` and parentheses group
+    * `-term` or `not term` negates
+    * `value|value` is a value-level OR (`aspect:justice|leadership`)
+    * `"quoted strings"` for multi-word values
+    * a bare word searches names (cards: name/subname; decks: title/hero)
+    * everything is case-insensitive; malformed pieces degrade gracefully
+      with diagnostics instead of failing the whole query
+
+  Fields are defined per surface in `Sanctum.Search.CardFields` and
+  `Sanctum.Search.DeckFields` — the registries are the allowlist of what a
+  query can touch.
+  """
+
+  alias Sanctum.Search.{Compiler, Diagnostic, Parser}
+
+  @type result :: %{
+          ast: Parser.ast() | nil,
+          expr: term() | nil,
+          diagnostics: [Diagnostic.t()]
+        }
+
+  @doc """
+  Parse and compile `input` against a field registry.
+
+  Returns `%{ast:, expr:, diagnostics:}`. `expr` is an Ash expression ready
+  for `Ash.Query.filter(query, ^expr)`, or nil when the input contains no
+  usable terms (empty/whitespace/only malformed pieces — callers should apply
+  no filter in that case).
+  """
+  @spec compile(String.t(), module()) :: result()
+  def compile(input, registry) when is_binary(input) do
+    {ast, parse_diags} = Parser.parse(input)
+    {expr, compile_diags} = Compiler.compile(ast, registry)
+    %{ast: ast, expr: expr, diagnostics: parse_diags ++ compile_diags}
+  end
+
+  @doc "Parse `input` into `{ast | nil, diagnostics}` without compiling."
+  defdelegate parse(input), to: Parser
+end

--- a/lib/sanctum/search/builders.ex
+++ b/lib/sanctum/search/builders.ex
@@ -1,0 +1,101 @@
+defmodule Sanctum.Search.Builders do
+  @moduledoc """
+  Shared helpers for registry `build` functions: value coercion (integers,
+  booleans, enums with did-you-mean) and dynamic Ash expression construction
+  (comparisons on plain columns and on jsonb `Sanctum.Games.Stat` values).
+  """
+
+  import Ash.Expr
+
+  alias Sanctum.Search.Registry
+
+  # -- expression builders -----------------------------------------------------
+
+  @doc "Comparison against a plain attribute (or any pinned expression)."
+  def cmp(target, :eq, value), do: expr(^target == ^value)
+  def cmp(target, :neq, value), do: expr(^target != ^value)
+  def cmp(target, :lt, value), do: expr(^target < ^value)
+  def cmp(target, :gt, value), do: expr(^target > ^value)
+  def cmp(target, :lte, value), do: expr(^target <= ^value)
+  def cmp(target, :gte, value), do: expr(^target >= ^value)
+
+  @doc """
+  Comparison against the printed number of a `Sanctum.Games.Stat` jsonb
+  attribute. Sides where the stat (or its value — a `⭐`/`X` printing) is
+  absent compare as SQL NULL and drop out of the results.
+  """
+  def stat_cmp(attr, op, value) do
+    cmp(expr(fragment("(? ->> 'value')::integer", ^ref(attr))), op, value)
+  end
+
+  @doc "Case-insensitive substring match, with ILIKE wildcards escaped."
+  def contains(target, raw) do
+    expr(ilike(^target, ^pattern(raw)))
+  end
+
+  @doc "`%…%` ILIKE pattern for user input, escaping `%`, `_`, and `\\`."
+  def pattern(raw) do
+    escaped =
+      raw
+      |> String.replace("\\", "\\\\")
+      |> String.replace("%", "\\%")
+      |> String.replace("_", "\\_")
+
+    "%" <> escaped <> "%"
+  end
+
+  # -- value coercion ----------------------------------------------------------
+
+  @doc "Strictly parse an integer value."
+  def parse_int(raw) do
+    case Integer.parse(String.trim(raw)) do
+      {n, ""} -> {:ok, n}
+      _ -> {:error, ~s("#{raw}" is not a number)}
+    end
+  end
+
+  @doc "Parse a boolean value (true/false/yes/no/1/0)."
+  def parse_bool(raw) do
+    case Registry.normalize(raw) do
+      t when t in ["true", "yes", "1"] -> {:ok, true}
+      f when f in ["false", "no", "0"] -> {:ok, false}
+      _ -> {:error, ~s("#{raw}" should be true or false)}
+    end
+  end
+
+  @doc """
+  Coerce user input to one of `values` (atoms or strings): exact match first,
+  then a unique-prefix match (`t:all` → `:ally`), otherwise an error with a
+  did-you-mean suggestion when one is close enough. Returns the matched value
+  as given in `values` — no atoms are created.
+  """
+  def coerce_enum(raw, values) do
+    norm = Registry.normalize(raw)
+    indexed = Enum.map(values, &{to_string(&1), &1})
+
+    exact = List.keyfind(indexed, norm, 0)
+    prefixed = Enum.filter(indexed, fn {s, _} -> String.starts_with?(s, norm) end)
+
+    case {exact, prefixed} do
+      {{_, value}, _} ->
+        {:ok, value}
+
+      {nil, [{_, value}]} when norm != "" ->
+        {:ok, value}
+
+      _ ->
+        strings = Enum.map(indexed, &elem(&1, 0))
+        {:error, ~s("#{raw}" doesn't match#{did_you_mean(norm, strings)})}
+    end
+  end
+
+  defp did_you_mean(input, candidates) do
+    candidates
+    |> Enum.map(&{&1, String.jaro_distance(input, &1)})
+    |> Enum.max_by(fn {_, score} -> score end, fn -> {nil, 0.0} end)
+    |> case do
+      {candidate, score} when score >= 0.6 -> ~s( — did you mean "#{candidate}"?)
+      _ -> ""
+    end
+  end
+end

--- a/lib/sanctum/search/card_fields.ex
+++ b/lib/sanctum/search/card_fields.ex
@@ -123,6 +123,7 @@ defmodule Sanctum.Search.CardFields do
         kind: :text,
         example: "trait:avenger",
         hint: "card trait (Avenger, Skill, …)",
+        values_fun: &Sanctum.Search.Values.traits/0,
         build: &trait_build/2
       }
     ]
@@ -158,6 +159,7 @@ defmodule Sanctum.Search.CardFields do
         kind: :text,
         example: "set:spider_man",
         hint: "card set",
+        values_fun: &Sanctum.Search.Values.sets/0,
         build: text_build(fn pattern -> expr(ilike(card.set, ^pattern)) end)
       },
       %Field{
@@ -166,6 +168,7 @@ defmodule Sanctum.Search.CardFields do
         kind: :text,
         example: "pack:core",
         hint: "product/pack",
+        values_fun: &Sanctum.Search.Values.packs/0,
         build: text_build(fn pattern -> expr(ilike(card.pack, ^pattern)) end)
       },
       %Field{

--- a/lib/sanctum/search/card_fields.ex
+++ b/lib/sanctum/search/card_fields.ex
@@ -1,0 +1,326 @@
+defmodule Sanctum.Search.CardFields do
+  @moduledoc """
+  Search-field registry for the card pool (queries run against
+  `Sanctum.Games.CardSide`, where all printed card data lives).
+
+  Shorthand letters follow MarvelCDB's smart-filter scheme where one exists
+  (`t:` type, `a:` aspect, `x:` text, `k:` trait, `c:` cost, `e:` set) so
+  muscle memory from MarvelCDB transfers.
+  """
+
+  @behaviour Sanctum.Search.Registry
+
+  import Ash.Expr
+
+  alias Sanctum.Games.{CardAspect, CardOwnership, CardType}
+  alias Sanctum.Search.{Builders, Field}
+
+  # `aspect` accepts the ownership pools too ("hero"/"basic"/…), matching the
+  # pool page's filter pills, which conflate the two on purpose.
+  @ownership_as_aspect ~w(hero basic encounter campaign player)
+
+  @resource_counts %{
+    "energy" => :resource_energy_count,
+    "mental" => :resource_mental_count,
+    "physical" => :resource_physical_count,
+    "wild" => :resource_wild_count
+  }
+
+  @stat_fields [
+    {"attack", ["atk"], :attack, "attack>=2"},
+    {"thwart", ["thw"], :thwart, "thwart>=2"},
+    {"defense", ["def"], :defense, "defense>=1"},
+    {"health", ["hp"], :health, "health<=3"},
+    {"recover", ["rec"], :recover, "recover>=3"},
+    {"threat", [], :base_threat, "threat>=7"},
+    {"escalation", [], :escalation_threat, "escalation>=1"},
+    {"max_threat", ["maxthreat"], :max_threat, "max_threat<=10"}
+  ]
+
+  @int_fields [
+    {"cost", ["c"], :cost, "cost<=2"},
+    {"stage", [], :stage, "stage=3"},
+    {"boost", ["b"], :boost, "boost>=2"},
+    {"hand_size", ["hand"], :hand_size, "hand_size>=6"},
+    {"energy", [], :resource_energy_count, "energy>=1"},
+    {"mental", [], :resource_mental_count, "mental>=1"},
+    {"physical", [], :resource_physical_count, "physical>=1"},
+    {"wild", [], :resource_wild_count, "wild>=1"}
+  ]
+
+  @flags %{
+    "unique" => :unique,
+    "permanent" => :permanent,
+    "multi_sided" => :multi_sided,
+    "acceleration" => :acceleration,
+    "amplify" => :amplify,
+    "crisis" => :crisis,
+    "hazard" => :hazard
+  }
+
+  @all_ops [:eq, :neq, :lt, :gt, :lte, :gte]
+
+  @impl true
+  def bare_word(value) do
+    pattern = Builders.pattern(value)
+    expr(ilike(name, ^pattern) or ilike(subname, ^pattern))
+  end
+
+  # Registry order doubles as autocomplete priority: the first ~10 fields are
+  # what an empty search box offers.
+  @impl true
+  def fields do
+    {cost_fields, other_int_fields} = Enum.split_with(int_fields(), &(&1.name == "cost"))
+
+    primary_fields() ++
+      cost_fields ++ stat_fields() ++ other_int_fields ++ misc_fields()
+  end
+
+  # -- field groups --------------------------------------------------------
+
+  defp primary_fields do
+    [
+      %Field{
+        name: "name",
+        aliases: ["n"],
+        kind: :text,
+        example: ~s(name:"peter parker"),
+        hint: "card or subtitle name",
+        build: text_build(&name_expr/1)
+      },
+      %Field{
+        name: "text",
+        aliases: ["x"],
+        kind: :text,
+        example: ~s(text:"draw a card"),
+        hint: "rules text",
+        build: text_build(fn pattern -> expr(ilike(text, ^pattern)) end)
+      },
+      %Field{
+        name: "type",
+        aliases: ["t"],
+        kind: :enum,
+        values: enum_strings(CardType),
+        example: "type:ally",
+        hint: "card type",
+        build:
+          enum_build(CardType, fn atom, op ->
+            Builders.cmp(expr(type), op, atom)
+          end)
+      },
+      %Field{
+        name: "aspect",
+        aliases: ["a"],
+        kind: :enum,
+        values: enum_strings(CardAspect) ++ @ownership_as_aspect,
+        example: "aspect:aggression",
+        hint: "aspect, or a pool like hero/basic",
+        build: &aspect_build/2
+      },
+      %Field{
+        name: "trait",
+        aliases: ["k", "traits"],
+        kind: :text,
+        example: "trait:avenger",
+        hint: "card trait (Avenger, Skill, …)",
+        build: &trait_build/2
+      }
+    ]
+  end
+
+  defp misc_fields do
+    [
+      %Field{
+        name: "resource",
+        aliases: ["r"],
+        kind: :enum,
+        values: Map.keys(@resource_counts),
+        example: "resource:mental",
+        hint: "cards printing this resource",
+        ops: [:eq],
+        build: &resource_build/2
+      },
+      %Field{
+        name: "ownership",
+        aliases: ["o"],
+        kind: :enum,
+        values: enum_strings(CardOwnership),
+        example: "ownership:encounter",
+        hint: "which pool the card comes from",
+        build:
+          enum_build(CardOwnership, fn atom, op ->
+            Builders.cmp(expr(ownership), op, atom)
+          end)
+      },
+      %Field{
+        name: "set",
+        aliases: ["e"],
+        kind: :text,
+        example: "set:spider_man",
+        hint: "card set",
+        build: text_build(fn pattern -> expr(ilike(card.set, ^pattern)) end)
+      },
+      %Field{
+        name: "pack",
+        aliases: ["p"],
+        kind: :text,
+        example: "pack:core",
+        hint: "product/pack",
+        build: text_build(fn pattern -> expr(ilike(card.pack, ^pattern)) end)
+      },
+      %Field{
+        name: "flavor",
+        aliases: [],
+        kind: :text,
+        example: ~s(flavor:avenger),
+        hint: "flavor text",
+        build: text_build(fn pattern -> expr(ilike(flavor, ^pattern)) end)
+      },
+      %Field{
+        name: "code",
+        aliases: [],
+        kind: :text,
+        example: "code:01001a",
+        hint: "exact card code",
+        build: fn op, value -> {:ok, Builders.cmp(expr(code), op, value)} end
+      },
+      %Field{
+        name: "unique",
+        aliases: ["u"],
+        kind: :boolean,
+        values: ["true", "false"],
+        example: "unique:true",
+        build: bool_build(fn bool, op -> Builders.cmp(expr(card.unique), op, bool) end)
+      },
+      %Field{
+        name: "is",
+        aliases: [],
+        kind: :flag,
+        values: @flags |> Map.keys() |> Enum.sort(),
+        example: "is:unique",
+        hint: "card properties and icons",
+        ops: [:eq],
+        build: &flag_build/2
+      }
+    ]
+  end
+
+  defp stat_fields do
+    for {name, aliases, attr, example} <- @stat_fields do
+      %Field{
+        name: name,
+        aliases: aliases,
+        kind: :stat,
+        example: example,
+        ops: @all_ops,
+        build: fn op, value ->
+          with {:ok, n} <- Builders.parse_int(value) do
+            {:ok, Builders.stat_cmp(attr, op, n)}
+          end
+        end
+      }
+    end
+  end
+
+  defp int_fields do
+    for {name, aliases, attr, example} <- @int_fields do
+      %Field{
+        name: name,
+        aliases: aliases,
+        kind: :integer,
+        example: example,
+        ops: @all_ops,
+        build: fn op, value ->
+          with {:ok, n} <- Builders.parse_int(value) do
+            {:ok, Builders.cmp(expr(^ref(attr)), op, n)}
+          end
+        end
+      }
+    end
+  end
+
+  # -- builders --------------------------------------------------------------
+
+  defp name_expr(pattern) do
+    expr(ilike(name, ^pattern) or ilike(subname, ^pattern))
+  end
+
+  defp text_build(to_expr) do
+    fn
+      :eq, value -> {:ok, to_expr.(Builders.pattern(value))}
+      :neq, value -> {:ok, expr(not (^to_expr.(Builders.pattern(value))))}
+    end
+  end
+
+  defp enum_build(enum_module, to_expr) do
+    values = enum_module.values()
+
+    fn op, value ->
+      with {:ok, atom} <- Builders.coerce_enum(value, values) do
+        {:ok, to_expr.(atom, op)}
+      end
+    end
+  end
+
+  defp bool_build(to_expr) do
+    fn op, value ->
+      with {:ok, bool} <- Builders.parse_bool(value) do
+        {:ok, to_expr.(bool, op)}
+      end
+    end
+  end
+
+  # "hero"/"basic"/… filter ownership; the five real aspects filter aspect.
+  defp aspect_build(op, value) do
+    case Builders.coerce_enum(value, CardOwnership.values() ++ CardAspect.values()) do
+      {:ok, atom} ->
+        if to_string(atom) in @ownership_as_aspect do
+          {:ok, Builders.cmp(expr(ownership), op, atom)}
+        else
+          {:ok, Builders.cmp(expr(aspect), op, atom)}
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # Each stored trait is used as the ILIKE pattern against the typed value,
+  # giving a case-insensitive exact match per array element.
+  defp trait_build(op, value) do
+    match = expr(fragment("? ILIKE ANY (?)", ^value, traits))
+
+    case op do
+      :eq -> {:ok, match}
+      :neq -> {:ok, expr(not (^match))}
+    end
+  end
+
+  defp resource_build(:eq, value) do
+    case Builders.coerce_enum(value, Map.keys(@resource_counts)) do
+      {:ok, atom} ->
+        attr = Map.fetch!(@resource_counts, to_string(atom))
+        {:ok, expr(^ref(attr) >= 1)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp flag_build(:eq, value) do
+    case Builders.coerce_enum(value, Map.keys(@flags)) do
+      {:ok, atom} -> {:ok, flag_expr(Map.fetch!(@flags, to_string(atom)))}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp flag_expr(:unique), do: expr(card.unique == true)
+  defp flag_expr(:permanent), do: expr(card.permanent == true)
+  defp flag_expr(:multi_sided), do: expr(card.is_multi_sided == true)
+  defp flag_expr(:acceleration), do: expr(acceleration_icon == true)
+  defp flag_expr(:amplify), do: expr(amplify_icon == true)
+  defp flag_expr(:crisis), do: expr(crisis_icon == true)
+  defp flag_expr(:hazard), do: expr(hazard_icon == true)
+
+  defp enum_strings(enum_module), do: Enum.map(enum_module.values(), &to_string/1)
+end

--- a/lib/sanctum/search/compiler.ex
+++ b/lib/sanctum/search/compiler.ex
@@ -1,0 +1,116 @@
+defmodule Sanctum.Search.Compiler do
+  @moduledoc """
+  Compiles a `Sanctum.Search.Parser` AST into an Ash filter expression using a
+  field registry.
+
+  Compilation is diagnostic-collecting, not failing: an unknown field drops
+  its clause with a warning (the rest of the query still filters); a known
+  field with an invalid value compiles to `false` (matches nothing) plus a
+  did-you-mean diagnostic — `aspect = agression` should return zero rows *and*
+  tell you why, not silently show everything.
+  """
+
+  import Ash.Expr
+
+  alias Sanctum.Search.{Diagnostic, Field, Registry, Token}
+
+  @doc "Compile an AST (or nil) into `{ash_expr | nil, diagnostics}`."
+  @spec compile(term(), module()) :: {term() | nil, [Diagnostic.t()]}
+  def compile(nil, _registry), do: {nil, []}
+  def compile(ast, registry), do: node_expr(ast, registry)
+
+  defp node_expr({:and, children}, registry), do: combine(children, registry, :and)
+  defp node_expr({:or, children}, registry), do: combine(children, registry, :or)
+
+  defp node_expr({:not, child}, registry) do
+    case node_expr(child, registry) do
+      {nil, diags} -> {nil, diags}
+      {e, diags} -> {expr(not (^e)), diags}
+    end
+  end
+
+  defp node_expr({:word, %Token{value: ""}}, _registry), do: {nil, []}
+
+  defp node_expr({:word, %Token{value: value}}, registry),
+    do: {registry.bare_word(value), []}
+
+  defp node_expr({:clause, clause}, registry), do: clause_expr(clause, registry)
+
+  defp combine(children, registry, kind) do
+    {exprs, diags} =
+      Enum.reduce(children, {[], []}, fn child, {exprs, diags} ->
+        {e, d} = node_expr(child, registry)
+        {if(is_nil(e), do: exprs, else: [e | exprs]), diags ++ d}
+      end)
+
+    {exprs |> Enum.reverse() |> join(kind), diags}
+  end
+
+  defp join([], _kind), do: nil
+  defp join([one], _kind), do: one
+  defp join([head | tail], :and), do: Enum.reduce(tail, head, &expr(^&2 and ^&1))
+  defp join([head | tail], :or), do: Enum.reduce(tail, head, &expr(^&2 or ^&1))
+
+  defp clause_expr(%{field: field_tok, op: op, op_token: op_tok, values: values}, registry) do
+    case Registry.lookup(registry, field_tok.value) do
+      nil ->
+        {nil, [unknown_field(field_tok, registry)]}
+
+      %Field{} = field ->
+        if op in field.ops do
+          values_expr(field, op, values)
+        else
+          message =
+            ~s(the "#{field.name}" field doesn't support "#{op_tok.value}")
+
+          {nil,
+           [
+             Diagnostic.new(:warning, :unsupported_operator, message, op_tok.start, op_tok.length)
+           ]}
+        end
+    end
+  end
+
+  # Each `|`-separated value builds its own expression. Alternatives combine
+  # with OR for positive matches and AND for `!=` ("neither x nor y").
+  defp values_expr(field, op, value_tokens) do
+    {exprs, diags} =
+      Enum.reduce(value_tokens, {[], []}, fn %Token{} = tok, {exprs, diags} ->
+        case field.build.(op, tok.value) do
+          {:ok, e} ->
+            {[e | exprs], diags}
+
+          {:error, message} ->
+            diag =
+              Diagnostic.new(:warning, :invalid_value, message, tok.start, tok.length)
+
+            {exprs, diags ++ [diag]}
+        end
+      end)
+
+    case {exprs, diags} do
+      # Every value was invalid on a known field: match nothing (and say why).
+      {[], [_ | _]} ->
+        {expr(false), diags}
+
+      {exprs, diags} ->
+        {exprs |> Enum.reverse() |> join(if op == :neq, do: :and, else: :or), diags}
+    end
+  end
+
+  defp unknown_field(%Token{} = tok, registry) do
+    suggestion =
+      case Registry.suggest(registry, tok.value) do
+        nil -> ""
+        name -> ~s( — did you mean "#{name}"?)
+      end
+
+    Diagnostic.new(
+      :warning,
+      :unknown_field,
+      ~s(unknown field "#{tok.value}"#{suggestion}),
+      tok.start,
+      tok.length
+    )
+  end
+end

--- a/lib/sanctum/search/deck_fields.ex
+++ b/lib/sanctum/search/deck_fields.ex
@@ -36,6 +36,7 @@ defmodule Sanctum.Search.DeckFields do
         kind: :text,
         example: "hero:spider-man",
         hint: "hero or alter-ego name",
+        values_fun: &Sanctum.Search.Values.heroes/0,
         build:
           text_build(fn pattern ->
             expr(ilike(hero.hero_name, ^pattern) or ilike(hero.alter_ego_name, ^pattern))

--- a/lib/sanctum/search/deck_fields.ex
+++ b/lib/sanctum/search/deck_fields.ex
@@ -1,0 +1,116 @@
+defmodule Sanctum.Search.DeckFields do
+  @moduledoc """
+  Search-field registry for the deck browser (queries run against
+  `Sanctum.Decks.Deck`).
+  """
+
+  @behaviour Sanctum.Search.Registry
+
+  import Ash.Expr
+
+  alias Sanctum.Decks.{DeckAspect, DeckSource}
+  alias Sanctum.Search.{Builders, Field}
+
+  @all_ops [:eq, :neq, :lt, :gt, :lte, :gte]
+
+  @impl true
+  def bare_word(value) do
+    pattern = Builders.pattern(value)
+    expr(ilike(title, ^pattern) or ilike(hero.hero_name, ^pattern))
+  end
+
+  @impl true
+  def fields do
+    [
+      %Field{
+        name: "title",
+        aliases: [],
+        kind: :text,
+        example: ~s(title:"web warriors"),
+        hint: "deck title",
+        build: text_build(fn pattern -> expr(ilike(title, ^pattern)) end)
+      },
+      %Field{
+        name: "hero",
+        aliases: ["h"],
+        kind: :text,
+        example: "hero:spider-man",
+        hint: "hero or alter-ego name",
+        build:
+          text_build(fn pattern ->
+            expr(ilike(hero.hero_name, ^pattern) or ilike(hero.alter_ego_name, ^pattern))
+          end)
+      },
+      %Field{
+        name: "aspect",
+        aliases: ["a"],
+        kind: :enum,
+        values: Enum.map(DeckAspect.values(), &to_string/1) ++ ["basic"],
+        example: "aspect:justice",
+        hint: "aspect the deck plays (basic = none)",
+        ops: [:eq, :neq],
+        build: &aspect_build/2
+      },
+      %Field{
+        name: "card",
+        aliases: ["includes"],
+        kind: :text,
+        example: ~s(card:"boot camp"),
+        hint: "decks containing a card",
+        build:
+          text_build(fn pattern ->
+            expr(exists(cards.card_sides, ilike(name, ^pattern)))
+          end)
+      },
+      %Field{
+        name: "cards",
+        aliases: [],
+        kind: :integer,
+        example: "cards>=45",
+        hint: "total card count",
+        ops: @all_ops,
+        build: fn op, value ->
+          with {:ok, n} <- Builders.parse_int(value) do
+            {:ok, Builders.cmp(expr(total_card_count), op, n)}
+          end
+        end
+      },
+      %Field{
+        name: "source",
+        aliases: [],
+        kind: :enum,
+        values: Enum.map(DeckSource.values(), &to_string/1),
+        example: "source:marvelcdb",
+        build: fn op, value ->
+          with {:ok, atom} <- Builders.coerce_enum(value, DeckSource.values()) do
+            {:ok, Builders.cmp(expr(source), op, atom)}
+          end
+        end
+      }
+    ]
+  end
+
+  defp text_build(to_expr) do
+    fn
+      :eq, value -> {:ok, to_expr.(Builders.pattern(value))}
+      :neq, value -> {:ok, expr(not (^to_expr.(Builders.pattern(value))))}
+    end
+  end
+
+  # A deck's aspects are an array; an empty array is a basic deck.
+  defp aspect_build(op, value) do
+    case Builders.coerce_enum(value, DeckAspect.values() ++ ["basic"]) do
+      {:ok, "basic"} ->
+        wrap_neq(op, expr(fragment("cardinality(?) = 0", aspects)))
+
+      {:ok, atom} ->
+        wrap_neq(op, expr(^atom in aspects))
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp wrap_neq(:eq, e), do: {:ok, e}
+  defp wrap_neq(:neq, e), do: {:ok, expr(not (^e))}
+end

--- a/lib/sanctum/search/diagnostic.ex
+++ b/lib/sanctum/search/diagnostic.ex
@@ -1,0 +1,32 @@
+defmodule Sanctum.Search.Diagnostic do
+  @moduledoc """
+  A parse- or compile-time problem with a search query, pointing back at the
+  offending span of the input.
+
+  Diagnostics are advisory: the query still compiles and runs with the
+  problematic part dropped (or, for a bad value on a known field, matching
+  nothing) so partially-typed input never blanks the results abruptly.
+  """
+
+  defstruct [:severity, :code, :message, :start, :length]
+
+  @type code ::
+          :incomplete_clause
+          | :unknown_field
+          | :unsupported_operator
+          | :invalid_value
+          | :stray_token
+          | :unclosed_paren
+
+  @type t :: %__MODULE__{
+          severity: :warning | :error,
+          code: code(),
+          message: String.t(),
+          start: non_neg_integer(),
+          length: non_neg_integer()
+        }
+
+  def new(severity, code, message, start, length) do
+    %__MODULE__{severity: severity, code: code, message: message, start: start, length: length}
+  end
+end

--- a/lib/sanctum/search/field.ex
+++ b/lib/sanctum/search/field.ex
@@ -6,7 +6,10 @@ defmodule Sanctum.Search.Field do
   * `aliases` — accepted shorthands (`["c"]`, MarvelCDB-style letters)
   * `kind` — drives autocomplete rendering and docs: `:text | :integer |
     :stat | :enum | :boolean | :flag`
-  * `values` — the completable values (enum fields and flags)
+  * `values` — the statically completable values (enum fields and flags)
+  * `values_fun` — optional zero-arity fun returning data-driven completable
+    values (distinct traits, hero names, …); called lazily at suggest time
+    and expected to be cheap (see `Sanctum.Search.Values` / `ValueCache`)
   * `ops` — operators this field accepts (`:eq :neq :lt :gt :lte :gte`)
   * `build` — `(op, raw_value) -> {:ok, ash_expr} | {:error, message}`;
     validation (enum coercion, integer parsing) happens here
@@ -20,6 +23,7 @@ defmodule Sanctum.Search.Field do
     :build,
     :example,
     :hint,
+    :values_fun,
     aliases: [],
     values: [],
     ops: [:eq, :neq]
@@ -33,6 +37,7 @@ defmodule Sanctum.Search.Field do
           build: (op(), String.t() -> {:ok, term()} | {:error, String.t()}),
           example: String.t() | nil,
           hint: String.t() | nil,
+          values_fun: (-> [String.t()]) | nil,
           aliases: [String.t()],
           values: [String.t()],
           ops: [op()]

--- a/lib/sanctum/search/field.ex
+++ b/lib/sanctum/search/field.ex
@@ -1,0 +1,40 @@
+defmodule Sanctum.Search.Field do
+  @moduledoc """
+  One queryable field in a search registry.
+
+  * `name` — canonical field name as typed by users (`"cost"`)
+  * `aliases` — accepted shorthands (`["c"]`, MarvelCDB-style letters)
+  * `kind` — drives autocomplete rendering and docs: `:text | :integer |
+    :stat | :enum | :boolean | :flag`
+  * `values` — the completable values (enum fields and flags)
+  * `ops` — operators this field accepts (`:eq :neq :lt :gt :lte :gte`)
+  * `build` — `(op, raw_value) -> {:ok, ash_expr} | {:error, message}`;
+    validation (enum coercion, integer parsing) happens here
+  * `example` / `hint` — shown in autocomplete and the syntax help
+  """
+
+  @enforce_keys [:name, :kind, :build]
+  defstruct [
+    :name,
+    :kind,
+    :build,
+    :example,
+    :hint,
+    aliases: [],
+    values: [],
+    ops: [:eq, :neq]
+  ]
+
+  @type op :: :eq | :neq | :lt | :gt | :lte | :gte
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          kind: :text | :integer | :stat | :enum | :boolean | :flag,
+          build: (op(), String.t() -> {:ok, term()} | {:error, String.t()}),
+          example: String.t() | nil,
+          hint: String.t() | nil,
+          aliases: [String.t()],
+          values: [String.t()],
+          ops: [op()]
+        }
+end

--- a/lib/sanctum/search/lexer.ex
+++ b/lib/sanctum/search/lexer.ex
@@ -1,0 +1,96 @@
+defmodule Sanctum.Search.Lexer do
+  @moduledoc """
+  Tokenizes a search query string into `Sanctum.Search.Token`s.
+
+  The lexer never fails: every character belongs to some token (unmatched
+  input degrades to `:word` tokens), so partially-typed queries still
+  tokenize and the parser can decide what to keep. Spans are byte offsets
+  into the original input.
+  """
+
+  import NimbleParsec
+
+  alias Sanctum.Search.Token
+
+  # Characters that terminate a word. Everything else — including `-`, `'`,
+  # `.`, `,`, `/` — is word material so card names like "Spider-Man",
+  # "S.H.I.E.L.D.", and "SP//dr" survive as single tokens.
+  @word_stops [?\s, ?\t, ?\n, ?\r, ?", ?(, ?), ?|, ?:, ?<, ?>, ?=, ?!]
+
+  # `mark` pushes `{[], current_byte_offset}` into the results without
+  # consuming input — used as start/end markers around each token matcher.
+  mark = byte_offset(empty())
+
+  token = fn kind, matcher ->
+    mark
+    |> concat(matcher)
+    |> concat(mark)
+    |> post_traverse({:emit, [kind]})
+  end
+
+  ws = ignore(ascii_string([?\s, ?\t, ?\n, ?\r], min: 1))
+
+  quoted =
+    token.(
+      :string,
+      ignore(string(~s(")))
+      |> utf8_string([not: ?"], min: 0)
+      |> optional(ignore(string(~s("))))
+    )
+
+  op =
+    token.(
+      :op,
+      choice([
+        string("<="),
+        string(">="),
+        string("!="),
+        string("<"),
+        string(">"),
+        string("="),
+        string(":"),
+        string("!")
+      ])
+    )
+
+  lparen = token.(:lparen, string("("))
+  rparen = token.(:rparen, string(")"))
+  pipe = token.(:pipe, string("|"))
+
+  # `-` negates the following term (Scryfall-style). Only lexed as negation
+  # when it starts a token and something follows; a hyphen inside a word
+  # ("spider-man") is consumed by the word matcher instead.
+  neg =
+    token.(
+      :neg,
+      string("-") |> lookahead(utf8_char(not: ?\s, not: ?\t, not: ?\n, not: ?\r))
+    )
+
+  word = token.(:word, utf8_string(Enum.map(@word_stops, &{:not, &1}), min: 1))
+
+  any_token = choice([quoted, op, lparen, rparen, pipe, neg, word])
+
+  defparsecp(:do_tokenize, repeat(choice([ws, any_token])) |> eos())
+
+  @doc "Tokenize `input`. Always succeeds."
+  @spec tokenize(String.t()) :: [Token.t()]
+  def tokenize(input) when is_binary(input) do
+    {:ok, tokens, "", _context, _line, _offset} = do_tokenize(input)
+    tokens
+  end
+
+  # Results between the two offset markers form the token value; ignored
+  # pieces (quote marks) contribute to the span but not the value.
+  defp emit(rest, args, context, _line, _offset, kind) do
+    [{[], end_off} | rest_args] = args
+    {value_parts, [{[], start_off}]} = Enum.split(rest_args, length(rest_args) - 1)
+
+    value =
+      value_parts
+      |> Enum.reverse()
+      |> Enum.map_join("", &to_string/1)
+
+    token = %Token{kind: kind, value: value, start: start_off, length: end_off - start_off}
+    {rest, [token], context}
+  end
+end

--- a/lib/sanctum/search/parser.ex
+++ b/lib/sanctum/search/parser.ex
@@ -1,0 +1,224 @@
+defmodule Sanctum.Search.Parser do
+  @moduledoc """
+  Error-tolerant recursive-descent parser over `Sanctum.Search.Lexer` tokens.
+
+  Produces an AST of:
+
+    * `{:and, [node]}` / `{:or, [node]}` — boolean combinations (space between
+      terms is an implicit AND, Scryfall-style)
+    * `{:not, node}` — negation (`-term` or `NOT term`)
+    * `{:clause, %{field:, op:, values:}}` — a `field op value` term; `values`
+      holds one token per `|`-separated alternative (`aspect:justice|leadership`)
+    * `{:word, token}` — a bare word or quoted phrase (full-text fallback)
+
+  The parser never fails. Malformed input — a trailing `cost <`, a stray `)`,
+  an operator with no field — is dropped with a `Diagnostic` while the valid
+  remainder still parses, so results stay live while the user types.
+  """
+
+  alias Sanctum.Search.{Diagnostic, Lexer, Token}
+
+  @type ast ::
+          {:and, [ast]}
+          | {:or, [ast]}
+          | {:not, ast}
+          | {:clause, %{field: Token.t(), op: atom(), op_token: Token.t(), values: [Token.t()]}}
+          | {:word, Token.t()}
+
+  @op_map %{
+    ":" => :eq,
+    "=" => :eq,
+    "!=" => :neq,
+    "!" => :neq,
+    "<" => :lt,
+    ">" => :gt,
+    "<=" => :lte,
+    ">=" => :gte
+  }
+
+  @doc "Parse `input` into `{ast | nil, diagnostics}`. Never raises."
+  @spec parse(String.t()) :: {ast() | nil, [Diagnostic.t()]}
+  def parse(input) when is_binary(input) do
+    tokens = Lexer.tokenize(input)
+    {node, rest, diags} = parse_or(tokens, 0)
+
+    # Defensive: at depth 0 the grammar consumes all input, but if anything
+    # ever remains, drop it rather than loop or crash.
+    extra_diags =
+      case rest do
+        [] -> []
+        [%Token{} = t | _] -> [stray(t)]
+      end
+
+    {node, diags ++ extra_diags}
+  end
+
+  # -- or-level ---------------------------------------------------------------
+
+  defp parse_or(tokens, depth) do
+    {left, rest, diags} = parse_and(tokens, depth)
+    parse_or_tail(left, rest, depth, diags)
+  end
+
+  defp parse_or_tail(left, [%Token{kind: :word, value: v} | rest] = tokens, depth, diags) do
+    if String.downcase(v) == "or" do
+      {right, rest2, d2} = parse_and(rest, depth)
+      parse_or_tail(merge(:or, left, right), rest2, depth, diags ++ d2)
+    else
+      {left, tokens, diags}
+    end
+  end
+
+  defp parse_or_tail(left, tokens, _depth, diags), do: {left, tokens, diags}
+
+  # -- and-level (implicit between adjacent terms) ----------------------------
+
+  defp parse_and(tokens, depth) do
+    {term, rest, diags} = parse_term(tokens, depth)
+    parse_and_tail(add_term([], term), rest, depth, diags)
+  end
+
+  defp parse_and_tail(terms, [] = rest, _depth, diags), do: {and_node(terms), rest, diags}
+
+  defp parse_and_tail(terms, [%Token{kind: :rparen} | _] = rest, depth, diags) when depth > 0 do
+    {and_node(terms), rest, diags}
+  end
+
+  defp parse_and_tail(terms, [%Token{kind: :rparen} = t | rest], depth, diags) when depth == 0 do
+    parse_and_tail(terms, rest, depth, diags ++ [stray(t)])
+  end
+
+  defp parse_and_tail(terms, [%Token{kind: k} = t | rest], depth, diags) when k in [:op, :pipe] do
+    parse_and_tail(terms, rest, depth, diags ++ [stray(t)])
+  end
+
+  defp parse_and_tail(terms, [%Token{kind: :word, value: v} | rest] = tokens, depth, diags) do
+    case String.downcase(v) do
+      "or" ->
+        {and_node(terms), tokens, diags}
+
+      "and" ->
+        {term, rest2, d} = parse_term(rest, depth)
+        parse_and_tail(add_term(terms, term), rest2, depth, diags ++ d)
+
+      _ ->
+        {term, rest2, d} = parse_term(tokens, depth)
+        parse_and_tail(add_term(terms, term), rest2, depth, diags ++ d)
+    end
+  end
+
+  defp parse_and_tail(terms, tokens, depth, diags) do
+    {term, rest, d} = parse_term(tokens, depth)
+    parse_and_tail(add_term(terms, term), rest, depth, diags ++ d)
+  end
+
+  # -- terms -------------------------------------------------------------------
+
+  defp parse_term([], _depth), do: {nil, [], []}
+
+  defp parse_term([%Token{kind: :rparen} | _] = tokens, depth) when depth > 0,
+    do: {nil, tokens, []}
+
+  defp parse_term([%Token{kind: :neg} | rest], depth) do
+    {node, rest2, diags} = parse_term(rest, depth)
+    {negate(node), rest2, diags}
+  end
+
+  defp parse_term([%Token{kind: :lparen} = lp | rest], depth) do
+    {node, rest2, diags} = parse_or(rest, depth + 1)
+
+    case rest2 do
+      [%Token{kind: :rparen} | rest3] ->
+        {node, rest3, diags}
+
+      _ ->
+        diag =
+          Diagnostic.new(:warning, :unclosed_paren, "unclosed parenthesis", lp.start, lp.length)
+
+        {node, rest2, diags ++ [diag]}
+    end
+  end
+
+  defp parse_term([%Token{kind: :string} = t | rest], _depth), do: {{:word, t}, rest, []}
+
+  defp parse_term([%Token{kind: :word} = t, %Token{kind: :op} = op | rest], _depth) do
+    parse_clause(t, op, rest)
+  end
+
+  defp parse_term([%Token{kind: :word, value: v} = t | rest], depth) do
+    if String.downcase(v) == "not" and starts_term?(rest) do
+      {node, rest2, diags} = parse_term(rest, depth)
+      {negate(node), rest2, diags}
+    else
+      {{:word, t}, rest, []}
+    end
+  end
+
+  # Stray operator/pipe at term position: skip it.
+  defp parse_term([%Token{} = t | rest], _depth), do: {nil, rest, [stray(t)]}
+
+  defp parse_clause(field_tok, op_tok, rest) do
+    case take_values(rest, []) do
+      {[], rest2} ->
+        span_end = op_tok.start + op_tok.length
+
+        diag =
+          Diagnostic.new(
+            :warning,
+            :incomplete_clause,
+            ~s(incomplete "#{field_tok.value}" filter — expected a value after "#{op_tok.value}"),
+            field_tok.start,
+            span_end - field_tok.start
+          )
+
+        {nil, rest2, [diag]}
+
+      {values, rest2} ->
+        node =
+          {:clause,
+           %{
+             field: field_tok,
+             op: Map.fetch!(@op_map, op_tok.value),
+             op_token: op_tok,
+             values: values
+           }}
+
+        {node, rest2, []}
+    end
+  end
+
+  defp take_values([%Token{kind: k} = v | rest], []) when k in [:word, :string],
+    do: take_values(rest, [v])
+
+  defp take_values([%Token{kind: :pipe}, %Token{kind: k} = v | rest], acc)
+       when acc != [] and k in [:word, :string],
+       do: take_values(rest, [v | acc])
+
+  # Trailing pipe with no value: stop; the pipe token is left for the
+  # and-level to report as stray.
+  defp take_values(rest, acc), do: {Enum.reverse(acc), rest}
+
+  defp starts_term?([%Token{kind: k} | _]) when k in [:word, :string, :lparen, :neg], do: true
+  defp starts_term?(_), do: false
+
+  # -- node assembly -----------------------------------------------------------
+
+  defp add_term(terms, nil), do: terms
+  defp add_term(terms, term), do: terms ++ [term]
+
+  defp and_node([]), do: nil
+  defp and_node([one]), do: one
+  defp and_node(terms), do: {:and, terms}
+
+  defp merge(_kind, left, nil), do: left
+  defp merge(_kind, nil, right), do: right
+  defp merge(kind, {kind, items}, right), do: {kind, items ++ [right]}
+  defp merge(kind, left, right), do: {kind, [left, right]}
+
+  defp negate(nil), do: nil
+  defp negate(node), do: {:not, node}
+
+  defp stray(%Token{} = t) do
+    Diagnostic.new(:warning, :stray_token, ~s(unexpected "#{t.value}"), t.start, t.length)
+  end
+end

--- a/lib/sanctum/search/registry.ex
+++ b/lib/sanctum/search/registry.ex
@@ -1,0 +1,46 @@
+defmodule Sanctum.Search.Registry do
+  @moduledoc """
+  Behaviour + helpers for a search-field registry (one per searchable surface:
+  `Sanctum.Search.CardFields`, `Sanctum.Search.DeckFields`).
+
+  A registry enumerates the queryable fields and provides the bare-word
+  fallback filter (what a plain `spider` term means on that surface). The
+  registry is the security boundary: the compiler only ever builds filters
+  for fields a registry explicitly defines.
+  """
+
+  alias Sanctum.Search.Field
+
+  @callback fields() :: [Field.t()]
+  @callback bare_word(String.t()) :: term()
+
+  @doc "Find a field by name or alias (case-insensitive, `-` treated as `_`)."
+  @spec lookup(module(), String.t()) :: Field.t() | nil
+  def lookup(registry, name) do
+    n = normalize(name)
+    Enum.find(registry.fields(), fn f -> n == f.name or n in f.aliases end)
+  end
+
+  @doc "Best did-you-mean suggestion for an unknown field name, or nil."
+  @spec suggest(module(), String.t()) :: String.t() | nil
+  def suggest(registry, name) do
+    n = normalize(name)
+
+    registry.fields()
+    |> Enum.map(& &1.name)
+    |> Enum.map(&{&1, String.jaro_distance(n, &1)})
+    |> Enum.max_by(fn {_, score} -> score end, fn -> {nil, 0.0} end)
+    |> case do
+      {candidate, score} when score >= 0.7 -> candidate
+      _ -> nil
+    end
+  end
+
+  @doc "Normalize user-typed field/value text for matching."
+  @spec normalize(String.t()) :: String.t()
+  def normalize(text) do
+    text
+    |> String.downcase()
+    |> String.replace(["-", " "], "_")
+  end
+end

--- a/lib/sanctum/search/suggest.ex
+++ b/lib/sanctum/search/suggest.ex
@@ -143,11 +143,26 @@ defmodule Sanctum.Search.Suggest do
          true <- op_allowed?(field, op) do
       norm = Registry.normalize(prefix)
 
-      for value <- field.values, String.starts_with?(Registry.normalize(value), norm) do
-        %{label: value, detail: nil, insert: value, kind: "value"}
+      for value <- field.values ++ dynamic_values(field),
+          String.starts_with?(Registry.normalize(value), norm) do
+        %{label: value, detail: nil, insert: quote_if_needed(value), kind: "value"}
       end
     else
       _ -> []
+    end
+  end
+
+  defp dynamic_values(%Field{values_fun: nil}), do: []
+  defp dynamic_values(%Field{values_fun: fun}), do: fun.()
+
+  # Values containing word-breaking characters ("Accuser Corps",
+  # "Black Widow") must be inserted as quoted phrases or the lexer would
+  # split them into separate terms.
+  defp quote_if_needed(value) do
+    if String.match?(value, ~r/[\s"()|:<>=!]/) do
+      ~s(") <> String.replace(value, ~s("), "") <> ~s(")
+    else
+      value
     end
   end
 

--- a/lib/sanctum/search/suggest.ex
+++ b/lib/sanctum/search/suggest.ex
@@ -1,0 +1,194 @@
+defmodule Sanctum.Search.Suggest do
+  @moduledoc """
+  Cursor-context-aware autocomplete for the search query language.
+
+  Given the input string, the cursor position (in UTF-16 code units, as
+  reported by the browser), and a field registry, returns the suggestions the
+  query-input hook renders as a combobox:
+
+      %{items: [%{label:, detail:, insert:, kind:}], start: s, length: l}
+
+  `start`/`length` (UTF-16 units) are the span the accepted suggestion's
+  `insert` text replaces — the token being completed, or a zero-length span
+  at the cursor.
+
+  Context rules:
+
+    * at a bare/partial word → complete field names (insert `field:`)
+    * after `field op` → complete the field's values (enums, flags, booleans)
+    * inside a quoted string or after an unknown field → no suggestions
+  """
+
+  alias Sanctum.Search.{Field, Lexer, Registry, Token}
+
+  @keywords ~w(or and not)
+
+  @max_items 10
+
+  @spec suggest(String.t(), non_neg_integer(), module()) :: map()
+  def suggest(input, cursor_utf16, registry)
+      when is_binary(input) and is_integer(cursor_utf16) do
+    cursor = utf16_to_byte(input, max(cursor_utf16, 0))
+    tokens = Lexer.tokenize(input)
+
+    current = Enum.find(tokens, &(&1.start < cursor and cursor <= &1.start + &1.length))
+    before = tokens |> Enum.take_while(&(&1.start + &1.length <= cursor)) |> Enum.reverse()
+
+    {items, {start, len}} = suggestions(current, before, cursor, registry)
+
+    %{
+      items: Enum.take(items, @max_items),
+      start: byte_to_utf16(input, start),
+      length: byte_to_utf16(input, start + len) - byte_to_utf16(input, start)
+    }
+  end
+
+  # -- context resolution ------------------------------------------------------
+
+  # Cursor inside/at the end of a word: completing a value if the word follows
+  # `field op`, otherwise completing a field name.
+  defp suggestions(%Token{kind: :word} = word, before, _cursor, registry) do
+    span = {word.start, word.length}
+
+    # `before` only includes the word itself when the cursor sits at its end;
+    # drop it either way to look at what precedes the word.
+    prior =
+      case before do
+        [^word | rest] -> rest
+        other -> other
+      end
+
+    case prior do
+      [%Token{kind: :op} = op, %Token{kind: :word} = field_tok | _] ->
+        {value_items(registry, field_tok, op, word.value), span}
+
+      _ ->
+        {field_items(registry, word.value), span}
+    end
+  end
+
+  # Cursor at the end of an operator: complete the field's values.
+  defp suggestions(%Token{kind: :op} = op, before, cursor, registry) do
+    case before do
+      [^op, %Token{kind: :word} = field_tok | _] ->
+        {value_items(registry, field_tok, op, ""), {cursor, 0}}
+
+      _ ->
+        {[], {cursor, 0}}
+    end
+  end
+
+  # No suggestions while typing a quoted phrase.
+  defp suggestions(%Token{kind: :string}, _before, cursor, _registry), do: {[], {cursor, 0}}
+
+  # Cursor in whitespace / at the ends of the input.
+  defp suggestions(nil, before, cursor, registry) do
+    case before do
+      # `aspect:` then a space — still the value position.
+      [%Token{kind: :op} = op, %Token{kind: :word} = field_tok | _] ->
+        {value_items(registry, field_tok, op, ""), {cursor, 0}}
+
+      _ ->
+        {field_items(registry, ""), {cursor, 0}}
+    end
+  end
+
+  defp suggestions(%Token{}, _before, cursor, _registry), do: {[], {cursor, 0}}
+
+  # -- item builders -----------------------------------------------------------
+
+  defp field_items(registry, prefix) do
+    norm = Registry.normalize(prefix)
+
+    fields =
+      for field <- registry.fields(),
+          match = matching_name(field, norm),
+          do: %{
+            label: match,
+            detail: field_detail(field, match),
+            insert: match <> ":",
+            kind: "field"
+          }
+
+    keywords =
+      for kw <- @keywords, norm != "", String.starts_with?(kw, norm) do
+        %{label: kw, detail: "combine terms", insert: kw <> " ", kind: "keyword"}
+      end
+
+    fields ++ keywords
+  end
+
+  # The canonical name if it matches, otherwise a matching alias (shown as the
+  # alias but described by the canonical name).
+  defp matching_name(%Field{} = field, prefix) do
+    cond do
+      String.starts_with?(field.name, prefix) -> field.name
+      match = Enum.find(field.aliases, &String.starts_with?(&1, prefix)) -> match
+      true -> nil
+    end
+  end
+
+  defp field_detail(%Field{} = field, shown_name) do
+    base = field.hint || field.example
+
+    if shown_name == field.name do
+      base
+    else
+      String.trim("#{field.name} — #{base}")
+    end
+  end
+
+  defp value_items(registry, %Token{value: field_name}, %Token{value: op}, prefix) do
+    with %Field{} = field <- Registry.lookup(registry, field_name),
+         true <- op_allowed?(field, op) do
+      norm = Registry.normalize(prefix)
+
+      for value <- field.values, String.starts_with?(Registry.normalize(value), norm) do
+        %{label: value, detail: nil, insert: value, kind: "value"}
+      end
+    else
+      _ -> []
+    end
+  end
+
+  defp op_allowed?(%Field{ops: ops}, op_text) do
+    op =
+      case op_text do
+        ":" -> :eq
+        "=" -> :eq
+        "!=" -> :neq
+        "!" -> :neq
+        "<" -> :lt
+        ">" -> :gt
+        "<=" -> :lte
+        ">=" -> :gte
+      end
+
+    op in ops
+  end
+
+  # -- UTF-16 <-> byte offset conversion ----------------------------------------
+  # The browser reports cursor positions in UTF-16 code units; lexer spans are
+  # byte offsets. Codepoints above 0xFFFF take two UTF-16 units.
+
+  defp utf16_to_byte(input, units), do: u2b(input, units, 0)
+
+  defp u2b(_rest, units, bytes) when units <= 0, do: bytes
+  defp u2b(<<>>, _units, bytes), do: bytes
+
+  defp u2b(<<cp::utf8, rest::binary>>, units, bytes) do
+    u2b(rest, units - utf16_units(cp), bytes + byte_size(<<cp::utf8>>))
+  end
+
+  defp byte_to_utf16(input, target), do: b2u(input, target, 0, 0)
+
+  defp b2u(_rest, target, bytes, units) when bytes >= target, do: units
+  defp b2u(<<>>, _target, _bytes, units), do: units
+
+  defp b2u(<<cp::utf8, rest::binary>>, target, bytes, units) do
+    b2u(rest, target, bytes + byte_size(<<cp::utf8>>), units + utf16_units(cp))
+  end
+
+  defp utf16_units(cp) when cp > 0xFFFF, do: 2
+  defp utf16_units(_cp), do: 1
+end

--- a/lib/sanctum/search/token.ex
+++ b/lib/sanctum/search/token.ex
@@ -1,0 +1,26 @@
+defmodule Sanctum.Search.Token do
+  @moduledoc """
+  A single lexed token of a search query, carrying its source span so
+  diagnostics and highlighting can point back at the original input.
+
+  Kinds:
+
+    * `:word` — an unquoted run of text (field names, values, bare search terms)
+    * `:string` — a double-quoted phrase (quotes stripped from `value`)
+    * `:op` — a comparison operator (`:` `=` `!=` `!` `<` `>` `<=` `>=`)
+    * `:lparen` / `:rparen` — grouping
+    * `:pipe` — value-level OR separator (`aspect:justice|leadership`)
+    * `:neg` — a `-` negation prefix
+  """
+
+  defstruct [:kind, :value, :start, :length]
+
+  @type kind :: :word | :string | :op | :lparen | :rparen | :pipe | :neg
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          value: String.t(),
+          start: non_neg_integer(),
+          length: non_neg_integer()
+        }
+end

--- a/lib/sanctum/search/value_cache.ex
+++ b/lib/sanctum/search/value_cache.ex
@@ -1,0 +1,64 @@
+defmodule Sanctum.Search.ValueCache do
+  @moduledoc """
+  A tiny per-node TTL cache for autocomplete value lists (traits, sets,
+  packs, hero names).
+
+  These vocabularies are small (tens to a few hundred short strings) and only
+  change on a card sync or deck import, so they're kept in memory via
+  `:persistent_term` and lazily refreshed after a TTL — no invalidation
+  wiring, no supervision. Writes are infrequent (once per key per TTL), which
+  is exactly the access pattern `:persistent_term` wants.
+
+  The loader runs in the calling process (the LiveView handling the suggest
+  event), so in tests the Ecto sandbox connection ownership just works.
+  """
+
+  @default_ttl :timer.minutes(10)
+
+  @doc """
+  Return the cached values for `key`, running `loader` (and caching its
+  result) when the entry is missing or older than `:ttl` milliseconds.
+
+  If the loader raises, the error is logged and `[]` is returned uncached, so
+  a transient DB problem degrades autocomplete instead of crashing the
+  LiveView.
+  """
+  @spec fetch(term(), (-> [String.t()]), keyword()) :: [String.t()]
+  def fetch(key, loader, opts \\ []) do
+    ttl = Keyword.get(opts, :ttl, @default_ttl)
+    now = System.monotonic_time(:millisecond)
+
+    case :persistent_term.get({__MODULE__, key}, :miss) do
+      {values, expires_at} when expires_at > now ->
+        values
+
+      _ ->
+        load(key, loader, now + ttl)
+    end
+  end
+
+  @doc "Drop every cached value list (used by tests and after manual syncs)."
+  @spec reset() :: :ok
+  def reset do
+    for {{__MODULE__, _key} = key, _value} <- :persistent_term.get() do
+      :persistent_term.erase(key)
+    end
+
+    :ok
+  end
+
+  defp load(key, loader, expires_at) do
+    values = loader.()
+    :persistent_term.put({__MODULE__, key}, {values, expires_at})
+    values
+  rescue
+    error ->
+      require Logger
+
+      Logger.warning(
+        "search value cache loader for #{inspect(key)} failed: #{Exception.message(error)}"
+      )
+
+      []
+  end
+end

--- a/lib/sanctum/search/values.ex
+++ b/lib/sanctum/search/values.ex
@@ -1,0 +1,66 @@
+defmodule Sanctum.Search.Values do
+  @moduledoc """
+  Data-driven autocomplete vocabularies for the search query language:
+  distinct traits, card sets, packs, and hero/alter-ego names.
+
+  Each list comes from the database on first use and is then served from
+  `Sanctum.Search.ValueCache` (per-node, 10-minute TTL) — these are small,
+  slow-moving catalogs that only change on card sync or deck import, so a
+  brief staleness window is fine and keeps the suggest path allocation-free.
+
+  Field registries reference these as `values_fun`; they are only invoked
+  when the cursor is actually in that field's value position.
+  """
+
+  alias Sanctum.Search.ValueCache
+
+  # All queries below are constant strings — no user input ever reaches them
+  # (each `Sanctum.Repo.query!` call takes a literal, which Sobelow verifies).
+
+  @doc "Distinct card traits (\"Avenger\", \"Accuser Corps\", \"A.I.M.\", …)."
+  @spec traits() :: [String.t()]
+  def traits do
+    ValueCache.fetch(:traits, fn ->
+      Sanctum.Repo.query!("SELECT DISTINCT unnest(traits) FROM card_sides ORDER BY 1")
+      |> clean_rows()
+    end)
+  end
+
+  @doc "Distinct card set slugs (\"age_of_apocalypse\", …)."
+  @spec sets() :: [String.t()]
+  def sets do
+    ValueCache.fetch(:sets, fn ->
+      Sanctum.Repo.query!("SELECT DISTINCT set FROM cards WHERE set IS NOT NULL ORDER BY 1")
+      |> clean_rows()
+    end)
+  end
+
+  @doc "Distinct pack codes (\"core\", \"aoa\", …)."
+  @spec packs() :: [String.t()]
+  def packs do
+    ValueCache.fetch(:packs, fn ->
+      Sanctum.Repo.query!("SELECT DISTINCT pack FROM cards WHERE pack IS NOT NULL ORDER BY 1")
+      |> clean_rows()
+    end)
+  end
+
+  @doc """
+  Hero and alter-ego names, merged and sorted — the deck `hero:` field
+  matches either, so both complete.
+  """
+  @spec heroes() :: [String.t()]
+  def heroes do
+    ValueCache.fetch(:heroes, fn ->
+      Sanctum.Repo.query!("SELECT hero_name, alter_ego_name FROM heroes")
+      |> clean_rows()
+      |> Enum.uniq()
+      |> Enum.sort()
+    end)
+  end
+
+  defp clean_rows(%{rows: rows}) do
+    rows
+    |> List.flatten()
+    |> Enum.reject(&(&1 in [nil, ""]))
+  end
+end

--- a/lib/sanctum_web/components/query_input.ex
+++ b/lib/sanctum_web/components/query_input.ex
@@ -1,0 +1,84 @@
+defmodule SanctumWeb.Components.QueryInput do
+  @moduledoc """
+  The advanced-search query input: a transparent-text `<input>` layered over a
+  syntax-highlighting mirror, with a server-driven autocomplete listbox —
+  wired up by the `QueryInput` JS hook.
+
+  Must be rendered inside a `<form phx-change="...">`; the input participates
+  in that form like a plain text input (same `name`, same debounce). The
+  hosting LiveView provides suggestions by handling the hook's `"suggest"`
+  event:
+
+      def handle_event("suggest", %{"value" => v, "cursor" => c}, socket) do
+        {:reply, Sanctum.Search.Suggest.suggest(v, c, MyRegistry), socket}
+      end
+  """
+
+  use Phoenix.Component
+
+  alias Sanctum.Search.Diagnostic
+
+  attr :id, :string, required: true
+  attr :value, :string, default: ""
+  attr :name, :string, default: "query"
+  attr :placeholder, :string, default: "Search…"
+  attr :registry, :atom, required: true, doc: "Sanctum.Search.Registry module"
+  attr :diagnostics, :list, default: []
+
+  def query_input(assigns) do
+    assigns = assign(assigns, :field_names, field_names(assigns.registry))
+
+    ~H"""
+    <div class="relative min-w-[260px] flex-1">
+      <div id={@id} phx-hook="QueryInput" data-fields={Jason.encode!(@field_names)}>
+        <span class="pointer-events-none absolute left-3.5 top-[21px] z-20 -translate-y-1/2 text-[17px] text-base-content/40">
+          ⌕
+        </span>
+        <div class="relative border-[2.5px] border-line bg-black focus-within:border-primary">
+          <div
+            id={@id <> "-mirror"}
+            phx-update="ignore"
+            aria-hidden="true"
+            class="qi-mirror pointer-events-none absolute inset-0 overflow-hidden whitespace-pre px-3.5 py-2.5 pl-[38px] font-barlow text-base text-base-content sm:text-[15px]"
+          >
+          </div>
+          <input
+            type="text"
+            name={@name}
+            value={@value}
+            phx-debounce="200"
+            autocomplete="off"
+            spellcheck="false"
+            autocapitalize="off"
+            placeholder={@placeholder}
+            role="combobox"
+            aria-expanded="false"
+            aria-autocomplete="list"
+            aria-controls={@id <> "-listbox"}
+            class="relative z-10 w-full bg-transparent px-3.5 py-2.5 pl-[38px] font-barlow text-base text-transparent caret-primary outline-none placeholder:text-base-content/35 sm:text-[15px]"
+          />
+        </div>
+        <div
+          id={@id <> "-listbox"}
+          phx-update="ignore"
+          role="listbox"
+          class="qi-listbox absolute left-0 right-0 top-full z-30 mt-1.5 hidden max-h-72 overflow-y-auto border-2 border-neutral bg-base-200 shadow-comic"
+        >
+        </div>
+      </div>
+      <div
+        :if={@diagnostics != []}
+        class="pointer-events-none absolute left-0 top-full z-20 mt-1 border border-line bg-base-100/95 px-2 py-0.5 font-barlow text-[12.5px] leading-tight text-primary/90"
+      >
+        {format_diagnostic(hd(@diagnostics))}
+      </div>
+    </div>
+    """
+  end
+
+  defp format_diagnostic(%Diagnostic{message: message}), do: "⚠ " <> message
+
+  defp field_names(registry) do
+    Enum.flat_map(registry.fields(), &[&1.name | &1.aliases])
+  end
+end

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -9,6 +9,7 @@ defmodule SanctumWeb.CardLive.Pool do
   require Ash.Query
 
   import SanctumWeb.Components.CardSideTile
+  import SanctumWeb.Components.QueryInput
 
   @page_size 24
 
@@ -54,18 +55,14 @@ defmodule SanctumWeb.CardLive.Pool do
 
       <!-- controls -->
       <div class="mb-3.5 flex flex-wrap items-center gap-2.5">
-        <form id="card-search" phx-change="search" class="relative min-w-[260px] flex-1">
-          <span class="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-[17px] text-base-content/40">
-            ⌕
-          </span>
-          <input
-            type="text"
-            name="query"
+        <form id="card-search" phx-change="search" class="flex min-w-[260px] flex-1">
+          <.query_input
+            id="card-query"
             value={@query}
-            phx-debounce="200"
-            autocomplete="off"
-            placeholder="Search cards by name…"
-            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-base text-base-content outline-none focus:border-primary sm:text-[15px]"
+            name="query"
+            placeholder="Search cards — try aspect:aggression cost<=2 type:ally"
+            registry={Sanctum.Search.CardFields}
+            diagnostics={@search_diagnostics}
           />
         </form>
         <div class="flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
@@ -170,6 +167,7 @@ defmodule SanctumWeb.CardLive.Pool do
       socket
       |> assign(:page_title, "Card Pool")
       |> assign(:query, "")
+      |> assign(:search_diagnostics, [])
       |> assign(:aspect, "all")
       |> assign(:type, "all")
       # nil until the first async load lands — drives the loading/skeleton UI.
@@ -202,7 +200,13 @@ defmodule SanctumWeb.CardLive.Pool do
       query != socket.assigns.query or aspect != socket.assigns.aspect or
         type != socket.assigns.type
 
-    socket = assign(socket, query: query, aspect: aspect, type: type)
+    socket =
+      assign(socket,
+        query: query,
+        aspect: aspect,
+        type: type,
+        search_diagnostics: search_diagnostics(query)
+      )
 
     socket =
       if connected?(socket) and (changed? or socket.assigns.req_id == 0),
@@ -217,6 +221,15 @@ defmodule SanctumWeb.CardLive.Pool do
   def handle_event("search", %{"query" => query}, socket) do
     {:noreply, push_patch(socket, to: pool_path(socket.assigns, query: query), replace: true)}
   end
+
+  # Autocomplete for the query input: the QueryInput hook pushes the raw
+  # value + cursor and renders whatever we reply with.
+  def handle_event("suggest", %{"value" => value, "cursor" => cursor}, socket)
+      when is_binary(value) and is_integer(cursor) do
+    {:reply, Sanctum.Search.Suggest.suggest(value, cursor, Sanctum.Search.CardFields), socket}
+  end
+
+  def handle_event("suggest", _params, socket), do: {:reply, %{items: []}, socket}
 
   def handle_event("filter_aspect", %{"key" => key}, socket) do
     {:noreply, push_patch(socket, to: pool_path(socket.assigns, aspect: key))}
@@ -385,4 +398,12 @@ defmodule SanctumWeb.CardLive.Pool do
   defp filters(assigns) do
     %{query: assigns.query, aspect: assigns.aspect, type: assigns.type}
   end
+
+  # Advisory parse/compile problems shown under the query input ("unknown
+  # field…", "did you mean…"). The query still runs with the bad part dropped.
+  defp search_diagnostics(query) when is_binary(query) and query != "" do
+    Sanctum.Search.compile(query, Sanctum.Search.CardFields).diagnostics
+  end
+
+  defp search_diagnostics(_query), do: []
 end

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -8,6 +8,8 @@ defmodule SanctumWeb.DeckLive.Index do
 
   require Ash.Query
 
+  import SanctumWeb.Components.QueryInput
+
   alias SanctumWeb.Components.Card, as: CardComponent
 
   @page_size 24
@@ -45,18 +47,14 @@ defmodule SanctumWeb.DeckLive.Index do
 
       <!-- search + count -->
       <div class="mb-3 flex flex-wrap items-center gap-2.5">
-        <form id="deck-search" phx-change="search" class="relative min-w-[260px] flex-1">
-          <span class="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-[17px] text-base-content/40">
-            ⌕
-          </span>
-          <input
-            type="text"
-            name="query"
+        <form id="deck-search" phx-change="search" class="flex min-w-[260px] flex-1">
+          <.query_input
+            id="deck-query"
             value={@query}
-            phx-debounce="200"
-            autocomplete="off"
-            placeholder="Search decks or heroes…"
-            class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 pl-[38px] font-barlow text-base text-base-content outline-none focus:border-primary sm:text-[15px]"
+            name="query"
+            placeholder="Search decks — try hero:spider aspect:justice cards>=45"
+            registry={Sanctum.Search.DeckFields}
+            diagnostics={@search_diagnostics}
           />
         </form>
         <div class="flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
@@ -221,6 +219,7 @@ defmodule SanctumWeb.DeckLive.Index do
       socket
       |> assign(:page_title, "Browse Decks")
       |> assign(:query, "")
+      |> assign(:search_diagnostics, [])
       |> assign(:sort, "new")
       |> assign(:aspect, "all")
       |> assign(:hero_id, "all")
@@ -255,7 +254,14 @@ defmodule SanctumWeb.DeckLive.Index do
       query != socket.assigns.query or sort != socket.assigns.sort or
         aspect != socket.assigns.aspect or hero_id != socket.assigns.hero_id
 
-    socket = assign(socket, query: query, sort: sort, aspect: aspect, hero_id: hero_id)
+    socket =
+      assign(socket,
+        query: query,
+        sort: sort,
+        aspect: aspect,
+        hero_id: hero_id,
+        search_diagnostics: search_diagnostics(query)
+      )
 
     socket =
       if connected?(socket) and (changed? or socket.assigns.req_id == 0),
@@ -288,6 +294,15 @@ defmodule SanctumWeb.DeckLive.Index do
   def handle_event("search", %{"query" => query}, socket) do
     {:noreply, push_patch(socket, to: decks_path(socket.assigns, query: query), replace: true)}
   end
+
+  # Autocomplete for the query input: the QueryInput hook pushes the raw
+  # value + cursor and renders whatever we reply with.
+  def handle_event("suggest", %{"value" => value, "cursor" => cursor}, socket)
+      when is_binary(value) and is_integer(cursor) do
+    {:reply, Sanctum.Search.Suggest.suggest(value, cursor, Sanctum.Search.DeckFields), socket}
+  end
+
+  def handle_event("suggest", _params, socket), do: {:reply, %{items: []}, socket}
 
   def handle_event("sort", %{"key" => key}, socket) do
     {:noreply, push_patch(socket, to: decks_path(socket.assigns, sort: key))}
@@ -489,6 +504,14 @@ defmodule SanctumWeb.DeckLive.Index do
   defp filters(a) do
     %{query: a.query, aspect: a.aspect, hero_id: a.hero_id, sort: a.sort}
   end
+
+  # Advisory parse/compile problems shown under the query input ("unknown
+  # field…", "did you mean…"). The query still runs with the bad part dropped.
+  defp search_diagnostics(query) when is_binary(query) and query != "" do
+    Sanctum.Search.compile(query, Sanctum.Search.DeckFields).diagnostics
+  end
+
+  defp search_diagnostics(_query), do: []
 
   # Builds the row display map from a loaded Deck.
   defp deck_view(deck) do

--- a/mix.exs
+++ b/mix.exs
@@ -106,6 +106,7 @@ defmodule Sanctum.MixProject do
       {:telemetry_poller, "~> 1.0"},
       {:gettext, "~> 1.0"},
       {:jason, "~> 1.2"},
+      {:nimble_parsec, "~> 1.4"},
       {:mdex, "~> 0.13"},
       {:dns_cluster, "~> 0.2.0"},
       {:bandit, "~> 1.5"},

--- a/test/sanctum/search/browse_integration_test.exs
+++ b/test/sanctum/search/browse_integration_test.exs
@@ -1,0 +1,151 @@
+defmodule Sanctum.Search.BrowseIntegrationTest do
+  @moduledoc """
+  End-to-end: advanced search queries through the real `:browse` read actions
+  against Postgres — this is what proves the jsonb stat fragments, trait
+  ILIKE ANY, relationship paths, and exists() subqueries actually run.
+  """
+
+  use Sanctum.DataCase, async: true
+
+  import Sanctum.Factory
+
+  alias Sanctum.Games.{Card, CardSide}
+
+  defp insert_card(attrs \\ %{}) do
+    create(Card, attrs: attrs)
+  end
+
+  defp insert_side(attrs) do
+    card = insert_card()
+
+    base = %{
+      card_id: card.id,
+      code: Faker.Util.format("%6da"),
+      side_identifier: "A",
+      is_primary_side: true
+    }
+
+    CardSide
+    |> Ash.Changeset.for_create(:create, Map.merge(card_side_factory(), Map.merge(base, attrs)))
+    |> Ash.create!(authorize?: false)
+  end
+
+  defp browse(query_string) do
+    CardSide
+    |> Ash.Query.for_read(:browse, %{query: query_string})
+    |> Ash.read!(authorize?: false)
+  end
+
+  defp browse_names(query_string) do
+    query_string |> browse() |> Enum.map(& &1.name) |> Enum.sort()
+  end
+
+  describe "card :browse with advanced queries" do
+    setup do
+      insert_side(%{
+        name: "Cheap Ally",
+        type: :ally,
+        aspect: :aggression,
+        ownership: :player,
+        cost: 2,
+        attack: %{value: 1},
+        traits: ["Avenger"],
+        text: "When Revealed: draw a card."
+      })
+
+      insert_side(%{
+        name: "Pricey Ally",
+        type: :ally,
+        aspect: :aggression,
+        ownership: :player,
+        cost: 4,
+        attack: %{value: 3},
+        traits: ["Guardian"],
+        text: "Enters play exhausted."
+      })
+
+      insert_side(%{
+        name: "Justice Event",
+        type: :event,
+        aspect: :justice,
+        ownership: :player,
+        cost: 1,
+        attack: nil,
+        traits: [],
+        text: "Remove 2 threat from a scheme."
+      })
+
+      :ok
+    end
+
+    test "the flagship query" do
+      assert browse_names("aspect = aggression AND cost <= 2 AND type = ally") == ["Cheap Ally"]
+    end
+
+    test "shorthand form matches" do
+      assert browse_names("a:aggression c<=2 t:ally") == ["Cheap Ally"]
+    end
+
+    test "bare word still searches names" do
+      assert browse_names("pricey") == ["Pricey Ally"]
+    end
+
+    test "stat comparison reaches into the jsonb value" do
+      assert browse_names("attack>=2") == ["Pricey Ally"]
+      # nil stats drop out rather than erroring
+      assert browse_names("attack<=1") == ["Cheap Ally"]
+    end
+
+    test "trait match is case-insensitive" do
+      assert browse_names("trait:avenger") == ["Cheap Ally"]
+      assert browse_names("k:AVENGER") == ["Cheap Ally"]
+    end
+
+    test "text search" do
+      assert browse_names(~s{text:"draw a card"}) == ["Cheap Ally"]
+    end
+
+    test "or and negation" do
+      assert browse_names("t:event or cost>=4") == ["Justice Event", "Pricey Ally"]
+      assert browse_names("t:ally -trait:guardian") == ["Cheap Ally"]
+    end
+
+    test "pipe value alternatives" do
+      assert browse_names("aspect:justice|aggression cost<=2") == ["Cheap Ally", "Justice Event"]
+    end
+
+    test "invalid value on a known field matches nothing" do
+      assert browse_names("aspect:agression") == []
+    end
+
+    test "unknown field is dropped, rest still filters" do
+      assert browse_names("bogus:1 t:event") == ["Justice Event"]
+    end
+
+    test "incomplete trailing clause keeps the valid prefix live" do
+      assert browse_names("t:ally cost <") == ["Cheap Ally", "Pricey Ally"]
+    end
+
+    test "card-level fields via the relationship" do
+      assert browse_names("set:core t:ally") == ["Cheap Ally", "Pricey Ally"]
+      assert browse_names("set:nonexistent") == []
+    end
+  end
+
+  describe "deck :browse with advanced queries" do
+    test "hero, aspect, and containment queries run" do
+      # No decks in the sandbox — just prove the filters execute (no SQL errors).
+      for q <- [
+            "hero:spider aspect:justice",
+            "aspect:basic",
+            ~s(card:"boot camp"),
+            "cards>=40",
+            "source:marvelcdb"
+          ] do
+        assert Sanctum.Decks.Deck
+               |> Ash.Query.for_read(:browse, %{query: q})
+               |> Ash.read!(authorize?: false) == []
+      end
+    end
+  end
+end

--- a/test/sanctum/search/compiler_test.exs
+++ b/test/sanctum/search/compiler_test.exs
@@ -1,0 +1,148 @@
+defmodule Sanctum.Search.CompilerTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias Sanctum.Search
+  alias Sanctum.Search.{CardFields, DeckFields}
+
+  defp compile(input, registry \\ CardFields), do: Search.compile(input, registry)
+
+  defp codes(result), do: Enum.map(result.diagnostics, & &1.code)
+
+  describe "card queries" do
+    test "the flagship example compiles cleanly" do
+      result = compile("aspect = aggression AND cost <= 2 AND type = ally")
+      assert result.expr != nil
+      assert result.diagnostics == []
+    end
+
+    test "shorthand aliases compile to the same filter as full names" do
+      a = compile("a:aggression c<=2 t:ally")
+      b = compile("aspect:aggression cost<=2 type:ally")
+      assert inspect(a.expr) == inspect(b.expr)
+      assert a.diagnostics == []
+    end
+
+    test "enum values accept unique prefixes" do
+      assert compile("t:all").diagnostics == []
+      assert compile("a:agg").diagnostics == []
+    end
+
+    test "aspect accepts ownership pools" do
+      assert %{expr: expr, diagnostics: []} = compile("aspect:hero")
+      assert inspect(expr) =~ "ownership"
+    end
+
+    test "stat fields compile to jsonb value fragments" do
+      assert %{expr: expr, diagnostics: []} = compile("attack>=2")
+      assert inspect(expr) =~ "value"
+    end
+
+    test "empty and whitespace input compile to no filter" do
+      assert %{expr: nil, diagnostics: []} = compile("")
+      assert %{expr: nil, diagnostics: []} = compile("   ")
+    end
+
+    test "bare word falls back to name search" do
+      assert %{expr: expr, diagnostics: []} = compile("spider")
+      assert inspect(expr) =~ "ilike"
+    end
+
+    test "unknown field drops the clause but keeps the rest" do
+      result = compile("bogus:1 t:ally")
+      assert result.expr != nil
+      assert codes(result) == [:unknown_field]
+      assert hd(result.diagnostics).message =~ ~s(unknown field "bogus")
+    end
+
+    test "unknown field alone yields no filter (results stay live)" do
+      assert %{expr: nil} = compile("bogus:1")
+    end
+
+    test "invalid enum value matches nothing and suggests a fix" do
+      result = compile("aspect:agression")
+      assert result.expr == false
+      assert codes(result) == [:invalid_value]
+      assert hd(result.diagnostics).message =~ "aggression"
+    end
+
+    test "non-numeric value on a numeric field" do
+      result = compile("cost:banana")
+      assert result.expr == false
+      assert codes(result) == [:invalid_value]
+    end
+
+    test "unsupported operator on a field" do
+      result = compile("aspect>2")
+      assert result.expr == nil
+      assert codes(result) == [:unsupported_operator]
+    end
+
+    test "incomplete trailing clause keeps the valid prefix" do
+      result = compile("t:ally cost <")
+      assert result.expr != nil
+      assert codes(result) == [:incomplete_clause]
+    end
+
+    test "pipe values OR for eq and AND for neq" do
+      eq = compile("aspect:justice|leadership")
+      neq = compile("aspect!=justice|leadership")
+      assert inspect(eq.expr) =~ " or "
+      assert inspect(neq.expr) =~ " and "
+    end
+
+    test "negation wraps in not" do
+      assert inspect(compile("-t:ally").expr) =~ "not"
+    end
+
+    test "is: flags" do
+      assert %{diagnostics: []} = compile("is:unique")
+      assert %{diagnostics: []} = compile("is:crisis")
+      result = compile("is:sparkly")
+      assert result.expr == false
+      assert codes(result) == [:invalid_value]
+    end
+
+    test "every registered example compiles without diagnostics" do
+      for field <- CardFields.fields(), field.example do
+        result = compile(field.example)
+        assert result.diagnostics == [], "example #{field.example} produced diagnostics"
+        assert result.expr != nil
+      end
+    end
+  end
+
+  describe "deck queries" do
+    test "hero + aspect + card count" do
+      result = compile(~s(hero:spider aspect:justice cards>=40), DeckFields)
+      assert result.expr != nil
+      assert result.diagnostics == []
+    end
+
+    test "basic decks filter on empty aspect array" do
+      assert %{expr: expr, diagnostics: []} = compile("aspect:basic", DeckFields)
+      assert inspect(expr) =~ "cardinality"
+    end
+
+    test "deck containment search" do
+      assert %{expr: expr, diagnostics: []} = compile(~s(card:"boot camp"), DeckFields)
+      assert inspect(expr) =~ "exists"
+    end
+
+    test "every registered example compiles without diagnostics" do
+      for field <- DeckFields.fields(), field.example do
+        result = compile(field.example, DeckFields)
+        assert result.diagnostics == [], "example #{field.example} produced diagnostics"
+        assert result.expr != nil
+      end
+    end
+  end
+
+  describe "ILIKE pattern safety" do
+    test "wildcards in user input are escaped" do
+      result = compile("name:100%")
+      assert inspect(result.expr) =~ ~S(\\%)
+    end
+  end
+end

--- a/test/sanctum/search/parser_test.exs
+++ b/test/sanctum/search/parser_test.exs
@@ -1,0 +1,151 @@
+defmodule Sanctum.Search.ParserTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias Sanctum.Search.{Parser, Token}
+
+  defp parse(input), do: Parser.parse(input)
+
+  defp clause({:clause, c}), do: {c.field.value, c.op, Enum.map(c.values, & &1.value)}
+
+  describe "clauses" do
+    test "field = value" do
+      {ast, []} = parse("aspect = aggression")
+      assert clause(ast) == {"aspect", :eq, ["aggression"]}
+    end
+
+    test "colon and equals are interchangeable" do
+      {a, []} = parse("cost:2")
+      {b, []} = parse("cost=2")
+      assert clause(a) == clause(b)
+    end
+
+    test "all comparison operators" do
+      for {op_text, op} <- [
+            {":", :eq},
+            {"=", :eq},
+            {"!=", :neq},
+            {"!", :neq},
+            {"<", :lt},
+            {">", :gt},
+            {"<=", :lte},
+            {">=", :gte}
+          ] do
+        {ast, []} = parse("cost#{op_text}2")
+        assert clause(ast) == {"cost", op, ["2"]}, "operator #{op_text}"
+      end
+    end
+
+    test "quoted value" do
+      {ast, []} = parse(~s(text:"draw a card"))
+      assert clause(ast) == {"text", :eq, ["draw a card"]}
+    end
+
+    test "pipe-separated values" do
+      {ast, []} = parse("aspect:justice|leadership|pool")
+      assert clause(ast) == {"aspect", :eq, ["justice", "leadership", "pool"]}
+    end
+  end
+
+  describe "boolean structure" do
+    test "adjacent terms are an implicit AND" do
+      {{:and, [a, b]}, []} = parse("aspect:justice cost<=2")
+      assert clause(a) == {"aspect", :eq, ["justice"]}
+      assert clause(b) == {"cost", :lte, ["2"]}
+    end
+
+    test "explicit AND keyword, case-insensitive" do
+      {ast, []} = parse("aspect = aggression AND cost <= 2 AND type = ally")
+      assert {:and, [a, b, c]} = ast
+      assert clause(a) == {"aspect", :eq, ["aggression"]}
+      assert clause(b) == {"cost", :lte, ["2"]}
+      assert clause(c) == {"type", :eq, ["ally"]}
+    end
+
+    test "or groups lower than and" do
+      {ast, []} = parse("type:ally cost:1 or type:event")
+      assert {:or, [{:and, _}, _]} = ast
+    end
+
+    test "parentheses group" do
+      {ast, []} = parse("(aspect:justice or aspect:pool) cost<3")
+      assert {:and, [{:or, _}, _]} = ast
+    end
+
+    test "negation with hyphen and NOT keyword" do
+      {{:not, a}, []} = parse("-type:ally")
+      {{:not, b}, []} = parse("not type:ally")
+      assert clause(a) == clause(b)
+    end
+
+    test "bare words" do
+      {ast, []} = parse("spider-man")
+      assert {:word, %Token{value: "spider-man"}} = ast
+    end
+
+    test "quoted phrase as bare term" do
+      {ast, []} = parse(~s("peter parker"))
+      assert {:word, %Token{value: "peter parker"}} = ast
+    end
+
+    test "bare word NOT at end of input stays a word" do
+      {ast, []} = parse("not")
+      assert {:word, %Token{value: "not"}} = ast
+    end
+  end
+
+  describe "error tolerance" do
+    test "trailing operator drops the clause, keeps the rest" do
+      {ast, [diag]} = parse("type:ally cost <")
+      assert clause(ast) == {"type", :eq, ["ally"]}
+      assert diag.code == :incomplete_clause
+    end
+
+    test "stray closing paren is skipped" do
+      {ast, [diag]} = parse("type:ally)")
+      assert clause(ast) == {"type", :eq, ["ally"]}
+      assert diag.code == :stray_token
+    end
+
+    test "unclosed paren still parses the group" do
+      {ast, [diag]} = parse("(type:ally cost:1")
+      assert {:and, [_, _]} = ast
+      assert diag.code == :unclosed_paren
+    end
+
+    test "leading operator is skipped" do
+      {ast, [diag]} = parse("<= 2 type:ally")
+      assert diag.code == :stray_token
+      # "2" becomes a bare word, type:ally still parses
+      assert {:and, [{:word, %Token{value: "2"}}, _]} = ast
+    end
+
+    test "empty input" do
+      assert {nil, []} = parse("")
+      assert {nil, []} = parse("   ")
+    end
+
+    test "unterminated quote takes the rest of the input" do
+      {ast, []} = parse(~s(text:"draw a))
+      assert clause(ast) == {"text", :eq, ["draw a"]}
+    end
+
+    test "trailing pipe keeps parsed values" do
+      {ast, [diag]} = parse("aspect:justice|")
+      assert clause(ast) == {"aspect", :eq, ["justice"]}
+      assert diag.code == :stray_token
+    end
+  end
+
+  describe "spans" do
+    test "tokens carry byte offsets into the input" do
+      {ast, []} = parse("cost <= 2")
+      {:clause, c} = ast
+      assert c.field.start == 0
+      assert c.field.length == 4
+      assert c.op_token.start == 5
+      assert [%Token{start: 8, length: 1}] = c.values
+    end
+  end
+end

--- a/test/sanctum/search/suggest_test.exs
+++ b/test/sanctum/search/suggest_test.exs
@@ -1,0 +1,87 @@
+defmodule Sanctum.Search.SuggestTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias Sanctum.Search.{CardFields, Suggest}
+
+  defp suggest(input, cursor), do: Suggest.suggest(input, cursor, CardFields)
+
+  defp labels(result), do: Enum.map(result.items, & &1.label)
+
+  test "empty input suggests fields" do
+    result = suggest("", 0)
+    assert "name" in labels(result)
+    assert result.start == 0 and result.length == 0
+    assert Enum.all?(result.items, &(&1.kind == "field"))
+  end
+
+  test "partial field name filters and spans the word" do
+    result = suggest("asp", 3)
+    assert labels(result) == ["aspect"]
+    assert %{start: 0, length: 3} = result
+    assert hd(result.items).insert == "aspect:"
+  end
+
+  test "alias prefix surfaces the alias with its canonical name in the detail" do
+    result = suggest("atk", 3)
+    assert [%{label: "atk", detail: detail, insert: "atk:"}] = result.items
+    assert detail =~ "attack"
+  end
+
+  test "after field colon suggests enum values" do
+    result = suggest("aspect:", 7)
+    assert "aggression" in labels(result)
+    assert "hero" in labels(result)
+    assert Enum.all?(result.items, &(&1.kind == "value"))
+    assert %{start: 7, length: 0} = result
+  end
+
+  test "partial value filters and spans the value token" do
+    result = suggest("aspect:agg", 10)
+    assert labels(result) == ["aggression"]
+    assert %{start: 7, length: 3} = result
+  end
+
+  test "cursor mid-word completes against the whole token" do
+    result = suggest("aspect:agg cost<=2", 9)
+    assert labels(result) == ["aggression"]
+  end
+
+  test "space after a complete clause starts a new field context" do
+    result = suggest("aspect:justice ", 15)
+    assert "cost" in labels(result)
+  end
+
+  test "value context survives a space after the operator" do
+    result = suggest("aspect: ", 8)
+    assert "justice" in labels(result)
+  end
+
+  test "text fields offer no value suggestions" do
+    assert suggest("name:", 5).items == []
+  end
+
+  test "unknown field offers no value suggestions" do
+    assert suggest("bogus:", 6).items == []
+  end
+
+  test "no suggestions inside a quoted phrase" do
+    assert suggest(~s(text:"draw), 8).items == []
+  end
+
+  test "keywords complete once typing starts" do
+    assert "or" in labels(suggest("t:ally o", 8))
+  end
+
+  test "is: suggests flags" do
+    assert "unique" in labels(suggest("is:", 3))
+  end
+
+  test "utf-16 offsets round-trip for non-BMP input" do
+    # "𝕏" is a surrogate pair: 2 UTF-16 units, 4 bytes.
+    result = suggest("𝕏 asp", 5)
+    assert labels(result) == ["aspect"]
+    assert %{start: 3, length: 3} = result
+  end
+end

--- a/test/sanctum/search/value_cache_test.exs
+++ b/test/sanctum/search/value_cache_test.exs
@@ -1,0 +1,59 @@
+defmodule Sanctum.Search.ValueCacheTest do
+  @moduledoc false
+
+  # persistent_term is node-global state (and reset/0 clears every key), so
+  # these tests stay synchronous.
+  use ExUnit.Case, async: false
+
+  alias Sanctum.Search.ValueCache
+
+  setup do
+    ValueCache.reset()
+    on_exit(&ValueCache.reset/0)
+  end
+
+  test "computes once and serves from cache within the TTL" do
+    counter = :counters.new(1, [])
+
+    loader = fn ->
+      :counters.add(counter, 1, 1)
+      ["a", "b"]
+    end
+
+    assert ValueCache.fetch(:test_key, loader) == ["a", "b"]
+    assert ValueCache.fetch(:test_key, loader) == ["a", "b"]
+    assert :counters.get(counter, 1) == 1
+  end
+
+  test "recomputes after the TTL expires" do
+    counter = :counters.new(1, [])
+
+    loader = fn ->
+      :counters.add(counter, 1, 1)
+      ["v"]
+    end
+
+    assert ValueCache.fetch(:test_ttl, loader, ttl: 0) == ["v"]
+    assert ValueCache.fetch(:test_ttl, loader, ttl: 0) == ["v"]
+    assert :counters.get(counter, 1) == 2
+  end
+
+  test "reset clears cached entries" do
+    assert ValueCache.fetch(:test_reset, fn -> ["old"] end) == ["old"]
+    ValueCache.reset()
+    assert ValueCache.fetch(:test_reset, fn -> ["new"] end) == ["new"]
+  end
+
+  test "a raising loader logs, returns [], and does not cache the failure" do
+    import ExUnit.CaptureLog
+
+    log =
+      capture_log(fn ->
+        assert ValueCache.fetch(:test_raise, fn -> raise "db down" end) == []
+      end)
+
+    assert log =~ "value cache loader"
+    # The failure wasn't cached — a later healthy loader works.
+    assert ValueCache.fetch(:test_raise, fn -> ["ok"] end) == ["ok"]
+  end
+end

--- a/test/sanctum/search/values_test.exs
+++ b/test/sanctum/search/values_test.exs
@@ -1,0 +1,96 @@
+defmodule Sanctum.Search.ValuesTest do
+  @moduledoc """
+  Data-driven autocomplete values end-to-end: DB → Values loaders →
+  ValueCache → Suggest items (with quoting for multi-word values).
+  """
+
+  # The value cache is node-global, so these tests can't run concurrently
+  # with each other (each resets the cache against its own sandbox data).
+  use Sanctum.DataCase, async: false
+
+  import Sanctum.Factory
+
+  alias Sanctum.Games.{Card, CardSide}
+  alias Sanctum.Search.{CardFields, DeckFields, Suggest, ValueCache, Values}
+
+  setup do
+    ValueCache.reset()
+    on_exit(&ValueCache.reset/0)
+  end
+
+  defp insert_side(attrs) do
+    card = create(Card, attrs: Map.take(attrs, [:set, :pack]))
+
+    base = %{
+      card_id: card.id,
+      code: Faker.Util.format("%6da"),
+      side_identifier: "A",
+      is_primary_side: true
+    }
+
+    CardSide
+    |> Ash.Changeset.for_create(
+      :create,
+      Map.merge(card_side_factory(), Map.merge(base, Map.drop(attrs, [:set, :pack])))
+    )
+    |> Ash.create!(authorize?: false)
+  end
+
+  test "traits/sets/packs come from the catalog, deduplicated" do
+    insert_side(%{traits: ["Accuser Corps", "Avenger"], set: "core", pack: "core"})
+    insert_side(%{traits: ["Avenger"], set: "spider_man", pack: "core"})
+
+    assert "Accuser Corps" in Values.traits()
+    assert Enum.count(Values.traits(), &(&1 == "Avenger")) == 1
+    assert "spider_man" in Values.sets()
+    assert Values.packs() == ["core"]
+  end
+
+  test "values are served from memory after first load" do
+    insert_side(%{traits: ["Avenger"]})
+    assert "Avenger" in Values.traits()
+
+    # Remove the underlying rows; the cached list must still answer.
+    Sanctum.Repo.query!("DELETE FROM card_sides")
+    assert "Avenger" in Values.traits()
+  end
+
+  test "trait suggestions complete from the catalog" do
+    insert_side(%{traits: ["Avenger", "Accuser Corps"]})
+
+    result = Suggest.suggest("trait:a", 7, CardFields)
+    labels = Enum.map(result.items, & &1.label)
+    assert "Avenger" in labels
+    assert "Accuser Corps" in labels
+  end
+
+  test "multi-word values insert as quoted phrases" do
+    insert_side(%{traits: ["Accuser Corps"]})
+
+    result = Suggest.suggest("trait:accuser", 13, CardFields)
+    assert [%{label: "Accuser Corps", insert: ~s("Accuser Corps")}] = result.items
+  end
+
+  test "hero suggestions complete hero and alter-ego names" do
+    card = create(Card, attrs: %{set: "black_widow"})
+
+    hero =
+      Sanctum.Heroes.Hero
+      |> Ash.Changeset.for_create(:create, %{
+        hero_name: "Black Widow",
+        alter_ego_name: "Natasha Romanoff",
+        set: "black_widow",
+        base_code: "07001",
+        card_id: card.id
+      })
+      |> Ash.create!(authorize?: false)
+
+    assert hero.hero_name == "Black Widow"
+
+    result = Suggest.suggest("hero:black", 10, DeckFields)
+    assert [%{label: "Black Widow", insert: ~s("Black Widow")}] = result.items
+
+    result2 = Suggest.suggest("hero:nat", 8, DeckFields)
+    assert [%{label: "Natasha Romanoff"}] = result2.items
+  end
+end


### PR DESCRIPTION
## What

Adds a Scryfall-style advanced search query language to the card pool and deck browser. Users can type structured queries like:

```
aspect = aggression AND cost <= 2 AND type = ally
```

or the terse MarvelCDB-flavored equivalent:

```
a:aggression c<=2 t:ally
```

with syntax highlighting, context-aware autocomplete, and gentle inline diagnostics. Plain searches are unchanged — a bare word still searches card names (or deck titles/heroes).

## Language

- `field op value` terms — `:` and `=` both mean equals, plus `!=` `<` `>` `<=` `>=`
- Space between terms is an implicit AND; `or` and parentheses group; `-term` / `NOT` negate
- `value|value` is a value-level OR (`aspect:justice|leadership`); `"quoted strings"` for phrases
- Case-insensitive everywhere; enum values accept unique prefixes (`t:all` → ally)
- **Error-tolerant by design**: a half-typed `cost <`, a stray `)`, or an unknown field is dropped with a positioned diagnostic while the valid remainder still filters — results stay live while typing. A bad value on a *known* field (`aspect:agression`) matches nothing and shows a did-you-mean hint, so zero results are always explained.

**Card fields**: name, text, flavor, type, aspect (accepts the hero/basic ownership pools, matching the filter pills), ownership, trait, cost, attack/thwart/defense/health/recover + threat stats (jsonb `Stat` values via `(stat->>'value')::integer` fragments), resource counts, set, pack, code, unique, and `is:` flags (unique, permanent, multi_sided, crisis, hazard, acceleration, amplify).

**Deck fields**: title, hero (hero or alter-ego name), aspect (incl. `aspect:basic` = empty array), `cards>=45` (total-count aggregate), `source`, and `card:"boot camp"` containment via an `exists()` subquery.

## How

- **`Sanctum.Search`** — NimbleParsec lexer → error-tolerant recursive-descent parser → registry-driven compiler emitting Ash expressions applied in the existing `:browse` actions. The field registries (`CardFields`/`DeckFields`) are the single source of truth for parser, compiler, autocomplete, and highlighting, and double as the security allowlist — a query can only ever touch registered fields.
- **Frontend** follows GitHub's QueryBuilder pattern (their published rationale rejected contenteditable for accessibility): a transparent-text `<input>` over an aria-hidden colored mirror div, driven by a small `QueryInput` phx-hook with a client regex tokenizer for instant coloring. No editor library.
- **Autocomplete is server-driven**: the hook pushes `{value, cursor}` and `Sanctum.Search.Suggest` replies with cursor-context-aware completions (field names at a term start; enum/flag values after `aspect:`), handling UTF-16↔byte offset conversion. Full keyboard support (arrows/Enter/Tab/Escape), W3C combobox semantics.

## Testing

- 70 new tests: parser and compiler units, suggest-context units, and DB integration tests proving the jsonb stat fragments, case-insensitive trait `ILIKE ANY`, relationship-path fields, and deck `exists()` containment all execute on Postgres.
- Full suite green (288 tests), `mix ck` clean.
- Verified in the browser against dev: flagship query returns the correct 11 aggression allies at cost ≤2; `hero:spider aspect:justice` → 23/720 decks; `card:"boot camp" cards>=40` → 44/720; typo queries show the did-you-mean hint with results staying live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)