### PR TITLE
ci: scan full git history for secrets with gitleaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,23 @@ jobs:
       - name: Run Dialyzer
         run: mix dialyzer --format github
 
+  gitleaks:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history so gitleaks scans every commit, not just the checkout
+          fetch-depth: 0
+
+      # Uses .gitleaks.toml at the repo root (allowlists the known-benign
+      # Phoenix dev/test keys that live in history)
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   lint:
     name: Formatting, Credo, and Unused Deps
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+# Gitleaks config — extends the default ruleset.
+# CI runs this over the full git history (see the gitleaks job in ci.yml).
+
+[extend]
+useDefault = true
+
+# Known non-secret values that live permanently in git history: the
+# Phoenix-generated dev/test secret_key_base + token_signing_secret
+# (committed by convention, never used in prod — prod reads runtime.exs/env)
+# and the fixed local-dev deploy-notice token. Allowlisted by exact value so
+# the files themselves stay covered by future scans.
+[allowlist]
+description = "Phoenix dev/test keys and dev placeholder tokens"
+regexTarget = "secret"
+regexes = [
+  '''r6twl/k5iX61kat0T5NGGiBLyDLjrPl/bWxCdGF/ZvYveZAeqDd22krsvlKcXtIc''',
+  '''Wh7ljKd3a5as9YkJ5V6y4eOptlWGPAkJSsNN/rTVG0SoiRxhR3pAKYR4etZadVXc''',
+  '''Ng9tUOyxnipHxWoTtOyIQ2F/ZTJ45\+Vv''',
+  '''dev-deploy-notice-token''',
+]


### PR DESCRIPTION
## Summary

Adds a **gitleaks** job to CI that scans the entire git history (`fetch-depth: 0`) for leaked credentials on every push/PR.

Follows a full audit of the repo's history (all refs + all 2,878 blobs in the object store): **no real secrets have ever been committed.** The only detector hits were the Phoenix-generated dev/test `secret_key_base` values, the dev `token_signing_secret`, and the literal `dev-deploy-notice-token` placeholder — all committed by convention and never used in prod.

A repo-root `.gitleaks.toml` extends the default ruleset and allowlists those four strings **by exact value** (not by file path), so `config/dev.exs`/`config/test.exs` remain fully covered by future scans.

## Verification

- `gitleaks git --log-opts="--all" --config .gitleaks.toml` → 318 commits scanned, no leaks
- Planted a fake GitHub PAT in a scratch dir and confirmed the config still detects it (i.e., the allowlist doesn't over-suppress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)