### PR TITLE
feat(decks): rewrite HTML anchor card links in deck writeups

### DIFF
--- a/lib/sanctum/decks/writeup.ex
+++ b/lib/sanctum/decks/writeup.ex
@@ -35,6 +35,11 @@ defmodule Sanctum.Decks.Writeup do
   # relative form MarvelCDB emits (`/card/30010`) and absolute marvelcdb.com URLs.
   @card_link_re ~r/\[([^\]]*)\]\((?:https?:\/\/(?:www\.)?marvelcdb\.com)?\/card\/([0-9A-Za-z-]+)\)/
 
+  # Some writeups link cards with raw HTML anchors instead of Markdown:
+  # `<a href="https://marvelcdb.com/card/41008">`. Only absolute marvelcdb.com
+  # URLs appear in this form.
+  @card_href_re ~r/href=(["'])https?:\/\/(?:www\.)?marvelcdb\.com\/card\/([0-9A-Za-z-]+)\/?\1/
+
   # A GFM delimiter row (e.g. `|-|-|`, `| :--- | ---: |`).
   @sep_re ~r/^\s*\|?[\s:|-]*-[\s:|-]*\|?\s*$/
   @table_row_re ~r/^\s*\|/
@@ -121,22 +126,35 @@ defmodule Sanctum.Decks.Writeup do
   defp normalize_newlines(md), do: String.replace(md, "\r\n", "\n")
 
   # Resolve every distinct card code once, then splice results back in. Resolved
-  # codes become links to our card page; unresolved ones keep only the link text.
+  # codes become links to our card page. Unresolved Markdown links keep only the
+  # link text (a relative `/card/…` would 404 here); unresolved HTML anchors keep
+  # their absolute marvelcdb.com URL, which still works.
   defp rewrite_card_links(md) do
     codes =
-      @card_link_re
-      |> Regex.scan(md, capture: :all_but_first)
-      |> Enum.map(fn [_name, code] -> code end)
+      [@card_link_re, @card_href_re]
+      |> Enum.flat_map(&Regex.scan(&1, md, capture: :all_but_first))
+      |> Enum.map(fn [_, code] -> code end)
       |> Enum.uniq()
 
     ids = resolve_codes(codes)
 
-    Regex.replace(@card_link_re, md, fn _full, name, code ->
-      case Map.get(ids, code) do
-        nil -> name
-        id -> "[#{name}](/cards/#{id})"
-      end
-    end)
+    md
+    |> then(
+      &Regex.replace(@card_link_re, &1, fn _full, name, code ->
+        case Map.get(ids, code) do
+          nil -> name
+          id -> "[#{name}](/cards/#{id})"
+        end
+      end)
+    )
+    |> then(
+      &Regex.replace(@card_href_re, &1, fn full, quote, code ->
+        case Map.get(ids, code) do
+          nil -> full
+          id -> "href=#{quote}/cards/#{id}#{quote}"
+        end
+      end)
+    )
   end
 
   # code => card_id, from a single Card read (by base_code) plus a single CardAlt

--- a/test/sanctum/decks/writeup_test.exs
+++ b/test/sanctum/decks/writeup_test.exs
@@ -1,0 +1,55 @@
+defmodule Sanctum.Decks.WriteupTest do
+  use Sanctum.DataCase, async: true
+
+  import Sanctum.Factory
+
+  alias Sanctum.Decks.Writeup
+
+  describe "card link rewriting" do
+    test "rewrites markdown card links to our card pages" do
+      card = create(Sanctum.Games.Card, attrs: %{base_code: "41008", code: "41008"})
+
+      html = rendered("[Training Regimen](/card/41008) tutors Skill cards.")
+
+      assert html =~ ~s(href="/cards/#{card.id}")
+      assert html =~ "Training Regimen"
+      refute html =~ "marvelcdb.com"
+    end
+
+    test "rewrites raw HTML anchors pointing at marvelcdb card pages" do
+      card = create(Sanctum.Games.Card, attrs: %{base_code: "41017", code: "41017"})
+
+      html =
+        rendered(~s(<a href="https://marvelcdb.com/card/41017">Float Like a Butterfly</a>))
+
+      assert html =~ ~s(href="/cards/#{card.id}")
+      assert html =~ "Float Like a Butterfly"
+      refute html =~ "marvelcdb.com/card"
+    end
+
+    test "unresolved markdown links degrade to plain text" do
+      html = rendered("[Mystery Card](/card/99999)")
+
+      assert html =~ "Mystery Card"
+      refute html =~ "href"
+    end
+
+    test "unresolved HTML anchors keep their marvelcdb URL" do
+      html = rendered(~s(<a href="https://marvelcdb.com/card/99999">Mystery Card</a>))
+
+      assert html =~ ~s(href="https://marvelcdb.com/card/99999")
+    end
+
+    test "non-card marvelcdb links are left alone" do
+      html =
+        rendered(~s(<a href="https://marvelcdb.com/find?q=surveillance">Surveillance</a>))
+
+      assert html =~ ~s(href="https://marvelcdb.com/find?q=surveillance")
+    end
+  end
+
+  defp rendered(md) do
+    assert [%{kind: :inline, html: html}] = Writeup.render(md)
+    html |> Phoenix.HTML.safe_to_string()
+  end
+end


### PR DESCRIPTION
feat(decks): rewrite HTML anchor card links in deck writeups

## Summary

`Sanctum.Decks.Writeup` already rewrites markdown-style card links (`[Name](/card/CODE)`) in imported MarvelCDB deck writeups to our own `/cards/:id` pages, but some writeups link cards with raw HTML anchors instead — `<a href="https://marvelcdb.com/card/41008">Training Regimen</a>` — and those were left pointing at MarvelCDB.

This adds a second pattern matching `href="https://marvelcdb.com/card/CODE"` in HTML anchors. Both link forms feed the same batched code→card resolution (one `Card` read by `base_code` plus one `CardAlt` fallback read).

Fallback behavior differs by form on purpose:
- Unresolved **markdown** links still degrade to plain text (their relative `/card/…` URL would 404 on our site).
- Unresolved **HTML anchors** keep their absolute marvelcdb.com URL, which still works.

Non-card MarvelCDB links (e.g. `marvelcdb.com/find?q=…` searches) are untouched.

## Testing

- New `test/sanctum/decks/writeup_test.exs` covering both link forms, unresolved codes, and non-card links.
- Verified against a real deck (Psylocke writeup with three HTML-anchor card links) — all resolve to `/cards/:id`.
- Full suite passes (353 tests, 0 failures); `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
