### PR TITLE
feat(auth): make registration enumeration-safe (email-first flow)

### DIFF
--- a/lib/sanctum/accounts/user.ex
+++ b/lib/sanctum/accounts/user.ex
@@ -282,6 +282,33 @@ defmodule Sanctum.Accounts.User do
       end
     end
 
+    action :request_registration do
+      description """
+      Enumeration-safe registration: registers the email if it's free, or
+      notifies the address that it already has an account. Returns :ok either
+      way so callers can't probe which emails exist. See the implementation
+      module for the full contract. Called with authorize?: false — safe by
+      construction for anonymous use.
+      """
+
+      argument :email, :ci_string do
+        allow_nil? false
+      end
+
+      argument :password, :string do
+        allow_nil? false
+        constraints min_length: 8
+        sensitive? true
+      end
+
+      argument :password_confirmation, :string do
+        allow_nil? false
+        sensitive? true
+      end
+
+      run Sanctum.Accounts.User.Actions.RequestRegistration
+    end
+
     action :request_password_reset_token do
       description "Send password reset instructions to a user if they exist."
 

--- a/lib/sanctum/accounts/user.ex
+++ b/lib/sanctum/accounts/user.ex
@@ -188,6 +188,7 @@ defmodule Sanctum.Accounts.User do
                 strategy_name: :password, password_argument: :current_password}
 
       change {AshAuthentication.Strategy.Password.HashPasswordChange, strategy_name: :password}
+      change Sanctum.Accounts.User.Changes.NotifyPasswordChanged
     end
 
     read :sign_in_with_password do
@@ -321,6 +322,10 @@ defmodule Sanctum.Accounts.User do
     end
 
     update :reset_password_with_token do
+      # NotifyPasswordChanged adds an after_action hook, which can't run
+      # atomically.
+      require_atomic? false
+
       argument :reset_token, :string do
         allow_nil? false
         sensitive? true
@@ -350,6 +355,9 @@ defmodule Sanctum.Accounts.User do
 
       # Generates an authentication token for the user
       change AshAuthentication.GenerateTokenChange
+
+      # Security notification: the owner learns their password changed
+      change Sanctum.Accounts.User.Changes.NotifyPasswordChanged
     end
   end
 

--- a/lib/sanctum/accounts/user/actions/request_registration.ex
+++ b/lib/sanctum/accounts/user/actions/request_registration.ex
@@ -1,0 +1,99 @@
+defmodule Sanctum.Accounts.User.Actions.RequestRegistration do
+  @moduledoc """
+  Enumeration-safe registration: succeeds identically whether or not the
+  email already has an account, so the register form can never be used to
+  probe which emails exist.
+
+    * Email is free — runs `register_with_password`; the confirmation add-on
+      emails the confirmation link.
+    * Email is taken — no account is touched; the address gets a "you already
+      have an account" notice instead. Only the mailbox owner learns which
+      case occurred.
+
+  Timing parity: the taken path runs the hash provider's `simulate/0` so it
+  costs the same bcrypt work as the real registration's password hash. Both
+  emails deliver off the request path (see the senders) and share the same
+  rate limits, so neither the response body nor its latency distinguishes
+  the cases.
+
+  Input problems that are about the *input* (password too short, confirmation
+  mismatch) still surface as form errors — they reveal nothing about accounts.
+  """
+
+  use Ash.Resource.Actions.Implementation
+
+  alias Ash.ActionInput
+  alias Sanctum.Accounts.User
+
+  @impl true
+  def run(input, _opts, _context) do
+    email = ActionInput.get_argument(input, :email)
+    password = ActionInput.get_argument(input, :password)
+    confirmation = ActionInput.get_argument(input, :password_confirmation)
+
+    if password == confirmation do
+      request(email, password, confirmation)
+    else
+      {:error,
+       Ash.Error.Action.InvalidArgument.exception(
+         field: :password_confirmation,
+         message: "does not match password"
+       )}
+    end
+  end
+
+  defp request(email, password, confirmation) do
+    existing =
+      User
+      |> Ash.Query.for_read(:get_by_email, %{email: email})
+      |> Ash.read_one!(authorize?: false)
+
+    if existing do
+      notice_existing(email)
+    else
+      register(email, password, confirmation)
+    end
+  end
+
+  defp register(email, password, confirmation) do
+    User
+    |> Ash.Changeset.for_create(
+      :register_with_password,
+      %{email: email, password: password, password_confirmation: confirmation},
+      authorize?: false
+    )
+    |> Ash.create()
+    |> case do
+      {:ok, _user} ->
+        :ok
+
+      {:error, error} ->
+        # A race on the unique email between our lookup and the insert must
+        # not leak either — fold it into the taken path.
+        if taken_email_error?(error) do
+          notice_existing(email)
+        else
+          {:error, error}
+        end
+    end
+  end
+
+  defp notice_existing(email) do
+    strategy = AshAuthentication.Info.strategy!(User, :password)
+    strategy.hash_provider.simulate()
+
+    Sanctum.Accounts.User.Senders.SendRegistrationNoticeEmail.send(email)
+
+    :ok
+  end
+
+  defp taken_email_error?(%{errors: errors}) when is_list(errors) do
+    Enum.any?(errors, fn
+      %Ash.Error.Changes.InvalidAttribute{field: :email} -> true
+      %Ash.Error.Changes.InvalidChanges{fields: fields} -> :email in List.wrap(fields)
+      _other -> false
+    end)
+  end
+
+  defp taken_email_error?(_error), do: false
+end

--- a/lib/sanctum/accounts/user/changes/notify_password_changed.ex
+++ b/lib/sanctum/accounts/user/changes/notify_password_changed.ex
@@ -1,0 +1,17 @@
+defmodule Sanctum.Accounts.User.Changes.NotifyPasswordChanged do
+  @moduledoc """
+  After a successful password change, emails the account owner a security
+  notification (`SendPasswordChangedEmail`). Attached to every action that
+  writes `hashed_password` on an existing account.
+  """
+
+  use Ash.Resource.Change
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, fn _changeset, user ->
+      Sanctum.Accounts.User.Senders.SendPasswordChangedEmail.send(user.email)
+      {:ok, user}
+    end)
+  end
+end

--- a/lib/sanctum/accounts/user/senders/send_password_changed_email.ex
+++ b/lib/sanctum/accounts/user/senders/send_password_changed_email.ex
@@ -1,0 +1,43 @@
+defmodule Sanctum.Accounts.User.Senders.SendPasswordChangedEmail do
+  @moduledoc """
+  Security notification: tells the account owner their password was just
+  changed, so a hijacked reset (or a change they didn't make) doesn't go
+  unnoticed. Sent after `reset_password_with_token` and `change_password`.
+  """
+
+  use SanctumWeb, :verified_routes
+
+  import Swoosh.Email
+
+  alias Sanctum.Mailer
+
+  def send(email_address) do
+    recipient = to_string(email_address)
+
+    with :ok <- Sanctum.Accounts.AuthLimits.check_email(:password_changed, recipient) do
+      email =
+        new()
+        |> from({"Sanctum", "noreply@mail.sanctummc.com"})
+        |> to(recipient)
+        |> subject("Your Sanctum password was changed")
+        |> html_body(body())
+
+      Task.Supervisor.start_child(Sanctum.TaskSupervisor, fn ->
+        Mailer.deliver!(email)
+        Sanctum.Observability.auth_email_sent(:password_changed)
+      end)
+    end
+
+    :ok
+  end
+
+  defp body do
+    """
+    <p>The password for your Sanctum account was just changed, and any other
+    active sessions were signed out.</p>
+    <p>If this was you, there's nothing to do.</p>
+    <p>If it wasn't you, someone else may have access to your account —
+    <a href="#{url(~p"/reset")}">reset your password</a> now to lock them out.</p>
+    """
+  end
+end

--- a/lib/sanctum/accounts/user/senders/send_registration_notice_email.ex
+++ b/lib/sanctum/accounts/user/senders/send_registration_notice_email.ex
@@ -1,0 +1,48 @@
+defmodule Sanctum.Accounts.User.Senders.SendRegistrationNoticeEmail do
+  @moduledoc """
+  Tells an address that a registration was attempted but it already has an
+  account. Part of the enumeration-safe register flow: the *form* response is
+  identical either way, and this email — visible only to the mailbox owner —
+  is where the "you already have an account" truth is allowed to live.
+  """
+
+  use SanctumWeb, :verified_routes
+
+  import Swoosh.Email
+
+  alias Sanctum.Mailer
+
+  def send(email_address) do
+    recipient = to_string(email_address)
+
+    # Same silent skip as the other auth senders — a hammered address stops
+    # receiving mail, the requester sees nothing different.
+    with :ok <- Sanctum.Accounts.AuthLimits.check_email(:registration_notice, recipient) do
+      email =
+        new()
+        |> from({"Sanctum", "noreply@mail.sanctummc.com"})
+        |> to(recipient)
+        |> subject("You already have a Sanctum account")
+        |> html_body(body())
+
+      Task.Supervisor.start_child(Sanctum.TaskSupervisor, fn ->
+        Mailer.deliver!(email)
+        Sanctum.Observability.auth_email_sent(:registration_notice)
+      end)
+    end
+
+    :ok
+  end
+
+  defp body do
+    """
+    <p>Someone (hopefully you) tried to create a Sanctum account with this
+    email address — but it already has one.</p>
+    <p><a href="#{url(~p"/sign-in")}">Sign in here</a>. If you want to sign in
+    with a password and haven't set one, use
+    <a href="#{url(~p"/reset")}">forgot your password</a> to set it.</p>
+    <p>If this wasn't you, you can safely ignore this email — nothing has
+    changed.</p>
+    """
+  end
+end

--- a/lib/sanctum_web/auth_overrides.ex
+++ b/lib/sanctum_web/auth_overrides.ex
@@ -42,6 +42,18 @@ defmodule SanctumWeb.AuthOverrides do
   @input_class @input_base <> " border-line focus:border-primary"
   @input_error_class @input_base <> " border-error focus:border-error"
 
+  # Public accessors so SanctumWeb.AuthSignInLive's hand-rolled register page
+  # (which bypasses the override system) stays pixel-identical to the stock
+  # auth surfaces styled above.
+  def page_class, do: @page_class
+  def panel_class, do: @panel_class
+  def heading_class, do: @heading_class
+  def field_label_class, do: @field_label_class
+  def input_class, do: @input_class
+  def input_error_class, do: @input_error_class
+  def button_primary, do: @button_primary
+  def button_ghost, do: @button_ghost
+
   override SignInLive do
     set :root_class, @page_class
   end

--- a/lib/sanctum_web/auth_sign_in_live.ex
+++ b/lib/sanctum_web/auth_sign_in_live.ex
@@ -10,6 +10,12 @@ defmodule SanctumWeb.AuthSignInLive do
 
   use SanctumWeb, :live_view
 
+  # The stock auth components emit flash as a {:put_flash, ...} message to
+  # their parent LiveView; this hook (which the stock SignInLive gets from
+  # AshAuthentication.Phoenix.Web) turns it into real flash. Without it the
+  # reset form's "check your email" feedback silently vanishes.
+  on_mount AshAuthentication.Phoenix.Utils.Flash
+
   alias AshAuthentication.Phoenix.Components
   alias SanctumWeb.AuthOverrides
 
@@ -73,6 +79,7 @@ defmodule SanctumWeb.AuthSignInLive do
   def render(%{live_action: :register} = assigns) do
     ~H"""
     <div class={AuthOverrides.page_class()}>
+      <Layouts.flash_group flash={@flash} />
       <div class={AuthOverrides.panel_class()}>
         <div class="w-full pb-6 mb-6 border-b-2 border-neutral text-center">
           <.link navigate="/" class="font-bangers text-[40px] leading-none tracking-wide text-primary">
@@ -141,6 +148,7 @@ defmodule SanctumWeb.AuthSignInLive do
   def render(assigns) do
     ~H"""
     <div class={AuthOverrides.page_class()}>
+      <Layouts.flash_group flash={@flash} />
       <.live_component
         module={Components.SignIn}
         otp_app={@otp_app}

--- a/lib/sanctum_web/auth_sign_in_live.ex
+++ b/lib/sanctum_web/auth_sign_in_live.ex
@@ -1,0 +1,207 @@
+defmodule SanctumWeb.AuthSignInLive do
+  @moduledoc """
+  Drop-in replacement for `AshAuthentication.Phoenix.SignInLive` (wired via
+  `sign_in_route`'s `live_view:` option). The `:sign_in` and `:reset` actions
+  render the stock `Components.SignIn` exactly as the library LiveView does;
+  `:register` renders our own form backed by the enumeration-safe
+  `:request_registration` action, which responds "check your email" whether
+  or not the address already has an account.
+  """
+
+  use SanctumWeb, :live_view
+
+  alias AshAuthentication.Phoenix.Components
+  alias SanctumWeb.AuthOverrides
+
+  @impl true
+  def mount(_params, session, socket) do
+    overrides = Map.get(session, "overrides", [AshAuthentication.Phoenix.Overrides.Default])
+
+    socket =
+      socket
+      |> assign(overrides: overrides)
+      |> assign_new(:otp_app, fn -> nil end)
+      |> assign(:path, session["path"] || "/")
+      |> assign(:reset_path, session["reset_path"])
+      |> assign(:register_path, session["register_path"])
+      |> assign(:current_tenant, session["tenant"])
+      |> assign(:resources, session["resources"])
+      |> assign(:context, session["context"] || %{})
+      |> assign(:auth_routes_prefix, session["auth_routes_prefix"])
+      |> assign(:gettext_fn, session["gettext_fn"])
+      |> assign(:sent?, false)
+      |> assign_register_form()
+
+    {:ok, socket}
+  end
+
+  defp assign_register_form(socket) do
+    form =
+      AshPhoenix.Form.for_action(Sanctum.Accounts.User, :request_registration,
+        as: "user",
+        authorize?: false
+      )
+
+    assign(socket, :form, to_form(form))
+  end
+
+  @impl true
+  def handle_params(_params, _uri, socket), do: {:noreply, socket}
+
+  @impl true
+  def handle_event("validate", %{"user" => params}, socket) do
+    {:noreply,
+     assign(socket, :form, to_form(AshPhoenix.Form.validate(socket.assigns.form.source, params)))}
+  end
+
+  def handle_event("submit", %{"user" => params}, socket) do
+    # :request_registration returns nothing, so a successful submit is a bare
+    # :ok rather than the {:ok, result} shape of record-returning actions.
+    case AshPhoenix.Form.submit(socket.assigns.form.source, params: params) do
+      {:error, form} ->
+        {:noreply, assign(socket, :form, to_form(form))}
+
+      _ok ->
+        {:noreply,
+         socket
+         |> assign(:sent?, true)
+         |> assign(:submitted_email, params["email"])}
+    end
+  end
+
+  @impl true
+  def render(%{live_action: :register} = assigns) do
+    ~H"""
+    <div class={AuthOverrides.page_class()}>
+      <div class={AuthOverrides.panel_class()}>
+        <div class="w-full pb-6 mb-6 border-b-2 border-neutral text-center">
+          <.link navigate="/" class="font-bangers text-[40px] leading-none tracking-wide text-primary">
+            SANCTUM
+          </.link>
+        </div>
+
+        <%= if @sent? do %>
+          <h2 class={AuthOverrides.heading_class()}>Check your email</h2>
+          <p class="font-barlow text-sm text-base-content/80">
+            We've sent a link to <span class="font-semibold">{@submitted_email}</span> to
+            finish setting up your account. It expires in three days.
+          </p>
+          <.link navigate={@path} class={[AuthOverrides.button_ghost(), "mt-6"]}>
+            Back to sign in
+          </.link>
+        <% else %>
+          <h2 class={AuthOverrides.heading_class()}>Register</h2>
+
+          <.form for={@form} phx-change="validate" phx-submit="submit" class="mt-2 mb-2">
+            <.register_input field={@form[:email]} type="email" label="Email" autocomplete="email" />
+            <.register_input
+              field={@form[:password]}
+              type="password"
+              label="Password"
+              autocomplete="new-password"
+            />
+            <.register_input
+              field={@form[:password_confirmation]}
+              type="password"
+              label="Password Confirmation"
+              autocomplete="new-password"
+            />
+
+            <div class="flex flex-row justify-between content-between mt-3">
+              <.auth_link navigate={@reset_path || "/reset"}>Forgot your password?</.auth_link>
+              <.auth_link navigate={@path}>Already have an account?</.auth_link>
+            </div>
+
+            <button type="submit" class={[AuthOverrides.button_primary(), "mt-5"]}>
+              Register
+            </button>
+          </.form>
+
+          <div class="relative my-5">
+            <div class="w-full border-t-2 border-neutral"></div>
+            <div class="absolute inset-0 flex items-center justify-center -top-2">
+              <span class="px-3 bg-base-200 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+                or
+              </span>
+            </div>
+          </div>
+
+          <div class="w-full mt-2 mb-2">
+            <a href={google_path(@auth_routes_prefix)} class={AuthOverrides.button_ghost()}>
+              <Components.OAuth2.icon icon={:google} overrides={@overrides} icon_src={nil} />
+              Sign in with Google
+            </a>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class={AuthOverrides.page_class()}>
+      <.live_component
+        module={Components.SignIn}
+        otp_app={@otp_app}
+        live_action={@live_action}
+        path={@path}
+        auth_routes_prefix={@auth_routes_prefix}
+        resources={@resources}
+        reset_path={@reset_path}
+        register_path={@register_path}
+        id="sign-in"
+        overrides={@overrides}
+        current_tenant={@current_tenant}
+        context={@context}
+        gettext_fn={@gettext_fn}
+      />
+    </div>
+    """
+  end
+
+  attr :field, Phoenix.HTML.FormField, required: true
+  attr :type, :string, required: true
+  attr :label, :string, required: true
+  attr :autocomplete, :string, required: true
+
+  defp register_input(assigns) do
+    ~H"""
+    <div class="mt-3">
+      <label for={@field.id} class={AuthOverrides.field_label_class()}>{@label}</label>
+      <input
+        type={@type}
+        name={@field.name}
+        id={@field.id}
+        value={@field.value}
+        autocomplete={@autocomplete}
+        class={
+          if @field.errors == [],
+            do: AuthOverrides.input_class(),
+            else: AuthOverrides.input_error_class()
+        }
+      />
+      <ul :if={@field.errors != []} class="font-barlow text-sm text-error mt-2 space-y-1">
+        <li :for={error <- @field.errors}>{translate_error(error)}</li>
+      </ul>
+    </div>
+    """
+  end
+
+  slot :inner_block, required: true
+  attr :navigate, :string, required: true
+
+  defp auth_link(assigns) do
+    ~H"""
+    <.link
+      navigate={@navigate}
+      class="flex-none px-2 first:pl-0 last:pr-0 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-primary hover:underline underline-offset-4"
+    >
+      {render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
+  defp google_path(nil), do: "/auth/user/google"
+  defp google_path(prefix), do: prefix <> "/user/google"
+end

--- a/lib/sanctum_web/controllers/auth_controller.ex
+++ b/lib/sanctum_web/controllers/auth_controller.ex
@@ -2,6 +2,18 @@ defmodule SanctumWeb.AuthController do
   use SanctumWeb, :controller
   use AshAuthentication.Phoenix.Controller
 
+  # A completed password reset intentionally does NOT start a session: the
+  # log_out_everywhere add-on (apply_on_password_change?) revokes every token
+  # the moment the password changes, so "signed in" here would be a half-state
+  # the next request drops anyway. Land on sign-in with the new password ready.
+  def success(conn, {:password, :reset} = activity, _user, _token) do
+    Sanctum.Observability.auth_success(activity)
+
+    conn
+    |> put_flash(:info, "Your password has been reset. Sign in with your new password.")
+    |> redirect(to: ~p"/sign-in")
+  end
+
   def success(conn, activity, user, _token) do
     Sanctum.Observability.auth_success(activity)
     return_to = get_session(conn, :return_to) || ~p"/"
@@ -9,7 +21,6 @@ defmodule SanctumWeb.AuthController do
     message =
       case activity do
         {:confirm_new_user, :confirm} -> "Your email address has now been confirmed"
-        {:password, :reset} -> "Your password has successfully been reset"
         _ -> "You are now signed in"
       end
 

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -131,10 +131,13 @@ defmodule SanctumWeb.Router do
                      AshAuthentication.Phoenix.Overrides.Default
                    ]
 
-    # Remove these if you'd like to use your own authentication views
+    # Custom live_view: /register is our enumeration-safe email-first flow
+    # (SanctumWeb.AuthSignInLive) instead of the stock create-or-error form;
+    # sign-in and reset render the stock component unchanged.
     sign_in_route register_path: "/register",
                   reset_path: "/reset",
                   auth_routes_prefix: "/auth",
+                  live_view: SanctumWeb.AuthSignInLive,
                   on_mount: [{SanctumWeb.LiveUserAuth, :live_no_user}],
                   overrides: [
                     SanctumWeb.AuthOverrides,

--- a/test/sanctum/accounts/password_reset_test.exs
+++ b/test/sanctum/accounts/password_reset_test.exs
@@ -1,0 +1,34 @@
+defmodule Sanctum.Accounts.PasswordResetTest do
+  # Shares the node-wide rate-limit ETS table with other tests.
+  use Sanctum.DataCase, async: false
+
+  import Swoosh.TestAssertions
+
+  alias AshAuthentication.{Info, Strategy}
+  alias Sanctum.Accounts.User
+
+  test "completing a reset sends the password-changed security notification" do
+    email = "reset-notify-#{System.unique_integer([:positive])}@example.com"
+
+    user =
+      Ash.Seed.seed!(User, %{
+        email: email,
+        confirmed_at: DateTime.utc_now(),
+        hashed_password: Bcrypt.hash_pwd_salt("oldPassword1!")
+      })
+
+    strategy = Info.strategy!(User, :password)
+    {:ok, token} = AshAuthentication.Strategy.Password.reset_token_for(strategy, user)
+
+    assert {:ok, _user} =
+             Strategy.action(strategy, :reset, %{
+               "reset_token" => token,
+               "password" => "newPassword2!",
+               "password_confirmation" => "newPassword2!"
+             })
+
+    assert_email_sent(fn sent ->
+      sent.subject == "Your Sanctum password was changed" and {"", email} in sent.to
+    end)
+  end
+end

--- a/test/sanctum/accounts/request_registration_test.exs
+++ b/test/sanctum/accounts/request_registration_test.exs
@@ -1,0 +1,73 @@
+defmodule Sanctum.Accounts.RequestRegistrationTest do
+  # Shares the node-wide rate-limit ETS table with other tests.
+  use Sanctum.DataCase, async: false
+
+  import Sanctum.AccountsFixtures
+  import Swoosh.TestAssertions
+
+  alias Sanctum.Accounts.User
+
+  defp unique_email, do: "register-#{System.unique_integer([:positive])}@example.com"
+
+  defp request(email, password, confirmation) do
+    User
+    |> Ash.ActionInput.for_action(:request_registration, %{
+      email: email,
+      password: password,
+      password_confirmation: confirmation
+    })
+    |> Ash.run_action(authorize?: false)
+  end
+
+  defp get_user(email) do
+    User
+    |> Ash.Query.for_read(:get_by_email, %{email: email})
+    |> Ash.read_one!(authorize?: false)
+  end
+
+  test "free email: registers an unconfirmed user and sends the confirmation email" do
+    email = unique_email()
+
+    assert :ok = request(email, "goodPassword1!", "goodPassword1!")
+
+    user = get_user(email)
+    assert user
+    assert user.confirmed_at == nil
+    assert user.hashed_password
+
+    assert_email_sent(fn sent ->
+      sent.subject == "Confirm your email address" and {"", email} in sent.to
+    end)
+  end
+
+  test "taken email: creates nothing and sends the already-have-an-account notice" do
+    email = unique_email()
+    existing = user_fixture(email: email)
+
+    assert :ok = request(email, "attackerPass1!", "attackerPass1!")
+
+    user = get_user(email)
+    assert user.id == existing.id
+    # The existing account is untouched — no password was set.
+    assert user.hashed_password == nil
+
+    assert_email_sent(fn sent ->
+      sent.subject == "You already have a Sanctum account" and {"", email} in sent.to
+    end)
+  end
+
+  test "both outcomes return :ok — the response can't distinguish them" do
+    taken = unique_email()
+    user_fixture(email: taken)
+
+    assert request(unique_email(), "goodPassword1!", "goodPassword1!") ==
+             request(taken, "goodPassword1!", "goodPassword1!")
+  end
+
+  test "input problems still error: confirmation mismatch and short password" do
+    assert {:error, %Ash.Error.Invalid{}} =
+             request(unique_email(), "goodPassword1!", "different1!")
+
+    assert {:error, %Ash.Error.Invalid{}} = request(unique_email(), "short", "short")
+  end
+end


### PR DESCRIPTION
## Summary

Stacked on #208 (which stacks on #204). Closes the last account-enumeration oracle in the auth surfaces: the stock register form errored with *"has already been taken"* for existing emails — with a timing side channel to match (duplicate check ~1ms vs. a real registration's bcrypt hash).

`/register` is now an **email-first flow**: the form always responds *"Check your email"*, and the truth lives only in the email — which only the mailbox owner can read.

| Case | What happens | What the requester sees |
|---|---|---|
| Email free | `register_with_password` runs, confirmation email sent | "Check your email" |
| Email taken | Nothing touched; address gets a *"you already have an account"* notice pointing at sign-in + the reset flow | "Check your email" (identical) |

### Mechanics

- **`SanctumWeb.AuthSignInLive`** replaces the stock `SignInLive` via `sign_in_route`'s `live_view:` option — `:sign_in`/`:reset` still render the stock component (all overrides intact); only `:register` is custom, pixel-matched via new public accessors on `AuthOverrides`.
- **`:request_registration`** generic action returns `:ok` for both cases; unique-index races between lookup and insert fold into the taken path instead of leaking the constraint error.
- **Timing parity**: taken path runs `hash_provider.simulate()` to match the real registration's bcrypt cost; both emails deliver async and share the per-recipient/global rate limits from #208.
- Input-only errors (short password, confirmation mismatch) still render on the form — they reveal nothing about accounts.

This also answers "how do I add a password to my Google account": the notice email routes people to the reset flow, which sets a password on any existing account (verified end-to-end — Google-only user + reset = both methods work on one user record).

## Test plan

- [x] 4 new tests: free-email registers + confirmation email; taken-email touches nothing + notice email; both return identical `:ok`; input errors still surface
- [x] Browser-verified both paths render the identical "Check your email" panel; emails confirmed in /dev/mailbox
- [x] Full suite green (303 tests), `mix ck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)