### PR TITLE
feat(ui): full-width search with counts below on deck index and card pool

### DIFF
--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -54,8 +54,8 @@ defmodule SanctumWeb.CardLive.Pool do
       </.header>
 
       <!-- controls -->
-      <div class="mb-3.5 flex flex-wrap items-center gap-2.5">
-        <form id="card-search" phx-change="search" class="flex min-w-[260px] flex-1">
+      <div class="mb-3.5">
+        <form id="card-search" phx-change="search" class="flex w-full">
           <.query_input
             id="card-query"
             value={@query}
@@ -66,7 +66,7 @@ defmodule SanctumWeb.CardLive.Pool do
             help_path={~p"/search-help" <> "#cards"}
           />
         </form>
-        <div class="flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
+        <div class="mt-2 flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
           <.icon
             :if={@loading?}
             name="hero-arrow-path"

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -46,8 +46,8 @@ defmodule SanctumWeb.DeckLive.Index do
       </.header>
 
       <!-- search + count -->
-      <div class="mb-3 flex flex-wrap items-center gap-2.5">
-        <form id="deck-search" phx-change="search" class="flex min-w-[260px] flex-1">
+      <div class="mb-3">
+        <form id="deck-search" phx-change="search" class="flex w-full">
           <.query_input
             id="deck-query"
             value={@query}
@@ -58,7 +58,7 @@ defmodule SanctumWeb.DeckLive.Index do
             help_path={~p"/search-help" <> "#decks"}
           />
         </form>
-        <div class="flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
+        <div class="mt-2 flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
           <.icon
             :if={@loading?}
             name="hero-arrow-path"


### PR DESCRIPTION
On `/decks` and `/cards`, the search input now spans the full content width on its own row, and the results / total count line (including the loading spinner state) moves beneath it instead of sitting to its right. Sort and filter pills are unchanged.

Verified visually against the running dev server on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)