### PR TITLE
feat(heroes): disambiguate same-named heroes with alter ego

### DIFF
--- a/lib/sanctum/decks/deck.ex
+++ b/lib/sanctum/decks/deck.ex
@@ -57,7 +57,7 @@ defmodule Sanctum.Decks.Deck do
             :total_card_count,
             :mcdb_user,
             :owner,
-            hero: [:hero_side, card: [:primary_side]]
+            hero: [:display_name, :hero_side, card: [:primary_side]]
           ])
 
         query =

--- a/lib/sanctum/heroes/hero.ex
+++ b/lib/sanctum/heroes/hero.ex
@@ -85,6 +85,35 @@ defmodule Sanctum.Heroes.Hero do
     end
   end
 
+  calculations do
+    # Heroes that share a printed hero name (the two Black Panthers, the two
+    # Spider-Men) get their alter ego appended — "Black Panther (T'Challa)" —
+    # so listings stay distinguishable. Same-name heroes with the same alter
+    # ego (Ironheart's three forms) stay plain.
+    calculate :display_name,
+              :string,
+              expr(
+                fragment(
+                  """
+                  CASE
+                    WHEN ? IS NOT NULL AND EXISTS (
+                      SELECT 1 FROM heroes h2
+                      WHERE h2.hero_name = ? AND h2.alter_ego_name IS DISTINCT FROM ?
+                    )
+                    THEN ? || ' (' || ? || ')'
+                    ELSE ?
+                  END
+                  """,
+                  alter_ego_name,
+                  hero_name,
+                  alter_ego_name,
+                  hero_name,
+                  alter_ego_name,
+                  hero_name
+                )
+              )
+  end
+
   identities do
     # A set contains exactly one hero identity, so `set` alone is the key.
     # Ironheart's three suit versions are three hero-sided cards in one set;

--- a/lib/sanctum/search/deck_fields.ex
+++ b/lib/sanctum/search/deck_fields.ex
@@ -39,7 +39,10 @@ defmodule Sanctum.Search.DeckFields do
         values_fun: &Sanctum.Search.Values.heroes/0,
         build:
           text_build(fn pattern ->
-            expr(ilike(hero.hero_name, ^pattern) or ilike(hero.alter_ego_name, ^pattern))
+            # display_name always contains hero_name, so it subsumes a
+            # hero_name match while also matching the disambiguated
+            # "Black Panther (T'Challa)" suggestions.
+            expr(ilike(hero.display_name, ^pattern) or ilike(hero.alter_ego_name, ^pattern))
           end)
       },
       %Field{

--- a/lib/sanctum/search/values.ex
+++ b/lib/sanctum/search/values.ex
@@ -45,14 +45,21 @@ defmodule Sanctum.Search.Values do
   end
 
   @doc """
-  Hero and alter-ego names, merged and sorted — the deck `hero:` field
-  matches either, so both complete.
+  Hero display names and alter-ego names, merged and sorted — the deck
+  `hero:` field matches either, so both complete. Display names (via the
+  Hero `display_name` calculation) carry the alter ego for same-named
+  heroes, so "Black Panther (T'Challa)" and "Black Panther (Shuri)"
+  suggest separately.
   """
   @spec heroes() :: [String.t()]
   def heroes do
     ValueCache.fetch(:heroes, fn ->
-      Sanctum.Repo.query!("SELECT hero_name, alter_ego_name FROM heroes")
-      |> clean_rows()
+      Sanctum.Heroes.Hero
+      |> Ash.Query.select([:alter_ego_name])
+      |> Ash.Query.load(:display_name)
+      |> Ash.read!()
+      |> Enum.flat_map(&[&1.display_name, &1.alter_ego_name])
+      |> Enum.reject(&(&1 in [nil, ""]))
       |> Enum.uniq()
       |> Enum.sort()
     end)

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -280,13 +280,15 @@ defmodule SanctumWeb.DeckLive.Index do
 
   defp valid_hero_id(_), do: "all"
 
-  # {id, hero_name} for every hero, sorted by name.
+  # {id, display_name} for every hero, sorted by name. `display_name` carries
+  # the alter ego for same-named heroes (the Black Panthers, the Spider-Men).
   defp load_hero_options do
     Sanctum.Heroes.Hero
     |> Ash.Query.select([:id, :hero_name])
-    |> Ash.Query.sort(hero_name: :asc)
+    |> Ash.Query.load(:display_name)
     |> Ash.read!()
-    |> Enum.map(&{&1.id, &1.hero_name})
+    |> Enum.map(&{&1.id, &1.display_name})
+    |> Enum.sort_by(fn {_id, name} -> name end)
   end
 
   # `replace: true` so typing doesn't spam a history entry per keystroke.
@@ -521,7 +523,7 @@ defmodule SanctumWeb.DeckLive.Index do
     %{
       id: deck.id,
       title: deck.title,
-      hero_name: hero.hero_name,
+      hero_name: hero.display_name,
       identity_image: identity_image(hero),
       gradient_from: hero.primary_color || elem(CardComponent.fallback_gradient(hero.set), 0),
       gradient_to: hero.secondary_color || elem(CardComponent.fallback_gradient(hero.set), 1),

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -450,7 +450,7 @@ defmodule SanctumWeb.DeckLive.Show do
              :total_card_count,
              :mcdb_user,
              :owner,
-             hero: [:hero_side, card: [:primary_side]],
+             hero: [:display_name, :hero_side, card: [:primary_side]],
              deck_cards: [card: [:primary_side]]
            ]
          ) do
@@ -505,7 +505,7 @@ defmodule SanctumWeb.DeckLive.Show do
     author = author(deck)
 
     %{
-      hero_name: hero.hero_name,
+      hero_name: hero.display_name,
       identity_image: identity_image(hero),
       gradient_from: gradient_from,
       gradient_to: gradient_to,

--- a/test/sanctum/search/browse_integration_test.exs
+++ b/test/sanctum/search/browse_integration_test.exs
@@ -133,6 +133,58 @@ defmodule Sanctum.Search.BrowseIntegrationTest do
   end
 
   describe "deck :browse with advanced queries" do
+    defp insert_hero_deck(hero_name, alter_ego, set, base_code) do
+      card = insert_card(%{base_code: base_code, set: set})
+
+      for {name, type, side_id} <- [{hero_name, :hero, "A"}, {alter_ego, :alter_ego, "B"}] do
+        CardSide
+        |> Ash.Changeset.for_create(
+          :create,
+          Map.merge(card_side_factory(), %{
+            card_id: card.id,
+            code: Faker.Util.format("%6da"),
+            name: name,
+            type: type,
+            side_identifier: side_id,
+            is_primary_side: side_id == "A"
+          })
+        )
+        |> Ash.create!(authorize?: false)
+      end
+
+      {:ok, hero} =
+        Sanctum.Heroes.find_or_create_hero(%{
+          hero_name: hero_name,
+          alter_ego_name: alter_ego,
+          set: set,
+          base_code: base_code,
+          card_id: card.id
+        })
+
+      Sanctum.Decks.Deck
+      |> Ash.Changeset.for_create(:create, %{title: "#{alter_ego} deck", hero_id: hero.id})
+      |> Ash.create!(authorize?: false)
+    end
+
+    defp deck_titles(query_string) do
+      Sanctum.Decks.Deck
+      |> Ash.Query.for_read(:browse, %{query: query_string})
+      |> Ash.read!(authorize?: false)
+      |> Enum.map(& &1.title)
+      |> Enum.sort()
+    end
+
+    test "hero search by display name disambiguates same-named heroes" do
+      insert_hero_deck("Black Panther", "T'Challa", "black_panther", "01040")
+      insert_hero_deck("Black Panther", "Shuri", "black_panther_shuri", "51001")
+
+      assert deck_titles(~s{hero:"black panther (shuri)"}) == ["Shuri deck"]
+      assert deck_titles(~s{hero:"black panther (t'challa)"}) == ["T'Challa deck"]
+      assert deck_titles("hero:shuri") == ["Shuri deck"]
+      # The bare hero name still matches both.
+      assert deck_titles(~s{hero:"black panther"}) == ["Shuri deck", "T'Challa deck"]
+    end
+
     test "hero, aspect, and containment queries run" do
       # No decks in the sandbox — just prove the filters execute (no SQL errors).
       for q <- [

--- a/test/sanctum/search/values_test.exs
+++ b/test/sanctum/search/values_test.exs
@@ -93,4 +93,29 @@ defmodule Sanctum.Search.ValuesTest do
     result2 = Suggest.suggest("hero:nat", 8, DeckFields)
     assert [%{label: "Natasha Romanoff"}] = result2.items
   end
+
+  test "same-named heroes suggest with their alter ego appended" do
+    for {alter_ego, set, base_code} <- [
+          {"T'Challa", "black_panther", "01040"},
+          {"Shuri", "black_panther_shuri", "51001"}
+        ] do
+      card = create(Card, attrs: %{set: set})
+
+      Sanctum.Heroes.Hero
+      |> Ash.Changeset.for_create(:create, %{
+        hero_name: "Black Panther",
+        alter_ego_name: alter_ego,
+        set: set,
+        base_code: base_code,
+        card_id: card.id
+      })
+      |> Ash.create!(authorize?: false)
+    end
+
+    result = Suggest.suggest("hero:black", 10, DeckFields)
+    labels = Enum.map(result.items, & &1.label)
+    assert "Black Panther (Shuri)" in labels
+    assert "Black Panther (T'Challa)" in labels
+    refute "Black Panther" in labels
+  end
 end


### PR DESCRIPTION
## Problem

Two heroes print as **Black Panther** (T'Challa and Shuri) and two as **Spider-Man** (Peter Parker and Miles Morales). In the deck browser's hero filter, deck tiles, deck covers, and the `hero:` search autocomplete they were indistinguishable.

## Change

- New `display_name` calculation on `Sanctum.Heroes.Hero` — a SQL-level Ash calculation that appends the alter ego (`Black Panther (T'Challa)`) whenever another hero shares the same printed hero name. Heroes whose duplicates share the same alter ego (Ironheart's suit versions) and nil-alter-ego heroes (SP//dr) stay plain.
- Deck browser: hero filter dropdown and deck tiles use `display_name` (`DeckLive.Index`), as does the deck show cover (`DeckLive.Show`); the `:browse` action loads the calculation.
- Search: the `hero:` autocomplete vocabulary now suggests display names (plus alter egos), and the `hero:` filter matches on `display_name` — which always contains the plain hero name, so it subsumes the old `hero_name` match — so picking `hero:"Black Panther (Shuri)"` actually filters.

The stats page's `per_hero` rollup already appends alter egos in its own schemaless SQL (same display format), so it's untouched here.

## Tests

- `values_test`: same-named heroes suggest as two disambiguated labels (and plain "Black Panther" no longer appears).
- `browse_integration_test`: `hero:"black panther (shuri)"` returns only the Shuri deck, `hero:shuri` works, and bare `hero:"black panther"` still matches both.

Verified live: dropdown shows both Black Panthers and both Spider-Men separately; a T'Challa deck cover renders "Black Panther (T'Challa)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
