### PR TITLE
fix(ui): swap in short search placeholders on mobile

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,6 +29,7 @@ import CardDrag from "./hooks/card-drag";
 import DragDrop from "./hooks/drag-drop";
 import LayoutHand from "./hooks/layout-hand";
 import QueryInput from "./hooks/query-input";
+import ResponsivePlaceholder from "./hooks/responsive-placeholder";
 import ScrollRestore from "./hooks/scroll-restore";
 
 // Sentry config arrives via meta tags rendered only when a DSN is configured
@@ -50,7 +51,7 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, CardDrag, DragDrop, LayoutHand, QueryInput, ScrollRestore},
+  hooks: {...colocatedHooks, CardDrag, DragDrop, LayoutHand, QueryInput, ResponsivePlaceholder, ScrollRestore},
 })
 
 // Uncheck the daisyUI drawer toggle when a sidebar link is clicked, so the

--- a/assets/js/hooks/responsive-placeholder.js
+++ b/assets/js/hooks/responsive-placeholder.js
@@ -1,0 +1,27 @@
+// Swaps an input's placeholder below Tailwind's `sm` breakpoint (640px):
+// the server-rendered `placeholder` attribute holds the full desktop hint,
+// `data-placeholder-short` the mobile variant that fits a narrow input.
+const mq = window.matchMedia("(min-width: 640px)")
+
+const ResponsivePlaceholder = {
+  mounted() {
+    this.full = this.el.getAttribute("placeholder") || ""
+    this.apply = () => {
+      const short = this.el.dataset.placeholderShort
+      this.el.setAttribute("placeholder", !mq.matches && short ? short : this.full)
+    }
+    mq.addEventListener("change", this.apply)
+    this.apply()
+  },
+
+  updated() {
+    // LiveView patches restore the server-rendered (full) placeholder.
+    this.apply()
+  },
+
+  destroyed() {
+    mq.removeEventListener("change", this.apply)
+  },
+}
+
+export default ResponsivePlaceholder

--- a/lib/sanctum_web/components/query_input.ex
+++ b/lib/sanctum_web/components/query_input.ex
@@ -22,6 +22,11 @@ defmodule SanctumWeb.Components.QueryInput do
   attr :value, :string, default: ""
   attr :name, :string, default: "query"
   attr :placeholder, :string, default: "Search…"
+
+  attr :placeholder_short, :string,
+    default: nil,
+    doc: "shorter placeholder swapped in below the `sm` breakpoint (ResponsivePlaceholder hook)"
+
   attr :registry, :atom, required: true, doc: "Sanctum.Search.Registry module"
   attr :diagnostics, :list, default: []
 
@@ -51,6 +56,7 @@ defmodule SanctumWeb.Components.QueryInput do
           </div>
           <input
             type="text"
+            id={@id <> "-input"}
             name={@name}
             value={@value}
             phx-debounce="200"
@@ -58,6 +64,8 @@ defmodule SanctumWeb.Components.QueryInput do
             spellcheck="false"
             autocapitalize="off"
             placeholder={@placeholder}
+            phx-hook={@placeholder_short && "ResponsivePlaceholder"}
+            data-placeholder-short={@placeholder_short}
             role="combobox"
             aria-expanded="false"
             aria-autocomplete="list"

--- a/lib/sanctum_web/live/browse_live/index.ex
+++ b/lib/sanctum_web/live/browse_live/index.ex
@@ -136,11 +136,14 @@ defmodule SanctumWeb.BrowseLive.Index do
       <form id="browse-search" phx-change="search" class="mb-6 flex min-w-[260px]">
         <input
           type="search"
+          id="browse-search-input"
           name="query"
           value={@query}
           autocomplete="off"
           phx-debounce="150"
           placeholder="Search products and sets — try “spider”, “kang”, or “bomb scare”"
+          phx-hook="ResponsivePlaceholder"
+          data-placeholder-short="Search products and sets — try “kang”"
           class="min-h-[44px] w-full border-[2.5px] border-line bg-black px-3 py-2 font-barlow-condensed text-base font-bold uppercase tracking-[0.04em] text-base-content outline-none placeholder:normal-case placeholder:font-normal placeholder:text-base-content/40 focus:border-primary sm:min-h-0 sm:text-[14px]"
         />
       </form>

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -61,6 +61,7 @@ defmodule SanctumWeb.CardLive.Pool do
             value={@query}
             name="query"
             placeholder="Search cards — try aspect:aggression cost<=2 type:ally"
+            placeholder_short="Search cards — try cost<=2"
             registry={Sanctum.Search.CardFields}
             diagnostics={@search_diagnostics}
             help_path={~p"/search-help" <> "#cards"}

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -53,6 +53,7 @@ defmodule SanctumWeb.DeckLive.Index do
             value={@query}
             name="query"
             placeholder="Search decks — try hero:spider aspect:justice cards>=45"
+            placeholder_short="Search decks — try hero:spider"
             registry={Sanctum.Search.DeckFields}
             diagnostics={@search_diagnostics}
             help_path={~p"/search-help" <> "#decks"}


### PR DESCRIPTION
## Summary

The "try …" search hints on `/cards`, `/decks`, and `/browse` overflowed their inputs at phone widths (measured 380–457px of placeholder text in 280–330px of input at a 390px viewport).

- New `ResponsivePlaceholder` JS hook: the server-rendered `placeholder` stays the full desktop hint; a `data-placeholder-short` variant is swapped in below Tailwind's `sm` breakpoint via a `matchMedia` listener, so resizes swap live and LiveView patches are re-applied on `updated()`.
- `QueryInput` component gains an optional `placeholder_short` attr (hook only attaches when set).
- `/cards` → "Search cards — try cost<=2", `/decks` → "Search decks — try hero:spider", `/browse` → "Search products and sets — try “kang”".

## Testing

- Verified via playwright against the dev server: at 390×844 all three placeholders now fit (widest is 274px in 330px); at 1280px the full hints are restored without a reload.
- All other placeholder-bearing inputs audited and already fit on mobile.
- `mix compile --warnings-as-errors` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)