### PR TITLE
feat(search): search-syntax help page linked from the query inputs

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -835,3 +835,33 @@ textarea::placeholder {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Search-syntax help page tables (SearchHelpLive) */
+.qh-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'Barlow', sans-serif;
+  font-size: 14px;
+}
+.qh-table th,
+.qh-table td {
+  border: 1px solid var(--color-line);
+  padding: 0.45rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+.qh-table td:first-child {
+  white-space: nowrap;
+}
+.qh-table thead th {
+  background: var(--color-base-300);
+  font-family: 'Anton', sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 12px;
+  color: color-mix(in srgb, var(--color-base-content) 70%, transparent);
+}
+.qh-table tbody td {
+  color: color-mix(in srgb, var(--color-base-content) 80%, transparent);
+}

--- a/lib/sanctum_web/components/query_input.ex
+++ b/lib/sanctum_web/components/query_input.ex
@@ -25,9 +25,16 @@ defmodule SanctumWeb.Components.QueryInput do
   attr :registry, :atom, required: true, doc: "Sanctum.Search.Registry module"
   attr :diagnostics, :list, default: []
 
+  attr :help_path, :string,
+    default: nil,
+    doc: "when set, renders a “?” link to the search-syntax reference"
+
   def query_input(assigns) do
     assigns = assign(assigns, :field_names, field_names(assigns.registry))
 
+    # The mirror div must keep identical padding to the input or the
+    # highlight overlay drifts out of alignment — pr-9 on both reserves room
+    # for the help link.
     ~H"""
     <div class="relative min-w-[260px] flex-1">
       <div id={@id} phx-hook="QueryInput" data-fields={Jason.encode!(@field_names)}>
@@ -39,7 +46,7 @@ defmodule SanctumWeb.Components.QueryInput do
             id={@id <> "-mirror"}
             phx-update="ignore"
             aria-hidden="true"
-            class="qi-mirror pointer-events-none absolute inset-0 overflow-hidden whitespace-pre px-3.5 py-2.5 pl-[38px] font-barlow text-base text-base-content sm:text-[15px]"
+            class="qi-mirror pointer-events-none absolute inset-0 overflow-hidden whitespace-pre py-2.5 pl-[38px] pr-9 font-barlow text-base text-base-content sm:text-[15px]"
           >
           </div>
           <input
@@ -55,8 +62,17 @@ defmodule SanctumWeb.Components.QueryInput do
             aria-expanded="false"
             aria-autocomplete="list"
             aria-controls={@id <> "-listbox"}
-            class="relative z-10 w-full bg-transparent px-3.5 py-2.5 pl-[38px] font-barlow text-base text-transparent caret-primary outline-none placeholder:text-base-content/35 sm:text-[15px]"
+            class="relative z-10 w-full bg-transparent py-2.5 pl-[38px] pr-9 font-barlow text-base text-transparent caret-primary outline-none placeholder:text-base-content/35 sm:text-[15px]"
           />
+          <.link
+            :if={@help_path}
+            navigate={@help_path}
+            title="Search syntax help"
+            aria-label="Search syntax help"
+            class="absolute right-2.5 top-1/2 z-20 grid size-[18px] -translate-y-1/2 place-items-center rounded-full border border-base-content/30 font-barlow text-[11px] font-bold text-base-content/45 hover:border-primary hover:text-primary"
+          >
+            ?
+          </.link>
         </div>
         <div
           id={@id <> "-listbox"}

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -63,6 +63,7 @@ defmodule SanctumWeb.CardLive.Pool do
             placeholder="Search cards — try aspect:aggression cost<=2 type:ally"
             registry={Sanctum.Search.CardFields}
             diagnostics={@search_diagnostics}
+            help_path={~p"/search-help" <> "#cards"}
           />
         </form>
         <div class="flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -55,6 +55,7 @@ defmodule SanctumWeb.DeckLive.Index do
             placeholder="Search decks — try hero:spider aspect:justice cards>=45"
             registry={Sanctum.Search.DeckFields}
             diagnostics={@search_diagnostics}
+            help_path={~p"/search-help" <> "#decks"}
           />
         </form>
         <div class="flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">

--- a/lib/sanctum_web/live/search_help_live.ex
+++ b/lib/sanctum_web/live/search_help_live.ex
@@ -1,0 +1,218 @@
+defmodule SanctumWeb.SearchHelpLive do
+  @moduledoc """
+  Reference page for the advanced search query language (`Sanctum.Search`).
+
+  The field tables are generated from the live registries
+  (`Sanctum.Search.CardFields` / `DeckFields`), so this page can never drift
+  from what the language actually supports. Every example is a link that runs
+  the query.
+  """
+
+  use SanctumWeb, :live_view
+
+  alias Sanctum.Search.{CardFields, DeckFields, Field}
+
+  @op_symbols [eq: ":", neq: "!=", lt: "<", gt: ">", lte: "<=", gte: ">="]
+
+  @card_examples [
+    {"spider", "cards whose name or subtitle contains “spider” — no syntax needed"},
+    {"aspect:aggression cost<=2 type:ally", "cheap Aggression allies"},
+    {"t:ally atk>=2 -trait:avenger", "hard-hitting allies that aren't Avengers"},
+    {~s(x:"draw a card" a:justice|leadership), "card draw in Justice or Leadership"},
+    {"is:unique hp>=10", "unique characters with 10+ health"},
+    {"(t:minion or t:treachery) boost>=2", "encounter cards with big boost"}
+  ]
+
+  @deck_examples [
+    {"hero:spider aspect:justice", "Justice decks for Spider-heroes"},
+    {~s(card:"boot camp" cards>=40), "40+ card decks running Boot Camp"},
+    {"aspect:basic", "decks with no aspect cards"}
+  ]
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app current_user={@current_user} flash={@flash}>
+      <.header>
+        Search Syntax
+        <:subtitle>
+          The card pool and deck browser share a query language: type plain words to
+          search names, or combine field filters for precise questions. Everything is
+          case-insensitive, and partial or imperfect queries still return results.
+        </:subtitle>
+      </.header>
+
+      <div class="max-w-4xl space-y-8">
+        <section>
+          <.section_title>Basics</.section_title>
+          <div class="space-y-2.5 font-barlow text-[15px] leading-relaxed text-base-content/85">
+            <p>
+              A bare word like <.q c="spider" /> searches card names and subtitles
+              (deck titles and heroes on the deck browser). Use <.q c={~s("quotes")} />
+              for multi-word phrases.
+            </p>
+            <p>
+              A filter is <span class="font-semibold">field, operator, value</span>:
+              <.q c="cost<=2" /> or <.q c="aspect:justice" />. The <.q c=":" /> and <.q c="=" />
+              operators both mean “equals”; numeric fields
+              also take <.q c="!=" />, <.q c="<" />, <.q c=">" />, <.q c="<=" />, and
+              <.q c=">=" />. Most fields have a short alias — <.q c="a:justice" /> is the same as
+              <.q c="aspect:justice" />.
+            </p>
+            <p>
+              Values can be shortened to any unambiguous prefix: <.q c="t:all" /> means
+              <.q c="type:ally" />.
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <.section_title>Combining terms</.section_title>
+          <table class="qh-table">
+            <tbody>
+              <tr>
+                <td><.q c="a:justice cost<=2" /></td>
+                <td>space between terms means AND (writing <.q c="and" /> also works)</td>
+              </tr>
+              <tr>
+                <td><.q c="t:ally or t:event" /></td>
+                <td><.q c="or" /> matches either side</td>
+              </tr>
+              <tr>
+                <td><.q c="(t:ally or t:event) cost:1" /></td>
+                <td>parentheses group</td>
+              </tr>
+              <tr>
+                <td><.q c="-trait:avenger" /></td>
+                <td>
+                  a leading <.q c="-" /> (or the word <.q c="not" />) excludes matches
+                </td>
+              </tr>
+              <tr>
+                <td><.q c="a:justice|leadership" /></td>
+                <td><.q c="|" /> tries several values for one field</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="cards">
+          <.section_title>Card fields</.section_title>
+          <.fields_table fields={@card_fields} base_path="/cards" />
+        </section>
+
+        <section id="decks">
+          <.section_title>Deck fields</.section_title>
+          <.fields_table fields={@deck_fields} base_path="/decks" />
+        </section>
+
+        <section>
+          <.section_title>Example searches</.section_title>
+          <table class="qh-table">
+            <tbody>
+              <tr :for={{query, description} <- @card_examples}>
+                <td><.try_link query={query} base_path="/cards" /></td>
+                <td>{description}</td>
+              </tr>
+              <tr :for={{query, description} <- @deck_examples}>
+                <td><.try_link query={query} base_path="/decks" /></td>
+                <td>{description} <span class="text-base-content/45">(decks)</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  defp section_title(assigns) do
+    ~H"""
+    <h2 class="mb-2.5 font-anton text-[19px] uppercase tracking-[0.05em] text-primary">
+      {render_slot(@inner_block)}
+    </h2>
+    """
+  end
+
+  # An inline query snippet.
+  defp q(assigns) do
+    ~H"""
+    <code class="whitespace-nowrap bg-base-300 px-1.5 py-0.5 font-mono text-[13px] text-base-content">{@c}</code>
+    """
+  end
+
+  # A query snippet that links to the search it demonstrates.
+  defp try_link(assigns) do
+    ~H"""
+    <.link
+      navigate={"#{@base_path}?#{URI.encode_query(query: @query)}"}
+      class="whitespace-nowrap bg-base-300 px-1.5 py-0.5 font-mono text-[13px] text-secondary underline decoration-secondary/40 underline-offset-2 hover:text-primary"
+    >
+      {@query}
+    </.link>
+    """
+  end
+
+  defp fields_table(assigns) do
+    ~H"""
+    <table class="qh-table">
+      <thead>
+        <tr>
+          <th>Field</th>
+          <th>Matches</th>
+          <th>Operators</th>
+          <th>Example</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr :for={field <- @fields}>
+          <td>
+            <span class="font-semibold text-base-content">{field.name}</span>
+            <span :for={alias_name <- field.aliases} class="ml-1.5 text-base-content/50">
+              {alias_name}
+            </span>
+          </td>
+          <td class="!whitespace-normal">{matches(field)}</td>
+          <td class="whitespace-nowrap font-mono text-[12.5px]">{ops(field)}</td>
+          <td>
+            <.try_link :if={field.example} query={field.example} base_path={@base_path} />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:page_title, "Search Syntax")
+      |> assign(:card_fields, CardFields.fields())
+      |> assign(:deck_fields, DeckFields.fields())
+      |> assign(:card_examples, @card_examples)
+      |> assign(:deck_examples, @deck_examples)
+
+    {:ok, socket}
+  end
+
+  # What a field matches against — enum values verbatim, or a description for
+  # free-text/numeric fields (mentioning autocomplete when values come from
+  # the catalog).
+  defp matches(%Field{kind: kind, values: values}) when kind in [:enum, :flag, :boolean],
+    do: Enum.join(values, ", ")
+
+  defp matches(%Field{kind: :text, values_fun: nil, hint: hint}), do: hint || "any text"
+
+  defp matches(%Field{kind: :text, hint: hint}),
+    do: "#{hint || "any text"} — autocompletes from the catalog"
+
+  defp matches(%Field{kind: :stat}), do: "number (the printed value)"
+  defp matches(%Field{kind: :integer}), do: "number"
+
+  defp ops(%Field{ops: ops}) do
+    @op_symbols
+    |> Enum.filter(fn {op, _symbol} -> op in ops end)
+    |> Enum.map_join("  ", fn {_op, symbol} -> symbol end)
+  end
+end

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -78,6 +78,9 @@ defmodule SanctumWeb.Router do
       live "/decks", DeckLive.Index, :index
       live "/decks/:id", DeckLive.Show, :show
 
+      # Reference page for the card/deck search query language.
+      live "/search-help", SearchHelpLive, :index
+
       # Public "Flavor Town" flavor-text guessing mini-game.
       live "/flavor-town", GuessLive.Play, :index
 

--- a/test/sanctum_web/live/search_help_live_test.exs
+++ b/test/sanctum_web/live/search_help_live_test.exs
@@ -1,0 +1,34 @@
+defmodule SanctumWeb.SearchHelpLiveTest do
+  @moduledoc false
+
+  use SanctumWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Sanctum.Search.{CardFields, DeckFields}
+
+  test "renders every registered card and deck field", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/search-help")
+
+    for field <- CardFields.fields() ++ DeckFields.fields() do
+      assert html =~ field.name
+    end
+  end
+
+  test "field examples link to live searches", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/search-help")
+
+    assert html =~ "/cards?query="
+    assert html =~ "/decks?query="
+  end
+
+  test "the card pool links to the help page", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/cards")
+    assert html =~ "/search-help#cards"
+  end
+
+  test "the deck browser links to the help page", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/decks")
+    assert html =~ "/search-help#decks"
+  end
+end


### PR DESCRIPTION
## What

Follow-on to #211: adds `/search-help`, a reference page for the search query language, linked from a small "?" button inside both query inputs (the card pool's links to `#cards`, the deck browser's to `#decks`).

## Contents

- **Basics** — bare-word search, `field op value` structure, `:` vs `=`, comparison operators, aliases, unique-prefix values
- **Combining terms** — implicit AND, `or`, parentheses, `-`/`NOT` negation, `|` value alternatives
- **Card fields / Deck fields tables** — generated from the `CardFields`/`DeckFields` registries at render time, so field names, aliases, operators, and enum values always match what the parser and autocomplete actually accept; the docs structurally can't drift as fields are added
- **Example searches** — curated queries with plain-language descriptions

Every example on the page — including each field's — is a link that runs the query against `/cards` or `/decks`.

## Notes

- The "?" link required matching right padding on both the input and its highlight mirror — any padding mismatch drifts the syntax-coloring overlay out of alignment.
- Route lives in the public catalog section of the router (`live "/search-help", SearchHelpLive, :index`).

## Testing

- 4 new LiveView tests (every registered field renders, example links present, both browse pages link to the help page); full suite 314 green, `mix ck` clean.
- Verified in the browser: on-theme rendering, anchor scroll from the "?" links, and example links executing their searches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)