### PR TITLE
fix(decks): capture MarvelCDB deck dates and backfill existing decks

### DIFF
--- a/lib/mix/tasks/sanctum.backfill_deck_dates.ex
+++ b/lib/mix/tasks/sanctum.backfill_deck_dates.ex
@@ -1,0 +1,60 @@
+defmodule Mix.Tasks.Sanctum.BackfillDeckDates do
+  @shortdoc "Backfills MarvelCDB dates onto already-imported decks"
+
+  @moduledoc """
+  One-time backfill of `mcdb_date_creation`/`mcdb_date_update` for decks
+  imported before those fields were captured. Walks MarvelCDB's `by_date`
+  endpoint and copies just the two dates onto existing rows — it does not
+  re-import decks. Idempotent: only rows still missing the dates are touched.
+
+      mix sanctum.backfill_deck_dates                    # full walk (2019 -> today)
+      mix sanctum.backfill_deck_dates --since 2024-01-15 # resume after a halt
+      mix sanctum.backfill_deck_dates --until 2024-01-20 # stop at a specific date
+      mix sanctum.backfill_deck_dates --private          # also re-import URL decks
+
+  `--private` additionally re-imports `mcdb_type: :deck` rows (private decks
+  imported by URL), which the by-date walk can't reach.
+  """
+
+  use Mix.Task
+
+  @requirements ["app.start"]
+
+  @switches [
+    since: :string,
+    until: :string,
+    private: :boolean
+  ]
+
+  @impl true
+  def run(argv) do
+    {opts, _argv} = OptionParser.parse!(argv, strict: @switches)
+
+    backfill_opts =
+      []
+      |> maybe_put_date(:since, opts[:since])
+      |> maybe_put_date(:until, opts[:until])
+
+    case Sanctum.Decks.McdbDateBackfill.run(backfill_opts) do
+      {:ok, _summary} ->
+        if opts[:private], do: Sanctum.Decks.McdbDateBackfill.run_private()
+        :ok
+
+      {:error, summary} ->
+        Mix.raise(
+          "Date backfill halted at #{summary.halted.date}: #{inspect(summary.halted.reason)} " <>
+            "(#{summary.updated} updated before halting). " <>
+            "Re-run with --since #{summary.halted.date} to resume."
+        )
+    end
+  end
+
+  defp maybe_put_date(opts, _key, nil), do: opts
+
+  defp maybe_put_date(opts, key, value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> Keyword.put(opts, key, date)
+      {:error, _} -> Mix.raise("Invalid #{key} date: #{value} (expected YYYY-MM-DD)")
+    end
+  end
+end

--- a/lib/sanctum/decks.ex
+++ b/lib/sanctum/decks.ex
@@ -13,6 +13,7 @@ defmodule Sanctum.Decks do
       define :create_with_cards, action: :create_with_cards
       define :list_decks, action: :read
       define :get_deck_by_mcdb_id, action: :read, get_by: :mcdb_id, not_found_error?: false
+      define :set_deck_mcdb_dates, action: :set_mcdb_dates
     end
 
     resource Sanctum.Decks.DeckCard

--- a/lib/sanctum/decks/deck.ex
+++ b/lib/sanctum/decks/deck.ex
@@ -113,6 +113,26 @@ defmodule Sanctum.Decks.Deck do
       require_atomic? false
     end
 
+    update :set_mcdb_dates do
+      description "Backfills the MarvelCDB provenance dates on an already-imported deck."
+      accept [:mcdb_date_creation, :mcdb_date_update]
+      require_atomic? false
+
+      # ValidateHero re-fetches the hero (card + sides) per row and rejects
+      # heroes without an alter-ego side (e.g. SP//dr) — both wrong for a
+      # provenance-only repair of decks that already imported successfully.
+      skip_global_validations? true
+
+      # This isn't a local sync: keep updated_at untouched so a backfill
+      # doesn't reshuffle the deck browser's recency sort. Force-changing it to
+      # its current value doesn't work (Ash prunes equal-value changes, then
+      # update_timestamp stamps it anyway); an atomic self-assignment counts as
+      # "changing" and so blocks the timestamp while writing a no-op.
+      change fn changeset, _context ->
+        Ash.Changeset.atomic_update(changeset, :updated_at, Ash.Expr.ref(:updated_at))
+      end
+    end
+
     create :create_with_cards do
       description "Upserts an imported deck and replaces its card list. Each slot is %{card_id, quantity, ignore_deck_limit}."
       accept [:*]

--- a/lib/sanctum/decks/mcdb_date_backfill.ex
+++ b/lib/sanctum/decks/mcdb_date_backfill.ex
@@ -1,0 +1,215 @@
+defmodule Sanctum.Decks.McdbDateBackfill do
+  @moduledoc """
+  One-time backfill of `mcdb_date_creation`/`mcdb_date_update` for decks that
+  were imported before those fields were captured.
+
+  Re-walks MarvelCDB's `by_date` endpoint like `Sanctum.DeckSync`, but instead
+  of re-importing each deck it only copies the two date fields onto existing
+  rows that are missing them — no hero resolution, no slot resolution, no
+  deck_cards churn. Per day that's one HTTP request, one indexed read, and a
+  handful of two-column updates, so the whole history costs minutes instead of
+  a full re-sync. The by-date payload reflects each decklist's *current*
+  `date_update`, so a creation-date walk still yields fresh values.
+
+  The walk never touches the deck-sync cursor. A transient fetch failure
+  (timeout / real outage) halts the run and reports the day it stopped at;
+  re-run with `:since` set to that day to resume. MarvelCDB's empty-day 500
+  quirk is disambiguated the same way `Sanctum.DeckSync` does it.
+
+  Decks imported by URL (`mcdb_type: :deck`) live in a different id space that
+  `by_date` can't reach — `run_private/1` re-imports those individually, which
+  captures the dates now that `import_decklist` stores them.
+
+  Entry points: `mix sanctum.backfill_deck_dates` (dev) and
+  `Sanctum.Release.backfill_deck_dates()` (prod).
+  """
+
+  require Ash.Query
+  require Logger
+
+  alias Sanctum.Decks.Deck
+  alias Sanctum.MarvelCdb
+
+  # Matches Sanctum.DeckSync's backfill floor (MarvelCDB launch).
+  @default_start_date ~D[2019-11-01]
+
+  # Be polite between day requests, matching the deck sync's pacing.
+  @download_pause_ms 200
+
+  @doc """
+  Backfills dates for `mcdb_type: :decklist` decks by walking `by_date`.
+
+  Options:
+
+    * `:since` — `Date` to start from (default: #{@default_start_date})
+    * `:until` — `Date` to stop at (default: today, UTC)
+    * `:progress_fun` — `fun/1` receiving progress events; defaults to
+      CLI-style logging
+
+  Returns `{:ok, summary}` or `{:error, summary}` when halted early; `summary`
+  is `%{days, processed, updated, halted}` where `halted` is `nil` or
+  `%{date, reason}`.
+  """
+  def run(opts \\ []) do
+    progress = Keyword.get(opts, :progress_fun, &log_progress/1)
+    since = Keyword.get(opts, :since, @default_start_date)
+    until = Keyword.get(opts, :until, Date.utc_today())
+
+    dates = date_range(since, until)
+    progress.({:started, %{from: since, to: until, days: length(dates)}})
+
+    acc =
+      Enum.reduce_while(dates, %{processed: 0, updated: 0, halted: nil}, fn date, acc ->
+        date |> backfill_date() |> handle_day(date, acc, progress)
+      end)
+
+    summary = %{
+      days: length(dates),
+      processed: acc.processed,
+      updated: acc.updated,
+      halted: acc.halted
+    }
+
+    progress.({:done, summary})
+
+    if acc.halted, do: {:error, summary}, else: {:ok, summary}
+  end
+
+  @doc """
+  Backfills dates for `mcdb_type: :deck` decks (private decks imported by URL)
+  by re-importing each one through `MarvelCdb.load_deck/1`, which now captures
+  the dates. A deck whose source object is gone from MarvelCDB is skipped and
+  counted as failed.
+
+  Returns `{:ok, %{updated, failed}}`.
+  """
+  def run_private(opts \\ []) do
+    progress = Keyword.get(opts, :progress_fun, &log_progress/1)
+
+    decks =
+      Deck
+      |> Ash.Query.filter(mcdb_type == :deck and is_nil(mcdb_date_update))
+      |> Ash.Query.select([:id, :mcdb_id])
+      |> Ash.read!(authorize?: false)
+
+    progress.({:private_started, %{count: length(decks)}})
+
+    summary =
+      Enum.reduce(decks, %{updated: 0, failed: 0}, fn deck, acc ->
+        Process.sleep(@download_pause_ms)
+
+        # Route through the /deck endpoint (a bare id would be treated as a
+        # decklist id — a different object in MarvelCDB's id space).
+        case MarvelCdb.load_deck("https://marvelcdb.com/deck/view/#{deck.mcdb_id}") do
+          {:ok, _deck} ->
+            Map.update!(acc, :updated, &(&1 + 1))
+
+          {:error, reason} ->
+            Logger.warning(
+              "Date backfill: re-import of deck #{deck.mcdb_id} failed: #{inspect(reason)}"
+            )
+
+            Map.update!(acc, :failed, &(&1 + 1))
+        end
+      end)
+
+    progress.({:private_done, summary})
+
+    {:ok, summary}
+  end
+
+  defp handle_day({:ok, updated}, date, acc, progress) do
+    if updated > 0, do: progress.({:date, %{date: date, updated: updated}})
+    Process.sleep(@download_pause_ms)
+    {:cont, %{acc | processed: acc.processed + 1, updated: acc.updated + updated}}
+  end
+
+  defp handle_day({:error, reason}, date, acc, progress) do
+    progress.({:date_error, %{date: date, reason: reason}})
+    {:halt, %{acc | halted: %{date: date, reason: reason}}}
+  end
+
+  defp backfill_date(date) do
+    case MarvelCdb.get_decklists_by_date(date) do
+      {:ok, decklists} ->
+        {:ok, apply_dates(decklists)}
+
+      # No decklists that day.
+      {:error, :not_found} ->
+        {:ok, 0}
+
+      # MarvelCDB's empty-day 500 quirk vs a real outage — same disambiguation
+      # as Sanctum.DeckSync.
+      {:error, {:server_error, status}} ->
+        if MarvelCdb.decklists_endpoint_healthy?() do
+          {:ok, 0}
+        else
+          {:error, "Unexpected status code: #{status}"}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp apply_dates([]), do: 0
+
+  defp apply_dates(decklists) do
+    dates_by_id =
+      Map.new(decklists, fn decklist ->
+        {to_string(decklist["id"]),
+         %{
+           mcdb_date_creation: decklist["date_creation"],
+           mcdb_date_update: decklist["date_update"]
+         }}
+      end)
+
+    ids = Map.keys(dates_by_id)
+
+    Deck
+    |> Ash.Query.filter(mcdb_type == :decklist and mcdb_id in ^ids and is_nil(mcdb_date_update))
+    |> Ash.Query.select([:id, :mcdb_id, :updated_at])
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(fn deck ->
+      Sanctum.Decks.set_deck_mcdb_dates!(deck, Map.fetch!(dates_by_id, deck.mcdb_id),
+        authorize?: false
+      )
+    end)
+    |> length()
+  end
+
+  defp date_range(since, until) do
+    if Date.compare(since, until) == :gt do
+      []
+    else
+      Date.range(since, until) |> Enum.to_list()
+    end
+  end
+
+  defp log_progress({:started, %{from: from, to: to, days: days}}),
+    do: Logger.info("Backfilling deck dates from #{from} to #{to} (#{days} days)...")
+
+  defp log_progress({:date, %{date: date, updated: updated}}),
+    do: Logger.info("  #{date}: #{updated} deck(s) updated")
+
+  defp log_progress({:date_error, %{date: date, reason: reason}}),
+    do: Logger.warning("  #{date}: fetch failed: #{inspect(reason)}")
+
+  defp log_progress({:done, %{halted: %{date: date, reason: reason}} = s}),
+    do:
+      Logger.warning(
+        "Date backfill halted at #{date} (#{inspect(reason)}) after #{s.processed} day(s): " <>
+          "#{s.updated} updated. Re-run with since: ~D[#{date}] to resume."
+      )
+
+  defp log_progress({:done, %{days: days, updated: updated}}),
+    do: Logger.info("Date backfill done: #{days} days, #{updated} deck(s) updated")
+
+  defp log_progress({:private_started, %{count: count}}),
+    do: Logger.info("Backfilling dates for #{count} private (URL-imported) deck(s)...")
+
+  defp log_progress({:private_done, %{updated: updated, failed: failed}}),
+    do: Logger.info("Private deck backfill done: #{updated} updated, #{failed} failed")
+
+  defp log_progress(_event), do: :ok
+end

--- a/lib/sanctum/marvel_cdb.ex
+++ b/lib/sanctum/marvel_cdb.ex
@@ -152,6 +152,10 @@ defmodule Sanctum.MarvelCdb do
       tags: presence(decklist["tags"]),
       description_md: presence(decklist["description_md"]),
       version: presence(decklist["version"]),
+      # ISO 8601 strings ("2024-01-15T00:10:13+00:00"); Ash casts them to
+      # :utc_datetime on the way in.
+      mcdb_date_creation: decklist["date_creation"],
+      mcdb_date_update: decklist["date_update"],
       slots: slots
     }
   end

--- a/lib/sanctum/release.ex
+++ b/lib/sanctum/release.ex
@@ -66,6 +66,22 @@ defmodule Sanctum.Release do
     Sanctum.CardSync.run(Keyword.merge([packs: :all, images?: false], opts))
   end
 
+  @doc """
+  One-time backfill of MarvelCDB deck dates for decks imported before the
+  fields were captured (see `Sanctum.Decks.McdbDateBackfill`). If it halts on
+  a transient MarvelCDB failure, re-run with `since:` set to the reported day.
+
+      /app/bin/sanctum eval 'Sanctum.Release.backfill_deck_dates()'
+      /app/bin/sanctum eval 'Sanctum.Release.backfill_deck_dates(since: ~D[2024-01-15])'
+  """
+  def backfill_deck_dates(opts \\ []) do
+    {:ok, _} = Application.ensure_all_started(@app)
+
+    with {:ok, _summary} <- Sanctum.Decks.McdbDateBackfill.run(opts) do
+      Sanctum.Decks.McdbDateBackfill.run_private()
+    end
+  end
+
   defp repos do
     Application.fetch_env!(@app, :ecto_repos)
   end

--- a/test/sanctum/decks/mcdb_date_backfill_test.exs
+++ b/test/sanctum/decks/mcdb_date_backfill_test.exs
@@ -1,0 +1,190 @@
+defmodule Sanctum.Decks.McdbDateBackfillTest do
+  @moduledoc false
+
+  # async: false — the tests toggle the global `:marvel_cdb_req_options` env.
+  use Sanctum.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Sanctum.Decks.Deck
+  alias Sanctum.Decks.McdbDateBackfill
+
+  setup do
+    original = Application.get_env(:sanctum, :marvel_cdb_req_options)
+
+    # Disable Req's own transient retry so a simulated error resolves in one
+    # shot — keeps these tests fast and deterministic.
+    Application.put_env(:sanctum, :marvel_cdb_req_options,
+      plug: {Req.Test, Sanctum.MarvelCdb},
+      retry: false
+    )
+
+    on_exit(fn -> Application.put_env(:sanctum, :marvel_cdb_req_options, original) end)
+    :ok
+  end
+
+  # Stub the by-date endpoint, dispatching on the ISO date in the request path
+  # (same shape as Sanctum.DeckSyncTest).
+  defp stub_by_date(responses) do
+    Req.Test.stub(Sanctum.MarvelCdb, fn conn ->
+      date = conn.request_path |> String.split("/") |> List.last()
+
+      case Map.fetch(responses, date) do
+        {:ok, {:ok, decks}} -> Req.Test.json(conn, decks)
+        {:ok, :not_found} -> conn |> Plug.Conn.put_status(404) |> Req.Test.json(%{})
+        {:ok, :server_error} -> conn |> Plug.Conn.put_status(500) |> Req.Test.json(%{})
+        {:ok, :timeout} -> Req.Test.transport_error(conn, :timeout)
+        :error -> flunk("unexpected fetch for #{date}")
+      end
+    end)
+  end
+
+  defp create_hero do
+    hero_card = create(Sanctum.Games.Card)
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: hero_card.id,
+        name: "Backfill Hero",
+        type: :hero,
+        code: "#{hero_card.code}a",
+        side_identifier: "A",
+        is_primary_side: true
+      }
+    )
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: hero_card.id,
+        name: "Backfill Alter Ego",
+        type: :alter_ego,
+        code: "#{hero_card.code}b",
+        side_identifier: "B",
+        is_primary_side: false
+      }
+    )
+
+    {:ok, hero} =
+      Sanctum.Heroes.find_or_create_hero(%{
+        hero_name: "Backfill Hero",
+        alter_ego_name: "Backfill Alter Ego",
+        set: hero_card.set,
+        base_code: hero_card.base_code,
+        card_id: hero_card.id
+      })
+
+    hero
+  end
+
+  defp create_mcdb_deck(hero, mcdb_id, attrs \\ %{}) do
+    Deck
+    |> Ash.Changeset.for_create(
+      :create,
+      Map.merge(
+        %{
+          title: "Deck #{mcdb_id}",
+          hero_id: hero.id,
+          source: :marvelcdb,
+          mcdb_id: mcdb_id,
+          mcdb_type: :decklist
+        },
+        attrs
+      )
+    )
+    |> Ash.create!(authorize?: false)
+  end
+
+  # Push updated_at into the past so a spurious bump can't hide inside the
+  # same-second cast window of :utc_datetime.
+  defp age(deck, timestamp) do
+    Sanctum.Repo.update_all(from(d in Deck, where: d.id == ^deck.id),
+      set: [updated_at: timestamp]
+    )
+
+    Ash.get!(Deck, deck.id, authorize?: false)
+  end
+
+  defp run(opts), do: McdbDateBackfill.run([progress_fun: fn _ -> :ok end] ++ opts)
+
+  test "fills missing dates from the payload without touching updated_at" do
+    hero = create_hero()
+    aged_at = ~U[2023-06-01 12:00:00Z]
+
+    missing = create_mcdb_deck(hero, "100") |> age(aged_at)
+
+    already_set =
+      create_mcdb_deck(hero, "101", %{
+        mcdb_date_creation: ~U[2020-05-05 05:05:05Z],
+        mcdb_date_update: ~U[2020-06-06 06:06:06Z]
+      })
+
+    # Same MarvelCDB id in the other id space — must not be touched by a
+    # decklist backfill.
+    private = create_mcdb_deck(hero, "100", %{mcdb_type: :deck})
+
+    stub_by_date(%{
+      "2024-01-15" =>
+        {:ok,
+         [
+           %{
+             "id" => 100,
+             "date_creation" => "2024-01-15T00:10:13+00:00",
+             "date_update" => "2024-01-21T16:02:07+00:00"
+           },
+           %{
+             "id" => 101,
+             "date_creation" => "2024-01-15T01:00:00+00:00",
+             "date_update" => "2024-01-15T01:00:00+00:00"
+           },
+           # A deck we never imported — must be skipped, not created.
+           %{
+             "id" => 999,
+             "date_creation" => "2024-01-15T02:00:00+00:00",
+             "date_update" => "2024-01-15T02:00:00+00:00"
+           }
+         ]}
+    })
+
+    assert {:ok, summary} = run(since: ~D[2024-01-15], until: ~D[2024-01-15])
+    assert summary == %{days: 1, processed: 1, updated: 1, halted: nil}
+
+    missing = Ash.get!(Deck, missing.id, authorize?: false)
+    assert missing.mcdb_date_creation == ~U[2024-01-15 00:10:13Z]
+    assert missing.mcdb_date_update == ~U[2024-01-21 16:02:07Z]
+    assert DateTime.compare(missing.updated_at, aged_at) == :eq
+
+    # Rows that already have dates keep them.
+    already_set = Ash.get!(Deck, already_set.id, authorize?: false)
+    assert already_set.mcdb_date_creation == ~U[2020-05-05 05:05:05Z]
+    assert already_set.mcdb_date_update == ~U[2020-06-06 06:06:06Z]
+
+    # The :deck-space row with the same id is untouched.
+    private = Ash.get!(Deck, private.id, authorize?: false)
+    assert private.mcdb_date_update == nil
+  end
+
+  test "treats a 404 and a healthy-endpoint 500 as empty days" do
+    # 2024-01-01 is the canary the health probe fetches on the 500.
+    stub_by_date(%{
+      "2024-01-01" => {:ok, []},
+      "2024-01-10" => :not_found,
+      "2024-01-11" => :server_error
+    })
+
+    assert {:ok, summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-11])
+    assert summary == %{days: 2, processed: 2, updated: 0, halted: nil}
+  end
+
+  test "halts on a transient failure and reports the day it stopped at" do
+    # 2024-01-12 is intentionally left unstubbed: reaching it would flunk,
+    # proving the walk stopped at the first failure.
+    stub_by_date(%{
+      "2024-01-10" => {:ok, []},
+      "2024-01-11" => :timeout
+    })
+
+    assert {:error, summary} = run(since: ~D[2024-01-10], until: ~D[2024-01-12])
+    assert summary.halted.date == ~D[2024-01-11]
+    assert summary.processed == 1
+  end
+end

--- a/test/sanctum/marvel_cdb_test.exs
+++ b/test/sanctum/marvel_cdb_test.exs
@@ -162,6 +162,55 @@ defmodule Sanctum.MarvelCdbTest do
     end
   end
 
+  describe "import_decklist/2" do
+    # All referenced codes are pre-seeded in the catalog, so the import runs
+    # entirely offline — no Req stub needed.
+    test "captures MarvelCDB's date_creation/date_update as mcdb dates" do
+      hero_card = create(Sanctum.Games.Card, attrs: %{base_code: "42001", code: "42001"})
+
+      create(Sanctum.Games.CardSide,
+        attrs: %{
+          card_id: hero_card.id,
+          name: "Import Hero",
+          type: :hero,
+          code: "42001a",
+          side_identifier: "A",
+          is_primary_side: true
+        }
+      )
+
+      create(Sanctum.Games.CardSide,
+        attrs: %{
+          card_id: hero_card.id,
+          name: "Import Alter Ego",
+          type: :alter_ego,
+          code: "42001b",
+          side_identifier: "B",
+          is_primary_side: false
+        }
+      )
+
+      slot_card = create(Sanctum.Games.Card, attrs: %{base_code: "42002", code: "42002"})
+
+      create(Sanctum.Games.CardSide,
+        attrs: %{card_id: slot_card.id, code: "42002", side_identifier: "A"}
+      )
+
+      payload = %{
+        "id" => 35_109,
+        "name" => "Dated deck",
+        "hero_code" => "42001a",
+        "slots" => %{"42002" => 2},
+        "date_creation" => "2024-01-15T00:10:13+00:00",
+        "date_update" => "2024-01-21T16:02:07+00:00"
+      }
+
+      assert {:ok, deck} = MarvelCdb.import_decklist(payload)
+      assert deck.mcdb_date_creation == ~U[2024-01-15 00:10:13Z]
+      assert deck.mcdb_date_update == ~U[2024-01-21 16:02:07Z]
+    end
+  end
+
   describe "helper functions" do
     test "extract_base_code/1" do
       assert MarvelCdb.extract_base_code("01001a") == "01001"


### PR DESCRIPTION
## Summary

- `mcdb_date_creation`/`mcdb_date_update` (added in a1af5db) were never actually populated — the `prepare_deck_attrs` hunk was lost before that commit landed, so the deck browser always fell back to `updated_at`. This wires the two dates from the MarvelCDB decklist payload into the import path; the `create_with_cards` upsert also refreshes them on re-import.
- Adds `Sanctum.Decks.McdbDateBackfill` to repair existing decks without re-syncing: it re-walks the `by_date` endpoint but only copies the two date columns onto rows missing them (one HTTP request + one indexed read + a few two-column updates per day — no hero/slot resolution, no `deck_cards` churn). Halts on transient failures with a resumable `--since`, reuses the empty-day-500 disambiguation, and never touches the deck-sync cursor. `run_private/1` covers URL-imported (`mcdb_type: :deck`) rows by re-importing them individually.
- Entry points: `mix sanctum.backfill_deck_dates [--since|--until|--private]` (dev) and `Sanctum.Release.backfill_deck_dates/1` (prod).

## Implementation notes

- The dedicated `:set_mcdb_dates` action skips `ValidateHero` (per-row hero re-fetch that also rejects heroes without an alter-ego side, e.g. SP//dr) and keeps `updated_at` untouched so the backfill doesn't reshuffle the deck browser's recency sort. Force-changing `updated_at` to its current value doesn't work — Ash prunes equal-value changes and then stamps the `update_timestamp` default anyway — so the action uses an atomic self-assignment (`SET updated_at = updated_at`), which counts as "changing" and blocks the default.

## Testing

- New offline `import_decklist/2` test asserts the dates are captured and cast from ISO 8601.
- New backfill tests cover: fills nils and parses payload dates, preserves `updated_at`, skips already-set rows and the `:deck` id space, treats 404/healthy-500 as empty days, halts and reports the resume date on transient failure.
- Full suite green (347 tests), `mix ck` clean.
- Verified against dev + real MarvelCDB: a 3-day backfill window updated 56 decks with exact MCDB dates while `updated_at` kept its original value; a live `mix sanctum.sync_decks` run showed both date columns written on insert and on conflict-update.

## Follow-up (not in this PR)

The deck browser's default "recent" sort still orders by `updated_at`; consider `coalesce(mcdb_date_update, updated_at)` so the sort matches the displayed date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)