### PR TITLE
feat(browse): restore scroll position on the pack browser and pack pages

### DIFF
--- a/lib/sanctum_web/live/browse_live/index.ex
+++ b/lib/sanctum_web/live/browse_live/index.ex
@@ -33,6 +33,7 @@ defmodule SanctumWeb.BrowseLive.Index do
       |> assign(:wave_sections, nil)
       |> assign(:other_packs, [])
       |> assign(:covers, %{})
+      |> assign(:scroll_restore_pending?, false)
 
     # Skip every query on the static (disconnected) render; the taxonomy loads
     # asynchronously once the socket connects so nothing blocks first paint.
@@ -42,13 +43,36 @@ defmodule SanctumWeb.BrowseLive.Index do
     {:ok, socket}
   end
 
+  # Pushed by the ScrollRestore hook when the user arrives with a saved scroll
+  # position. The page renders asynchronously, so hold the confirmation until
+  # the taxonomy load lands and the content exists at its full height.
+  @impl true
+  def handle_event("restore-scroll", _params, socket) do
+    if socket.assigns.wave_sections do
+      {:noreply, push_event(socket, "sanctum:scroll-restore", %{})}
+    else
+      {:noreply, assign(socket, :scroll_restore_pending?, true)}
+    end
+  end
+
   @impl true
   def handle_async(:load_browse, {:ok, result}, socket) do
-    {:noreply,
-     socket
-     |> assign(:wave_sections, result.wave_sections)
-     |> assign(:other_packs, result.other_packs)
-     |> assign(:covers, result.covers)}
+    socket =
+      socket
+      |> assign(:wave_sections, result.wave_sections)
+      |> assign(:other_packs, result.other_packs)
+      |> assign(:covers, result.covers)
+
+    socket =
+      if socket.assigns.scroll_restore_pending? do
+        socket
+        |> assign(:scroll_restore_pending?, false)
+        |> push_event("sanctum:scroll-restore", %{})
+      else
+        socket
+      end
+
+    {:noreply, socket}
   end
 
   def handle_async(:load_browse, {:exit, reason}, socket) do
@@ -88,6 +112,7 @@ defmodule SanctumWeb.BrowseLive.Index do
   def render(assigns) do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:browse}>
+      <div id="scroll-restore" phx-hook="ScrollRestore"></div>
       <.header>
         Browse
         <:subtitle>

--- a/lib/sanctum_web/live/browse_live/show.ex
+++ b/lib/sanctum_web/live/browse_live/show.ex
@@ -35,6 +35,7 @@ defmodule SanctumWeb.BrowseLive.Show do
       |> assign(:sections, [])
       |> assign(:modular_groups, [])
       |> assign(:player_groups, [])
+      |> assign(:scroll_restore_pending?, false)
 
     # Skip the (heavy) product load on the static render; it runs asynchronously
     # once the socket connects so the shell paints immediately.
@@ -46,17 +47,40 @@ defmodule SanctumWeb.BrowseLive.Show do
     {:ok, socket}
   end
 
+  # Pushed by the ScrollRestore hook when the user arrives with a saved scroll
+  # position. The page renders asynchronously, so hold the confirmation until
+  # the pack load lands and the content exists at its full height.
+  @impl true
+  def handle_event("restore-scroll", _params, socket) do
+    if socket.assigns.pack do
+      {:noreply, push_event(socket, "sanctum:scroll-restore", %{})}
+    else
+      {:noreply, assign(socket, :scroll_restore_pending?, true)}
+    end
+  end
+
   @impl true
   def handle_async(:load_pack, {:ok, {:ok, data}}, socket) do
-    {:noreply,
-     socket
-     |> assign(:page_title, data.page_title)
-     |> assign(:pack, data.pack)
-     |> assign(:villain_groups, data.villain_groups)
-     |> assign(:encounter_groups, data.encounter_groups)
-     |> assign(:sections, data.sections)
-     |> assign(:modular_groups, data.modular_groups)
-     |> assign(:player_groups, data.player_groups)}
+    socket =
+      socket
+      |> assign(:page_title, data.page_title)
+      |> assign(:pack, data.pack)
+      |> assign(:villain_groups, data.villain_groups)
+      |> assign(:encounter_groups, data.encounter_groups)
+      |> assign(:sections, data.sections)
+      |> assign(:modular_groups, data.modular_groups)
+      |> assign(:player_groups, data.player_groups)
+
+    socket =
+      if socket.assigns.scroll_restore_pending? do
+        socket
+        |> assign(:scroll_restore_pending?, false)
+        |> push_event("sanctum:scroll-restore", %{})
+      else
+        socket
+      end
+
+    {:noreply, socket}
   end
 
   def handle_async(:load_pack, {:ok, {:error, code}}, socket) do
@@ -103,6 +127,7 @@ defmodule SanctumWeb.BrowseLive.Show do
   def render(assigns) do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:browse}>
+      <div id="scroll-restore" phx-hook="ScrollRestore"></div>
       <!-- first-load skeleton -->
       <div :if={@pack == nil} class="flex flex-col gap-6">
         <div class="h-9 w-1/2 max-w-md animate-pulse bg-base-300"></div>

--- a/test/sanctum_web/live/browse_live/browse_test.exs
+++ b/test/sanctum_web/live/browse_live/browse_test.exs
@@ -42,4 +42,26 @@ defmodule SanctumWeb.BrowseLiveTest do
     # The async load resolves to not-found and redirects to /browse.
     assert_redirect(view, ~p"/browse")
   end
+
+  test "the browser confirms restore-scroll once the taxonomy has loaded", %{conn: conn} do
+    make_pack("spdr", "SP//dr")
+
+    {:ok, view, _html} = live(conn, ~p"/browse")
+
+    render_hook(view, "restore-scroll", %{"offset" => 0})
+    render_async(view)
+
+    assert_push_event(view, "sanctum:scroll-restore", %{})
+  end
+
+  test "a product page confirms restore-scroll once the pack has loaded", %{conn: conn} do
+    make_pack("spdr", "SP//dr")
+
+    {:ok, view, _html} = live(conn, ~p"/browse/spdr")
+
+    render_hook(view, "restore-scroll", %{"offset" => 0})
+    render_async(view)
+
+    assert_push_event(view, "sanctum:scroll-restore", %{})
+  end
 end


### PR DESCRIPTION
## What

Extends the scroll restoration from #205/#206 to the last two async pages that were missing it: the **pack browser** (`/browse`) and the **pack detail** page (`/browse/:pack`).

Both pages load their content asynchronously after mount, so LiveView's native back-navigation scroll restore had nothing to scroll to. Each now confirms a pending `restore-scroll` request from the `ScrollRestore` hook once its async load lands — the same deferred-confirmation shape as the deck detail page (#206). Neither page paginates, so there's no offset refetch.

## Verification

- Browser-verified end-to-end: browse → scroll (y=800) → pack detail → scroll (y=1400) → card page, then back restores the pack page to y=1400 and a second back restores the browser to y=800.
- New tests assert the `sanctum:scroll-restore` push event fires after each page's async load.
- `mix ck` clean; browse suite 5 tests / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)