### PR TITLE
feat(ui): back buttons return to where the user came from

### DIFF
--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -133,6 +133,51 @@ defmodule SanctumWeb.CoreComponents do
   end
 
   @doc """
+  Renders a "← Back" button that returns the user to wherever they came from
+  (`history.back()`), so list pages restore their query/scroll state via the
+  ScrollRestore hook instead of landing at the top. When there's nothing
+  in-app to go back to (direct link, new tab), it navigates to `fallback`.
+
+  ## Examples
+
+      <.back_button fallback={~p"/cards"} />
+  """
+  attr :fallback, :string, required: true
+
+  def back_button(assigns) do
+    ~H"""
+    <.button type="button" id="back-nav" phx-hook=".BackNav" data-fallback={@fallback}>
+      <.icon name="hero-arrow-left" /> Back
+    </.button>
+    <script :type={Phoenix.LiveView.ColocatedHook} name=".BackNav">
+      // The Navigation API's canGoBack only counts same-origin entries, so it
+      // correctly rejects a new-tab page or an external referrer;
+      // history.length (the Firefox/Safari fallback) can't tell those apart
+      // and may step out of the app.
+      export default {
+        mounted() {
+          this.onClick = () => {
+            const canGoBack =
+              "navigation" in window ? window.navigation.canGoBack : window.history.length > 1
+
+            if (canGoBack) {
+              window.history.back()
+            } else {
+              window.location.assign(this.el.dataset.fallback || "/")
+            }
+          }
+          this.el.addEventListener("click", this.onClick)
+        },
+
+        destroyed() {
+          this.el.removeEventListener("click", this.onClick)
+        },
+      }
+    </script>
+    """
+  end
+
+  @doc """
   Renders a comic-dossier filter pill (aspect / type filters, sort toggles).
 
   ## Examples

--- a/lib/sanctum_web/live/card_live/detail.ex
+++ b/lib/sanctum_web/live/card_live/detail.ex
@@ -34,9 +34,7 @@ defmodule SanctumWeb.CardLive.Detail do
           </:subtitle>
 
           <:actions>
-            <.button navigate={~p"/cards"}>
-              <.icon name="hero-arrow-left" /> Card Pool
-            </.button>
+            <.back_button fallback={~p"/cards"} />
             <.button
               :if={@current_user && @current_user.admin}
               variant="primary"

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -22,9 +22,7 @@ defmodule SanctumWeb.CardLive.Show do
         </:subtitle>
 
         <:actions>
-          <.button navigate={~p"/admin/cards"}>
-            <.icon name="hero-arrow-left" /> Back
-          </.button>
+          <.back_button fallback={~p"/admin/cards"} />
           <.button variant="primary" navigate={~p"/admin/cards/#{@card}/edit?return_to=show"}>
             <.icon name="hero-pencil-square" /> Edit
           </.button>

--- a/lib/sanctum_web/live/card_live/sync.ex
+++ b/lib/sanctum_web/live/card_live/sync.ex
@@ -13,9 +13,7 @@ defmodule SanctumWeb.CardLive.Sync do
           Pulls the card catalog from MarvelCDB and mirrors card scans into the public bucket.
         </:subtitle>
         <:actions>
-          <.button navigate={~p"/admin/cards"}>
-            <.icon name="hero-arrow-left" /> Back to cards
-          </.button>
+          <.back_button fallback={~p"/admin/cards"} />
         </:actions>
       </.header>
 

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -63,9 +63,7 @@ defmodule SanctumWeb.DeckLive.Show do
               >
                 <.icon name="hero-arrow-top-right-on-square" /> MarvelCDB
               </.button>
-              <.button navigate={~p"/decks"}>
-                <.icon name="hero-arrow-left" /> Decks
-              </.button>
+              <.back_button fallback={~p"/decks"} />
             </div>
           </div>
         </header>


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `← Card Pool` / `← Decks` / `← Back to cards` header links (card detail, deck detail, admin card show, admin card sync) with a shared `<.back_button>` component, standardized on a plain **← Back** label.
- The component's colocated `BackNav` hook calls `history.back()`, so the source list page restores its search query and scroll position via the existing `ScrollRestore` hook instead of dumping the user at the top of the index.
- With no in-app history (direct link, new tab), it navigates to a per-page `fallback` route instead — the same destinations the old hardcoded buttons used.

## Implementation notes

- The prod CSP is `default-src 'self'` with no inline scripts, so this is a LiveView hook rather than an inline `onclick`. It's a colocated hook on the component, so no `app.js` changes.
- "Can we go back?" uses the Navigation API's `canGoBack`, which only counts same-origin entries — a new-tab page or external referrer correctly falls back (plain `history.length > 1` misfires there, e.g. popping to `about:blank`). Firefox/Safari lack the API and use the `history.length` heuristic.

## Testing

- Verified with playwright-cli against the dev server: pool search → card detail → Back restores `?query=…` and scroll position; same for the deck flow; direct-load of a card URL falls back to `/cards`.
- `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)