### PR TITLE
fix(ui): keep guess bar above the site footer

### DIFF
--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -117,8 +117,6 @@ defmodule SanctumWeb.Layouts do
         <main class="relative z-10 mx-auto w-full max-w-[1480px] flex-1 px-4 pb-24 pt-7 sm:px-6">
           {render_slot(@inner_block)}
         </main>
-
-        <.site_footer />
       </div>
 
       <!-- sidebar: fixed on lg+, slideout drawer below -->
@@ -193,6 +191,8 @@ defmodule SanctumWeb.Layouts do
       </div>
     </div>
 
+    <.site_footer />
+
     <.flash_group flash={@flash} />
     """
   end
@@ -236,7 +236,7 @@ defmodule SanctumWeb.Layouts do
   # disclaimer that fan sites (MarvelCDB, mc4db) surface.
   defp site_footer(assigns) do
     ~H"""
-    <footer class="relative z-10 mt-auto border-t-[3px] border-neutral bg-base-100/80">
+    <footer class="relative border-t-[3px] border-neutral bg-base-100/80">
       <div class="mx-auto w-full max-w-[1480px] px-4 py-8 sm:px-6">
         <div class="flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
           <div class="flex items-baseline gap-3">


### PR DESCRIPTION
## Summary
- On the Flavor Town page, the site footer could paint over the fixed mobile guess bar — covering the input and the Guess / Give up buttons — because `<main>`'s `relative z-10` stacking context capped the bar's effective z-index at the same level as the footer's `z-10`, and the footer came later in the DOM.
- Move `<.site_footer />` out of the drawer content so it renders below the sidebar and spans the full page width.
- Drop the footer's `z-10` (and now-unneeded `mt-auto`) so the fixed guess bar always stacks above it.

## Testing
- Verified in the browser at localhost:4150: at a 390px viewport scrolled to the bottom of `/flavor-town`, the guess input and buttons render on top of the footer; at 1440px the footer spans full width below the sidebar; `/cards` still lays out normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)