### PR TITLE
feat(stats): public deck stats page

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/sanctum"
 import topbar from "../vendor/topbar"
 import CardDrag from "./hooks/card-drag";
+import Chart from "./hooks/chart";
 import DragDrop from "./hooks/drag-drop";
 import LayoutHand from "./hooks/layout-hand";
 import QueryInput from "./hooks/query-input";
@@ -51,7 +52,7 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, CardDrag, DragDrop, LayoutHand, QueryInput, ResponsivePlaceholder, ScrollRestore},
+  hooks: {...colocatedHooks, CardDrag, Chart, DragDrop, LayoutHand, QueryInput, ResponsivePlaceholder, ScrollRestore},
 })
 
 // Uncheck the daisyUI drawer toggle when a sidebar link is clicked, so the

--- a/assets/js/hooks/chart.js
+++ b/assets/js/hooks/chart.js
@@ -7,8 +7,9 @@ import * as echarts from "echarts/core"
 import {BarChart, LineChart} from "echarts/charts"
 import {GridComponent, TooltipComponent} from "echarts/components"
 import {CanvasRenderer} from "echarts/renderers"
+import {UniversalTransition} from "echarts/features"
 
-echarts.use([BarChart, LineChart, GridComponent, TooltipComponent, CanvasRenderer])
+echarts.use([BarChart, LineChart, GridComponent, TooltipComponent, CanvasRenderer, UniversalTransition])
 
 const INK = "#f4f1ea"
 const MUTED = "rgba(244, 241, 234, 0.55)"
@@ -47,8 +48,29 @@ const Chart = {
   mounted() {
     this.chart = echarts.init(this.el, "sanctum", {renderer: "canvas"})
     this.apply()
-    this.resizeObserver = new ResizeObserver(() => this.chart.resize())
+    // apply() already resizes for server-driven height changes; only react to
+    // sizes the chart doesn't know yet (viewport changes), so we never
+    // re-layout mid-transition.
+    this.resizeObserver = new ResizeObserver(() => {
+      if (
+        this.el.clientWidth !== this.chart.getWidth() ||
+        this.el.clientHeight !== this.chart.getHeight()
+      ) {
+        this.chart.resize()
+      }
+    })
     this.resizeObserver.observe(this.el)
+
+    // Drill-down: when the server tags the element with data-click-event,
+    // clicking a mark whose data item carries a `drill` payload pushes that
+    // event with the payload. The attribute is read per click, so the server
+    // can swap or disable it (e.g. per drill level) without re-mounting.
+    this.chart.on("click", (params) => {
+      const event = this.el.dataset.clickEvent
+      if (event && params.data && params.data.drill) {
+        this.pushEvent(event, {...params.data.drill, name: params.name})
+      }
+    })
   },
 
   updated() {
@@ -61,6 +83,13 @@ const Chart = {
   },
 
   apply() {
+    // phx-update="ignore" only lets data-* attributes through on updates, so
+    // the server sends height as data-height and we apply it here. Resize
+    // BEFORE setOption: resizing mid-transition corrupts the morph layout.
+    if (this.el.dataset.height) {
+      this.el.style.height = this.el.dataset.height
+      this.chart.resize()
+    }
     const option = JSON.parse(this.el.dataset.option || "{}")
     this.chart.setOption(option, {notMerge: true})
   },

--- a/assets/js/hooks/chart.js
+++ b/assets/js/hooks/chart.js
@@ -1,0 +1,69 @@
+// ECharts LiveView hook. The server renders a full chart option as JSON in
+// data-option; this hook initializes the canvas, registers the comic-dossier
+// chart chrome as a theme, and re-applies the option whenever the attribute
+// changes. The element carries phx-update="ignore" so LiveView never patches
+// the DOM ECharts owns — attribute updates still fire updated().
+import * as echarts from "echarts/core"
+import {BarChart, LineChart} from "echarts/charts"
+import {GridComponent, TooltipComponent} from "echarts/components"
+import {CanvasRenderer} from "echarts/renderers"
+
+echarts.use([BarChart, LineChart, GridComponent, TooltipComponent, CanvasRenderer])
+
+const INK = "#f4f1ea"
+const MUTED = "rgba(244, 241, 234, 0.55)"
+const HAIRLINE = "#2a2a30"
+const CONDENSED = "'Barlow Condensed', sans-serif"
+
+// Recessive hairline axes/grid, muted ink labels, dossier-panel tooltip.
+// Data, series colors, and per-chart geometry come from the server.
+const axis = {
+  axisLine: {lineStyle: {color: HAIRLINE}},
+  axisTick: {show: false},
+  axisLabel: {color: MUTED, fontFamily: CONDENSED, fontSize: 12},
+  splitLine: {show: false},
+}
+
+echarts.registerTheme("sanctum", {
+  textStyle: {fontFamily: CONDENSED, color: INK},
+  categoryAxis: axis,
+  timeAxis: axis,
+  valueAxis: {
+    ...axis,
+    axisLine: {show: false},
+    splitLine: {show: true, lineStyle: {color: HAIRLINE, width: 1, type: "solid"}},
+  },
+  tooltip: {
+    backgroundColor: "#1a1a1f",
+    borderColor: "#08080a",
+    borderWidth: 2,
+    padding: [8, 12],
+    textStyle: {color: INK, fontFamily: CONDENSED},
+    extraCssText: "border-radius: 0; box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.55);",
+  },
+})
+
+const Chart = {
+  mounted() {
+    this.chart = echarts.init(this.el, "sanctum", {renderer: "canvas"})
+    this.apply()
+    this.resizeObserver = new ResizeObserver(() => this.chart.resize())
+    this.resizeObserver.observe(this.el)
+  },
+
+  updated() {
+    this.apply()
+  },
+
+  destroyed() {
+    this.resizeObserver?.disconnect()
+    this.chart?.dispose()
+  },
+
+  apply() {
+    const option = JSON.parse(this.el.dataset.option || "{}")
+    this.chart.setOption(option, {notMerge: true})
+  },
+}
+
+export default Chart

--- a/assets/js/hooks/chart.js
+++ b/assets/js/hooks/chart.js
@@ -4,12 +4,22 @@
 // changes. The element carries phx-update="ignore" so LiveView never patches
 // the DOM ECharts owns — attribute updates still fire updated().
 import * as echarts from "echarts/core"
-import {BarChart, LineChart} from "echarts/charts"
-import {GridComponent, TooltipComponent} from "echarts/components"
+import {BarChart, LineChart, PieChart} from "echarts/charts"
+import {GridComponent, MarkLineComponent, MarkPointComponent, TooltipComponent} from "echarts/components"
 import {CanvasRenderer} from "echarts/renderers"
 import {UniversalTransition} from "echarts/features"
 
-echarts.use([BarChart, LineChart, GridComponent, TooltipComponent, CanvasRenderer, UniversalTransition])
+echarts.use([
+  BarChart,
+  LineChart,
+  PieChart,
+  GridComponent,
+  MarkLineComponent,
+  MarkPointComponent,
+  TooltipComponent,
+  CanvasRenderer,
+  UniversalTransition,
+])
 
 const INK = "#f4f1ea"
 const MUTED = "rgba(244, 241, 234, 0.55)"

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@sentry/browser": "^10.65.0",
+        "echarts": "^6.1.0",
         "interactjs": "^1.10.27"
       }
     },
@@ -96,12 +97,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
     "node_modules/interactjs": {
       "version": "1.10.27",
       "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
       "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
       "dependencies": {
         "@interactjs/types": "1.10.27"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "dependencies": {
+        "tslib": "2.3.0"
       }
     }
   }

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@sentry/browser": "^10.65.0",
+    "echarts": "^6.1.0",
     "interactjs": "^1.10.27"
   }
 }

--- a/lib/sanctum/decks/stats.ex
+++ b/lib/sanctum/decks/stats.ex
@@ -66,32 +66,46 @@ defmodule Sanctum.Decks.Stats do
   end
 
   @doc """
-  Top `limit` heroes by deck count, as `{display_name, deck_count}`. Heroes
-  that share a hero name (the Spider-Men, notably) get their alter ego
-  appended so the rows stay distinguishable.
+  Every hero with at least one deck, by deck count descending, with the
+  hero's brand colors (`primary`/`secondary`, nilable) and `set` for the
+  gradient fallback. Heroes that share a hero name (the Spider-Men, notably)
+  get their alter ego appended so the rows stay distinguishable.
   """
-  def per_hero(limit \\ 15) do
+  def per_hero do
     rows =
       Repo.all(
         from d in "decks",
           join: h in "heroes",
           on: h.id == d.hero_id,
-          group_by: [h.id, h.hero_name, h.alter_ego_name],
+          group_by: [
+            h.id,
+            h.hero_name,
+            h.alter_ego_name,
+            h.primary_color,
+            h.secondary_color,
+            h.set
+          ],
           order_by: [desc: count(d.id), asc: h.hero_name],
-          limit: ^limit,
-          select: {h.hero_name, h.alter_ego_name, count(d.id)}
+          select: %{
+            name: h.hero_name,
+            alter_ego: h.alter_ego_name,
+            primary: h.primary_color,
+            secondary: h.secondary_color,
+            set: h.set,
+            count: count(d.id)
+          }
       )
 
     dupes =
       rows
-      |> Enum.frequencies_by(fn {name, _, _} -> name end)
+      |> Enum.frequencies_by(& &1.name)
       |> Map.filter(fn {_, n} -> n > 1 end)
 
-    Enum.map(rows, fn {name, alter_ego, count} ->
-      if Map.has_key?(dupes, name) and is_binary(alter_ego) do
-        {"#{name} (#{alter_ego})", count}
+    Enum.map(rows, fn row ->
+      if Map.has_key?(dupes, row.name) and is_binary(row.alter_ego) do
+        %{row | name: "#{row.name} (#{row.alter_ego})"}
       else
-        {name, count}
+        row
       end
     end)
   end

--- a/lib/sanctum/decks/stats.ex
+++ b/lib/sanctum/decks/stats.ex
@@ -168,16 +168,17 @@ defmodule Sanctum.Decks.Stats do
 
   @doc """
   The `aspect` cards appearing in the most of the hero's decks that run that
-  aspect, as `{card_name, deck_count}`. `"basic"` instead counts
-  basic-ownership cards across the hero's aspect-less decks. Raises on an
-  unknown aspect — validate untrusted input before calling.
+  aspect, as `{card_id, card_name, deck_count}` (id as a UUID string, for
+  linking to the card detail page). `"basic"` instead counts basic-ownership
+  cards across the hero's aspect-less decks. Raises on an unknown aspect —
+  validate untrusted input before calling.
   """
   def top_cards(hero_id, aspect, limit \\ 10)
 
   def top_cards(hero_id, "basic", limit) do
     Repo.query!(
       """
-      SELECT cs.name, count(DISTINCT dc.deck_id) AS decks
+      SELECT c.id, cs.name, count(DISTINCT dc.deck_id) AS decks
       FROM deck_cards dc
       JOIN decks d ON d.id = dc.deck_id
       JOIN cards c ON c.id = dc.card_id
@@ -191,13 +192,13 @@ defmodule Sanctum.Decks.Stats do
       """,
       [Ecto.UUID.dump!(hero_id), limit]
     ).rows
-    |> Enum.map(fn [name, n] -> {name, n} end)
+    |> Enum.map(&load_card_row/1)
   end
 
   def top_cards(hero_id, aspect, limit) when aspect in @canonical_aspects do
     Repo.query!(
       """
-      SELECT cs.name, count(DISTINCT dc.deck_id) AS decks
+      SELECT c.id, cs.name, count(DISTINCT dc.deck_id) AS decks
       FROM deck_cards dc
       JOIN decks d ON d.id = dc.deck_id
       JOIN cards c ON c.id = dc.card_id
@@ -211,7 +212,25 @@ defmodule Sanctum.Decks.Stats do
       """,
       [Ecto.UUID.dump!(hero_id), aspect, limit]
     ).rows
-    |> Enum.map(fn [name, n] -> {name, n} end)
+    |> Enum.map(&load_card_row/1)
+  end
+
+  defp load_card_row([id, name, n]), do: {Ecto.UUID.load!(id), name, n}
+
+  @doc """
+  Pack releases for timeline annotation, as `{name, product_type,
+  released_on}`, oldest first: big boxes (core + campaign expansions) and
+  hero packs.
+  """
+  def pack_releases do
+    Repo.all(
+      from p in "packs",
+        where:
+          p.product_type in ["core", "campaign_expansion", "hero_pack"] and
+            not is_nil(p.released_on),
+        order_by: p.released_on,
+        select: {p.name, p.product_type, p.released_on}
+    )
   end
 
   defp fill_months([]), do: []

--- a/lib/sanctum/decks/stats.ex
+++ b/lib/sanctum/decks/stats.ex
@@ -17,14 +17,11 @@ defmodule Sanctum.Decks.Stats do
 
   @canonical_aspects ~w(aggression justice leadership protection pool)
 
-  @doc "Headline counts: total decks, distinct heroes built, decks added this month."
+  @doc """
+  Headline counts: decks, decks added this month, and the catalog totals
+  (unique canonical cards — reprints live on card_alts — heroes, villains).
+  """
   def totals do
-    %{decks: decks, heroes: heroes} =
-      Repo.one(
-        from d in "decks",
-          select: %{decks: count(d.id), heroes: count(d.hero_id, :distinct)}
-      )
-
     month_start = DateTime.utc_now() |> DateTime.to_date() |> Date.beginning_of_month()
 
     this_month =
@@ -40,7 +37,17 @@ defmodule Sanctum.Decks.Stats do
           select: count(d.id)
       )
 
-    %{decks: decks, heroes: heroes, this_month: this_month}
+    %{
+      decks: count_all("decks"),
+      this_month: this_month,
+      cards: count_all("cards"),
+      heroes: count_all("heroes"),
+      villains: count_all("villains")
+    }
+  end
+
+  defp count_all(table) do
+    Repo.one(from t in table, select: count(t.id))
   end
 
   @doc """
@@ -87,6 +94,7 @@ defmodule Sanctum.Decks.Stats do
           ],
           order_by: [desc: count(d.id), asc: h.hero_name],
           select: %{
+            id: type(h.id, Ecto.UUID),
             name: h.hero_name,
             alter_ego: h.alter_ego_name,
             primary: h.primary_color,
@@ -113,13 +121,15 @@ defmodule Sanctum.Decks.Stats do
   @doc """
   `{aspect, deck_count}` in canonical aspect order, with aspect-less ("basic")
   decks last. A multi-aspect deck counts once under each of its aspects.
+  Pass a hero id (UUID string) to scope the split to that hero's decks.
   """
-  def by_aspect do
-    counts =
+  def by_aspect(hero_id \\ nil)
+
+  def by_aspect(nil) do
+    rows =
       Repo.query!(
         "SELECT a.aspect::text, count(*) FROM decks d CROSS JOIN LATERAL unnest(d.aspects) AS a(aspect) GROUP BY 1"
       ).rows
-      |> Map.new(fn [aspect, n] -> {aspect, n} end)
 
     basic =
       Repo.one(
@@ -128,7 +138,80 @@ defmodule Sanctum.Decks.Stats do
           select: count(d.id)
       )
 
+    assemble_aspects(rows, basic)
+  end
+
+  def by_aspect(hero_id) do
+    uuid = Ecto.UUID.dump!(hero_id)
+
+    rows =
+      Repo.query!(
+        "SELECT a.aspect::text, count(*) FROM decks d CROSS JOIN LATERAL unnest(d.aspects) AS a(aspect) WHERE d.hero_id = $1 GROUP BY 1",
+        [uuid]
+      ).rows
+
+    basic =
+      Repo.one(
+        from d in "decks",
+          where: fragment("cardinality(?) = 0", d.aspects),
+          where: d.hero_id == type(^hero_id, Ecto.UUID),
+          select: count(d.id)
+      )
+
+    assemble_aspects(rows, basic)
+  end
+
+  defp assemble_aspects(rows, basic) do
+    counts = Map.new(rows, fn [aspect, n] -> {aspect, n} end)
     Enum.map(@canonical_aspects, &{&1, Map.get(counts, &1, 0)}) ++ [{"basic", basic}]
+  end
+
+  @doc """
+  The `aspect` cards appearing in the most of the hero's decks that run that
+  aspect, as `{card_name, deck_count}`. `"basic"` instead counts
+  basic-ownership cards across the hero's aspect-less decks. Raises on an
+  unknown aspect — validate untrusted input before calling.
+  """
+  def top_cards(hero_id, aspect, limit \\ 10)
+
+  def top_cards(hero_id, "basic", limit) do
+    Repo.query!(
+      """
+      SELECT cs.name, count(DISTINCT dc.deck_id) AS decks
+      FROM deck_cards dc
+      JOIN decks d ON d.id = dc.deck_id
+      JOIN cards c ON c.id = dc.card_id
+      JOIN card_sides cs ON cs.card_id = c.id AND cs.is_primary_side
+      WHERE d.hero_id = $1
+        AND cardinality(d.aspects) = 0
+        AND cs.ownership = 'basic'
+      GROUP BY c.id, cs.name
+      ORDER BY decks DESC, cs.name ASC
+      LIMIT $2
+      """,
+      [Ecto.UUID.dump!(hero_id), limit]
+    ).rows
+    |> Enum.map(fn [name, n] -> {name, n} end)
+  end
+
+  def top_cards(hero_id, aspect, limit) when aspect in @canonical_aspects do
+    Repo.query!(
+      """
+      SELECT cs.name, count(DISTINCT dc.deck_id) AS decks
+      FROM deck_cards dc
+      JOIN decks d ON d.id = dc.deck_id
+      JOIN cards c ON c.id = dc.card_id
+      JOIN card_sides cs ON cs.card_id = c.id AND cs.is_primary_side
+      WHERE d.hero_id = $1
+        AND $2 = ANY(d.aspects::text[])
+        AND cs.aspect::text = $2
+      GROUP BY c.id, cs.name
+      ORDER BY decks DESC, cs.name ASC
+      LIMIT $3
+      """,
+      [Ecto.UUID.dump!(hero_id), aspect, limit]
+    ).rows
+    |> Enum.map(fn [name, n] -> {name, n} end)
   end
 
   defp fill_months([]), do: []

--- a/lib/sanctum/decks/stats.ex
+++ b/lib/sanctum/decks/stats.ex
@@ -1,0 +1,133 @@
+defmodule Sanctum.Decks.Stats do
+  @moduledoc """
+  Read-only rollups behind the public `/stats` page.
+
+  These are group-by aggregates over the decks table, which Ash read actions
+  don't model — schemaless Ecto (the admin health snapshot's pattern) keeps
+  each one a single round trip. Deck reads are public, so nothing here
+  bypasses a policy that would apply through Ash.
+
+  Deck dates use the MarvelCDB publish date when we have it (imported decks),
+  falling back to our own insert time (native decks).
+  """
+
+  import Ecto.Query
+
+  alias Sanctum.Repo
+
+  @canonical_aspects ~w(aggression justice leadership protection pool)
+
+  @doc "Headline counts: total decks, distinct heroes built, decks added this month."
+  def totals do
+    %{decks: decks, heroes: heroes} =
+      Repo.one(
+        from d in "decks",
+          select: %{decks: count(d.id), heroes: count(d.hero_id, :distinct)}
+      )
+
+    month_start = DateTime.utc_now() |> DateTime.to_date() |> Date.beginning_of_month()
+
+    this_month =
+      Repo.one(
+        from d in "decks",
+          where:
+            fragment(
+              "coalesce(?, ?) >= ?",
+              d.mcdb_date_creation,
+              d.inserted_at,
+              type(^month_start, :date)
+            ),
+          select: count(d.id)
+      )
+
+    %{decks: decks, heroes: heroes, this_month: this_month}
+  end
+
+  @doc """
+  `{month, deck_count}` per calendar month, oldest first, zero-filled so time
+  charts don't silently skip empty months.
+  """
+  def by_month do
+    from(d in "decks",
+      group_by: selected_as(:month),
+      order_by: selected_as(:month),
+      select:
+        {selected_as(
+           fragment(
+             "date_trunc('month', coalesce(?, ?))::date",
+             d.mcdb_date_creation,
+             d.inserted_at
+           ),
+           :month
+         ), count(d.id)}
+    )
+    |> Repo.all()
+    |> fill_months()
+  end
+
+  @doc """
+  Top `limit` heroes by deck count, as `{display_name, deck_count}`. Heroes
+  that share a hero name (the Spider-Men, notably) get their alter ego
+  appended so the rows stay distinguishable.
+  """
+  def per_hero(limit \\ 15) do
+    rows =
+      Repo.all(
+        from d in "decks",
+          join: h in "heroes",
+          on: h.id == d.hero_id,
+          group_by: [h.id, h.hero_name, h.alter_ego_name],
+          order_by: [desc: count(d.id), asc: h.hero_name],
+          limit: ^limit,
+          select: {h.hero_name, h.alter_ego_name, count(d.id)}
+      )
+
+    dupes =
+      rows
+      |> Enum.frequencies_by(fn {name, _, _} -> name end)
+      |> Map.filter(fn {_, n} -> n > 1 end)
+
+    Enum.map(rows, fn {name, alter_ego, count} ->
+      if Map.has_key?(dupes, name) and is_binary(alter_ego) do
+        {"#{name} (#{alter_ego})", count}
+      else
+        {name, count}
+      end
+    end)
+  end
+
+  @doc """
+  `{aspect, deck_count}` in canonical aspect order, with aspect-less ("basic")
+  decks last. A multi-aspect deck counts once under each of its aspects.
+  """
+  def by_aspect do
+    counts =
+      Repo.query!(
+        "SELECT a.aspect::text, count(*) FROM decks d CROSS JOIN LATERAL unnest(d.aspects) AS a(aspect) GROUP BY 1"
+      ).rows
+      |> Map.new(fn [aspect, n] -> {aspect, n} end)
+
+    basic =
+      Repo.one(
+        from d in "decks",
+          where: fragment("cardinality(?) = 0", d.aspects),
+          select: count(d.id)
+      )
+
+    Enum.map(@canonical_aspects, &{&1, Map.get(counts, &1, 0)}) ++ [{"basic", basic}]
+  end
+
+  defp fill_months([]), do: []
+
+  defp fill_months(rows) do
+    counts = Map.new(rows)
+    {first, _} = List.first(rows)
+    {last, _} = List.last(rows)
+
+    first
+    |> Stream.unfold(fn month ->
+      if Date.after?(month, last), do: nil, else: {month, Date.shift(month, month: 1)}
+    end)
+    |> Enum.map(&{&1, Map.get(counts, &1, 0)})
+  end
+end

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -35,7 +35,7 @@ defmodule SanctumWeb.Layouts do
 
   attr :active_tab, :atom,
     default: nil,
-    values: [nil, :browse, :cards, :guess, :decks, :profile, :admin],
+    values: [nil, :browse, :cards, :guess, :decks, :stats, :profile, :admin],
     doc: "which top-nav tab to highlight"
 
   slot :inner_block, required: true
@@ -150,6 +150,9 @@ defmodule SanctumWeb.Layouts do
             </.sidebar_link>
             <.sidebar_link navigate={~p"/flavor-town"} active={@active_tab == :guess}>
               Flavor Town
+            </.sidebar_link>
+            <.sidebar_link navigate={~p"/stats"} active={@active_tab == :stats}>
+              Stats
             </.sidebar_link>
             <.sidebar_link
               :if={@current_user}

--- a/lib/sanctum_web/live/stats_live/index.ex
+++ b/lib/sanctum_web/live/stats_live/index.ex
@@ -34,6 +34,13 @@ defmodule SanctumWeb.StatsLive.Index do
 
   @impl true
   def render(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :hero_panel,
+        assigns.stats && hero_panel_view(assigns.stats, assigns.hero_drill, assigns.aspect_drill)
+      )
+
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:stats}>
       <.header>
@@ -43,15 +50,25 @@ defmodule SanctumWeb.StatsLive.Index do
         </:subtitle>
       </.header>
 
-      <div :if={@stats == nil} class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <div :for={_ <- 1..4} class="h-20 animate-pulse border-[3px] border-neutral bg-base-300" />
+      <div :if={@stats == nil} class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <div :for={_ <- 1..6} class="h-20 animate-pulse border-[3px] border-neutral bg-base-300" />
       </div>
 
       <div :if={@stats != nil} class="flex flex-col gap-6">
-        <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <.stat_tile label="Decks" value={@stats.totals.decks} />
-          <.stat_tile label="Heroes built" value={@stats.totals.heroes} />
-          <.stat_tile label="Added this month" value={@stats.totals.this_month} />
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+          <.stat_tile label="Decks" value={@stats.totals.decks} color="text-primary" />
+          <.stat_tile label="Unique cards" value={@stats.totals.cards} color="text-secondary" />
+          <.stat_tile label="Heroes" value={@stats.totals.heroes} color="text-aspect-hero" />
+          <.stat_tile
+            label="Villains"
+            value={@stats.totals.villains}
+            color="text-aspect-encounter"
+          />
+          <.stat_tile
+            label="Added this month"
+            value={@stats.totals.this_month}
+            color="text-success"
+          />
           <.text_tile label="Most built hero" value={top_hero_name(@stats.per_hero)} />
         </div>
 
@@ -76,18 +93,24 @@ defmodule SanctumWeb.StatsLive.Index do
         <.chart_panel
           :if={@stats.totals.decks > 0}
           id="decks-per-hero"
-          title="Decks per hero"
-          subtitle={"Every hero with a deck in the vault — all #{@stats.totals.heroes} of them, each bar in the hero's own colors."}
-          option={per_hero_option(@stats.per_hero)}
-          height={"#{length(@stats.per_hero) * 24 + 70}px"}
+          title={@hero_panel.title}
+          subtitle={@hero_panel.subtitle}
+          option={@hero_panel.option}
+          height={@hero_panel.height}
+          click_event={@hero_panel.click_event}
         >
+          <:action :if={@hero_panel.back}>
+            <.button phx-click="drill_back">
+              <.icon name="hero-arrow-left" class="size-4" /> {@hero_panel.back}
+            </.button>
+          </:action>
           <:table_head>
-            <th class="pr-6 text-left">Hero</th>
+            <th class="pr-6 text-left">{@hero_panel.col}</th>
             <th class="text-right">Decks</th>
           </:table_head>
-          <tr :for={row <- @stats.per_hero}>
-            <td class="pr-6">{row.name}</td>
-            <td class="text-right tabular-nums">{row.count}</td>
+          <tr :for={{label, count} <- @hero_panel.rows}>
+            <td class="pr-6">{label}</td>
+            <td class="text-right tabular-nums">{count}</td>
           </tr>
         </.chart_panel>
 
@@ -124,19 +147,28 @@ defmodule SanctumWeb.StatsLive.Index do
   attr :subtitle, :string, required: true
   attr :option, :map, required: true
   attr :height, :string, required: true
+  attr :click_event, :string, default: nil
+  slot :action
   slot :table_head, required: true
   slot :inner_block, required: true
 
   defp chart_panel(assigns) do
     ~H"""
     <.panel class="p-4 sm:p-5">
-      <h2 class="font-anton text-lg uppercase tracking-[0.05em]">{@title}</h2>
-      <p class="mb-3 font-barlow-condensed text-sm text-base-content/55">{@subtitle}</p>
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <h2 class="font-anton text-lg uppercase tracking-[0.05em]">{@title}</h2>
+          <p class="mb-3 font-barlow-condensed text-sm text-base-content/55">{@subtitle}</p>
+        </div>
+        {render_slot(@action)}
+      </div>
       <div
         id={"#{@id}-chart"}
         phx-hook="Chart"
         phx-update="ignore"
         data-option={Jason.encode!(@option)}
+        data-click-event={@click_event}
+        data-height={@height}
         class="w-full"
         style={"height: #{@height}"}
         role="img"
@@ -166,16 +198,24 @@ defmodule SanctumWeb.StatsLive.Index do
 
   attr :label, :string, required: true
   attr :value, :integer, required: true
+  attr :color, :string, default: "text-primary"
 
   defp stat_tile(assigns) do
     ~H"""
     <div class="border-[3px] border-neutral bg-base-300 px-4 py-3">
-      <div class="font-bangers text-3xl leading-none text-primary">{@value}</div>
+      <div class={["font-bangers text-3xl leading-none", @color]}>{format_count(@value)}</div>
       <div class="mt-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
         {@label}
       </div>
     </div>
     """
+  end
+
+  # 51461 → "51,461"
+  defp format_count(n) do
+    n
+    |> Integer.to_string()
+    |> String.replace(~r/(?<=\d)(?=(\d{3})+$)/, ",")
   end
 
   attr :label, :string, required: true
@@ -196,7 +236,13 @@ defmodule SanctumWeb.StatsLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    socket = assign(socket, page_title: "Vault Stats", stats: nil)
+    socket =
+      assign(socket,
+        page_title: "Vault Stats",
+        stats: nil,
+        hero_drill: nil,
+        aspect_drill: nil
+      )
 
     # Defer the rollup queries past the static render so the shell paints
     # immediately (same pattern as the admin health snapshot).
@@ -204,6 +250,40 @@ defmodule SanctumWeb.StatsLive.Index do
       if connected?(socket), do: start_async(socket, :load_stats, &load_stats/0), else: socket
 
     {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("hero_bar_clicked", %{"heroId" => hero_id, "name" => name}, socket) do
+    case Ecto.UUID.cast(hero_id) do
+      {:ok, id} ->
+        {:noreply,
+         assign(socket,
+           hero_drill: %{id: id, name: name, rows: Stats.by_aspect(id)},
+           aspect_drill: nil
+         )}
+
+      :error ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("aspect_bar_clicked", %{"aspect" => key}, socket) do
+    hero = socket.assigns.hero_drill
+
+    if hero && List.keymember?(@aspect_colors, key, 0) do
+      {:noreply, assign(socket, :aspect_drill, %{key: key, rows: Stats.top_cards(hero.id, key)})}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # Pops one drill level: top cards → aspect split → all heroes.
+  def handle_event("drill_back", _params, socket) do
+    if socket.assigns.aspect_drill do
+      {:noreply, assign(socket, :aspect_drill, nil)}
+    else
+      {:noreply, assign(socket, :hero_drill, nil)}
+    end
   end
 
   @impl true
@@ -235,6 +315,57 @@ defmodule SanctumWeb.StatsLive.Index do
   defp top_hero_name([%{name: name} | _]), do: name
   defp top_hero_name([]), do: "—"
 
+  # Everything the hero drill-down panel needs for its current level:
+  # all heroes → one hero's aspect split → one aspect's most-used cards.
+  # `rows` is normalized to `{label, count}` for the shared table twin.
+  defp hero_panel_view(stats, nil = _hero_drill, _aspect_drill) do
+    %{
+      title: "Decks per hero",
+      subtitle:
+        "Every hero with a deck in the vault — all #{length(stats.per_hero)} of them, each bar in the hero's own colors. Click a bar for that hero's aspect split.",
+      option: per_hero_option(stats.per_hero),
+      height: "#{length(stats.per_hero) * 24 + 70}px",
+      click_event: "hero_bar_clicked",
+      back: nil,
+      col: "Hero",
+      rows: Enum.map(stats.per_hero, &{&1.name, &1.count})
+    }
+  end
+
+  defp hero_panel_view(_stats, hero, nil = _aspect_drill) do
+    %{
+      title: "#{hero.name} — decks by aspect",
+      subtitle:
+        "How #{hero.name}'s decks split across aspects. Click a bar for the aspect's most-used cards.",
+      option: by_aspect_option(hero.rows, drill_from: hero.id, clickable: true),
+      height: "260px",
+      click_event: "aspect_bar_clicked",
+      back: "All heroes",
+      col: "Aspect",
+      rows: Enum.map(hero.rows, fn {key, count} -> {aspect_label(key), count} end)
+    }
+  end
+
+  defp hero_panel_view(_stats, hero, aspect) do
+    label = aspect_label(aspect.key)
+
+    subtitle =
+      if aspect.key == "basic",
+        do: "The basic cards appearing in the most of #{hero.name}'s aspect-less decks.",
+        else: "The #{label} cards appearing in the most of #{hero.name}'s #{label} decks."
+
+    %{
+      title: "#{hero.name} — top #{label} cards",
+      subtitle: subtitle,
+      option: top_cards_option(aspect.rows, aspect.key),
+      height: "#{max(length(aspect.rows), 1) * 30 + 70}px",
+      click_event: nil,
+      back: "#{hero.name} aspects",
+      col: "Card",
+      rows: aspect.rows
+    }
+  end
+
   defp aspect_label(key) do
     {_, label, _} = List.keyfind!(@aspect_colors, key, 0)
     label
@@ -251,7 +382,7 @@ defmodule SanctumWeb.StatsLive.Index do
 
   defp by_month_option(rows) do
     %{
-      grid: %{left: 8, right: 16, top: 16, bottom: 8, containLabel: true},
+      grid: %{left: 8, right: 16, top: 16, bottom: 8},
       tooltip: %{trigger: "axis", axisPointer: %{type: "line", lineStyle: %{color: @hairline}}},
       xAxis: %{type: "time"},
       yAxis: %{type: "value", minInterval: 1},
@@ -277,7 +408,7 @@ defmodule SanctumWeb.StatsLive.Index do
     rows = Enum.reverse(rows)
 
     %{
-      grid: %{left: 8, right: 40, top: 8, bottom: 8, containLabel: true},
+      grid: %{left: 8, right: 40, top: 8, bottom: 8},
       tooltip: %{trigger: "item"},
       xAxis: %{type: "value", minInterval: 1},
       yAxis: %{
@@ -288,14 +419,23 @@ defmodule SanctumWeb.StatsLive.Index do
       },
       series: [
         %{
+          # A stable series id + universalTransition lets ECharts morph this
+          # chart into the per-hero aspect drill-down (and back) instead of
+          # redrawing from scratch.
+          id: "decks",
           name: "Decks",
           type: "bar",
+          universalTransition: %{enabled: true, divideShape: "clone"},
           data:
             Enum.map(rows, fn row ->
               {from, to} = hero_gradient(row)
 
               %{
                 value: row.count,
+                # groupId ties each bar to its drill-down series; drill is
+                # our own payload, pushed back on click by the Chart hook.
+                groupId: row.id,
+                drill: %{heroId: row.id},
                 itemStyle: %{
                   color: %{
                     type: "linear",
@@ -369,24 +509,71 @@ defmodule SanctumWeb.StatsLive.Index do
     Enum.map([r, g, b], &String.to_integer(&1, 16))
   end
 
-  defp by_aspect_option(rows) do
+  defp by_aspect_option(rows, opts \\ []) do
     rows = Enum.reverse(rows)
+    drill_from = Keyword.get(opts, :drill_from)
+
+    clickable = Keyword.get(opts, :clickable, false)
+
+    series = %{
+      id: "decks",
+      name: "Decks",
+      type: "bar",
+      universalTransition: %{enabled: true, divideShape: "clone"},
+      data:
+        Enum.map(rows, fn {key, count} ->
+          base = %{value: count, itemStyle: %{color: aspect_color(key)}}
+
+          # groupId ties each aspect bar to the top-cards series it morphs
+          # into; drill is the click payload the Chart hook pushes back.
+          if clickable,
+            do: Map.merge(base, %{groupId: key, drill: %{aspect: key}}),
+            else: base
+        end),
+      barWidth: 16,
+      itemStyle: %{borderRadius: [0, 4, 4, 0]},
+      label: %{show: true, position: "right", color: @muted, fontSize: 12}
+    }
+
+    # As a drill-down, tie the series back to the hero bar it came from so
+    # the morph animation splits/merges the right mark. Bars only advertise
+    # clickability (pointer cursor) when they actually drill somewhere.
+    series = if drill_from, do: Map.put(series, :dataGroupId, drill_from), else: series
+    series = if clickable, do: series, else: Map.put(series, :cursor, "default")
 
     %{
-      grid: %{left: 8, right: 40, top: 8, bottom: 8, containLabel: true},
+      grid: %{left: 8, right: 40, top: 8, bottom: 8},
       tooltip: %{trigger: "item"},
       xAxis: %{type: "value", minInterval: 1},
       yAxis: %{type: "category", data: Enum.map(rows, fn {key, _} -> aspect_label(key) end)},
+      series: [series]
+    }
+  end
+
+  defp top_cards_option(rows, aspect_key) do
+    rows = Enum.reverse(rows)
+
+    %{
+      grid: %{left: 8, right: 40, top: 8, bottom: 8},
+      tooltip: %{trigger: "item"},
+      xAxis: %{type: "value", minInterval: 1},
+      yAxis: %{
+        type: "category",
+        data: Enum.map(rows, &elem(&1, 0)),
+        axisLabel: %{interval: 0}
+      },
       series: [
         %{
+          id: "decks",
           name: "Decks",
           type: "bar",
-          data:
-            Enum.map(rows, fn {key, count} ->
-              %{value: count, itemStyle: %{color: aspect_color(key)}}
-            end),
+          universalTransition: %{enabled: true, divideShape: "clone"},
+          # Morph out of (and back into) the aspect bar that was clicked.
+          dataGroupId: aspect_key,
+          cursor: "default",
+          data: Enum.map(rows, &elem(&1, 1)),
           barWidth: 16,
-          itemStyle: %{borderRadius: [0, 4, 4, 0]},
+          itemStyle: %{color: aspect_color(aspect_key), borderRadius: [0, 4, 4, 0]},
           label: %{show: true, position: "right", color: @muted, fontSize: 12}
         }
       ]

--- a/lib/sanctum_web/live/stats_live/index.ex
+++ b/lib/sanctum_web/live/stats_live/index.ex
@@ -65,7 +65,7 @@ defmodule SanctumWeb.StatsLive.Index do
             color="text-aspect-encounter"
           />
           <.stat_tile
-            label="Added this month"
+            label="Decks Added this Month"
             value={@stats.totals.this_month}
             color="text-success"
           />

--- a/lib/sanctum_web/live/stats_live/index.ex
+++ b/lib/sanctum_web/live/stats_live/index.ex
@@ -50,12 +50,12 @@ defmodule SanctumWeb.StatsLive.Index do
         </:subtitle>
       </.header>
 
-      <div :if={@stats == nil} class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-        <div :for={_ <- 1..6} class="h-20 animate-pulse border-[3px] border-neutral bg-base-300" />
+      <div :if={@stats == nil} class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <div :for={_ <- 1..5} class="h-20 animate-pulse border-[3px] border-neutral bg-base-300" />
       </div>
 
       <div :if={@stats != nil} class="flex flex-col gap-6">
-        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
           <.stat_tile label="Decks" value={@stats.totals.decks} color="text-primary" />
           <.stat_tile label="Unique cards" value={@stats.totals.cards} color="text-secondary" />
           <.stat_tile label="Heroes" value={@stats.totals.heroes} color="text-aspect-hero" />
@@ -69,15 +69,14 @@ defmodule SanctumWeb.StatsLive.Index do
             value={@stats.totals.this_month}
             color="text-success"
           />
-          <.text_tile label="Most built hero" value={top_hero_name(@stats.per_hero)} />
         </div>
 
         <.chart_panel
           :if={@stats.totals.decks > 0}
           id="decks-by-month"
           title="Decks added over time"
-          subtitle="New decks per month, by their MarvelCDB publish date."
-          option={by_month_option(@stats.by_month)}
+          subtitle="New decks per month, by their MarvelCDB publish date. Lines mark big-box set releases; diamonds along the baseline are hero packs (hover for names)."
+          option={by_month_option(@stats.by_month, @stats.pack_releases)}
           height="320px"
         >
           <:table_head>
@@ -92,6 +91,24 @@ defmodule SanctumWeb.StatsLive.Index do
 
         <.chart_panel
           :if={@stats.totals.decks > 0}
+          id="decks-by-aspect"
+          title="Decks by aspect"
+          subtitle="Multi-aspect decks count once under each aspect, so slices sum to more than the deck total; basic decks run no aspect."
+          option={aspect_pie_option(@stats.by_aspect)}
+          height="320px"
+        >
+          <:table_head>
+            <th class="pr-6 text-left">Aspect</th>
+            <th class="text-right">Decks</th>
+          </:table_head>
+          <tr :for={{aspect, count} <- @stats.by_aspect}>
+            <td class="pr-6">{aspect_label(aspect)}</td>
+            <td class="text-right tabular-nums">{count}</td>
+          </tr>
+        </.chart_panel>
+
+        <.chart_panel
+          :if={@stats.totals.decks > 0}
           id="decks-per-hero"
           title={@hero_panel.title}
           subtitle={@hero_panel.subtitle}
@@ -100,8 +117,8 @@ defmodule SanctumWeb.StatsLive.Index do
           click_event={@hero_panel.click_event}
         >
           <:action :if={@hero_panel.back}>
-            <.button phx-click="drill_back">
-              <.icon name="hero-arrow-left" class="size-4" /> {@hero_panel.back}
+            <.button patch={@hero_panel.back.patch}>
+              <.icon name="hero-arrow-left" class="size-4" /> {@hero_panel.back.label}
             </.button>
           </:action>
           <:table_head>
@@ -110,24 +127,6 @@ defmodule SanctumWeb.StatsLive.Index do
           </:table_head>
           <tr :for={{label, count} <- @hero_panel.rows}>
             <td class="pr-6">{label}</td>
-            <td class="text-right tabular-nums">{count}</td>
-          </tr>
-        </.chart_panel>
-
-        <.chart_panel
-          :if={@stats.totals.decks > 0}
-          id="decks-by-aspect"
-          title="Decks by aspect"
-          subtitle="Multi-aspect decks count once under each aspect; basic decks run no aspect."
-          option={by_aspect_option(@stats.by_aspect)}
-          height="288px"
-        >
-          <:table_head>
-            <th class="pr-6 text-left">Aspect</th>
-            <th class="text-right">Decks</th>
-          </:table_head>
-          <tr :for={{aspect, count} <- @stats.by_aspect}>
-            <td class="pr-6">{aspect_label(aspect)}</td>
             <td class="text-right tabular-nums">{count}</td>
           </tr>
         </.chart_panel>
@@ -218,22 +217,6 @@ defmodule SanctumWeb.StatsLive.Index do
     |> String.replace(~r/(?<=\d)(?=(\d{3})+$)/, ",")
   end
 
-  attr :label, :string, required: true
-  attr :value, :string, required: true
-
-  defp text_tile(assigns) do
-    ~H"""
-    <div class="border-[3px] border-neutral bg-base-300 px-4 py-3">
-      <div class="truncate font-barlow-condensed text-xl font-bold leading-none text-primary">
-        {@value}
-      </div>
-      <div class="mt-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
-        {@label}
-      </div>
-    </div>
-    """
-  end
-
   @impl true
   def mount(_params, _session, socket) do
     socket =
@@ -241,7 +224,8 @@ defmodule SanctumWeb.StatsLive.Index do
         page_title: "Vault Stats",
         stats: nil,
         hero_drill: nil,
-        aspect_drill: nil
+        aspect_drill: nil,
+        drill_params: %{hero: nil, aspect: nil}
       )
 
     # Defer the rollup queries past the static render so the shell paints
@@ -252,18 +236,23 @@ defmodule SanctumWeb.StatsLive.Index do
     {:ok, socket}
   end
 
+  # The drill level lives in the URL (?hero=<id>&aspect=<key>), so browser
+  # back/forward walks the levels and returning from a card detail page
+  # restores the view. Clicks only patch the URL; handle_params derives the
+  # actual drill state.
   @impl true
-  def handle_event("hero_bar_clicked", %{"heroId" => hero_id, "name" => name}, socket) do
-    case Ecto.UUID.cast(hero_id) do
-      {:ok, id} ->
-        {:noreply,
-         assign(socket,
-           hero_drill: %{id: id, name: name, rows: Stats.by_aspect(id)},
-           aspect_drill: nil
-         )}
+  def handle_params(params, _uri, socket) do
+    socket =
+      assign(socket, :drill_params, %{hero: params["hero"], aspect: params["aspect"]})
 
-      :error ->
-        {:noreply, socket}
+    {:noreply, derive_drills(socket)}
+  end
+
+  @impl true
+  def handle_event("hero_bar_clicked", %{"heroId" => hero_id}, socket) do
+    case Ecto.UUID.cast(hero_id) do
+      {:ok, id} -> {:noreply, push_patch(socket, to: ~p"/stats?hero=#{id}")}
+      :error -> {:noreply, socket}
     end
   end
 
@@ -271,24 +260,24 @@ defmodule SanctumWeb.StatsLive.Index do
     hero = socket.assigns.hero_drill
 
     if hero && List.keymember?(@aspect_colors, key, 0) do
-      {:noreply, assign(socket, :aspect_drill, %{key: key, rows: Stats.top_cards(hero.id, key)})}
+      {:noreply, push_patch(socket, to: ~p"/stats?hero=#{hero.id}&aspect=#{key}")}
     else
       {:noreply, socket}
     end
   end
 
-  # Pops one drill level: top cards → aspect split → all heroes.
-  def handle_event("drill_back", _params, socket) do
-    if socket.assigns.aspect_drill do
-      {:noreply, assign(socket, :aspect_drill, nil)}
-    else
-      {:noreply, assign(socket, :hero_drill, nil)}
+  def handle_event("card_bar_clicked", %{"cardId" => card_id}, socket) do
+    case Ecto.UUID.cast(card_id) do
+      {:ok, id} -> {:noreply, push_navigate(socket, to: ~p"/cards/#{id}")}
+      :error -> {:noreply, socket}
     end
   end
 
   @impl true
   def handle_async(:load_stats, {:ok, stats}, socket) do
-    {:noreply, assign(socket, :stats, stats)}
+    # Re-derive drill state now that the data to resolve it exists — this is
+    # what restores a deep-linked ?hero=…&aspect=… view after a fresh mount.
+    {:noreply, socket |> assign(:stats, stats) |> derive_drills()}
   end
 
   def handle_async(:load_stats, {:exit, reason}, socket) do
@@ -308,12 +297,49 @@ defmodule SanctumWeb.StatsLive.Index do
       totals: Stats.totals(),
       by_month: Stats.by_month(),
       per_hero: Stats.per_hero(),
-      by_aspect: Stats.by_aspect()
+      by_aspect: Stats.by_aspect(),
+      pack_releases: Stats.pack_releases()
     }
   end
 
-  defp top_hero_name([%{name: name} | _]), do: name
-  defp top_hero_name([]), do: "—"
+  # Resolve ?hero/?aspect params into drill state. Unknown or malformed
+  # params quietly resolve to a shallower level. Rows already loaded for the
+  # same hero/aspect are reused, so patch navigation between levels only
+  # queries what actually changed. No-op until the stats load lands.
+  defp derive_drills(%{assigns: %{stats: nil}} = socket), do: socket
+
+  defp derive_drills(socket) do
+    hero_drill = derive_hero_drill(socket, socket.assigns.drill_params.hero)
+    aspect_drill = derive_aspect_drill(socket, hero_drill, socket.assigns.drill_params.aspect)
+
+    assign(socket, hero_drill: hero_drill, aspect_drill: aspect_drill)
+  end
+
+  defp derive_hero_drill(_socket, nil), do: nil
+
+  defp derive_hero_drill(socket, id_param) do
+    with {:ok, id} <- Ecto.UUID.cast(id_param),
+         %{name: name} <- Enum.find(socket.assigns.stats.per_hero, &(&1.id == id)) do
+      case socket.assigns.hero_drill do
+        %{id: ^id} = current -> current
+        _ -> %{id: id, name: name, rows: Stats.by_aspect(id)}
+      end
+    else
+      _ -> nil
+    end
+  end
+
+  defp derive_aspect_drill(_socket, nil = _hero, _key), do: nil
+  defp derive_aspect_drill(_socket, _hero, nil = _key), do: nil
+
+  defp derive_aspect_drill(socket, hero, key) do
+    if List.keymember?(@aspect_colors, key, 0) do
+      case {socket.assigns.hero_drill, socket.assigns.aspect_drill} do
+        {%{id: hero_id}, %{key: ^key} = current} when hero_id == hero.id -> current
+        _ -> %{key: key, rows: Stats.top_cards(hero.id, key)}
+      end
+    end
+  end
 
   # Everything the hero drill-down panel needs for its current level:
   # all heroes → one hero's aspect split → one aspect's most-used cards.
@@ -340,7 +366,7 @@ defmodule SanctumWeb.StatsLive.Index do
       option: by_aspect_option(hero.rows, drill_from: hero.id, clickable: true),
       height: "260px",
       click_event: "aspect_bar_clicked",
-      back: "All heroes",
+      back: %{label: "All heroes", patch: ~p"/stats"},
       col: "Aspect",
       rows: Enum.map(hero.rows, fn {key, count} -> {aspect_label(key), count} end)
     }
@@ -351,18 +377,20 @@ defmodule SanctumWeb.StatsLive.Index do
 
     subtitle =
       if aspect.key == "basic",
-        do: "The basic cards appearing in the most of #{hero.name}'s aspect-less decks.",
-        else: "The #{label} cards appearing in the most of #{hero.name}'s #{label} decks."
+        do:
+          "The basic cards appearing in the most of #{hero.name}'s aspect-less decks. Click a bar to open the card.",
+        else:
+          "The #{label} cards appearing in the most of #{hero.name}'s #{label} decks. Click a bar to open the card."
 
     %{
       title: "#{hero.name} — top #{label} cards",
       subtitle: subtitle,
       option: top_cards_option(aspect.rows, aspect.key),
       height: "#{max(length(aspect.rows), 1) * 30 + 70}px",
-      click_event: nil,
-      back: "#{hero.name} aspects",
+      click_event: "card_bar_clicked",
+      back: %{label: "#{hero.name} aspects", patch: ~p"/stats?hero=#{hero.id}"},
       col: "Card",
-      rows: aspect.rows
+      rows: Enum.map(aspect.rows, fn {_id, name, count} -> {name, count} end)
     }
   end
 
@@ -380,7 +408,23 @@ defmodule SanctumWeb.StatsLive.Index do
   # Chrome (axis hairlines, text, tooltip surface) lives in the hook's
   # registered theme; these carry data and per-chart geometry.
 
-  defp by_month_option(rows) do
+  defp by_month_option(rows, pack_releases) do
+    {big_boxes, hero_packs} =
+      Enum.split_with(pack_releases, fn {_name, type, _date} -> type != "hero_pack" end)
+
+    # A dozen release days ship two hero packs at once — one marker per date,
+    # names joined, so diamonds never stack and the hover label names both.
+    hero_pack_markers =
+      hero_packs
+      |> Enum.group_by(fn {_name, _type, date} -> date end)
+      |> Enum.sort_by(fn {date, _packs} -> date end, Date)
+      |> Enum.map(fn {date, packs} ->
+        %{
+          name: Enum.map_join(packs, " · ", fn {name, _type, _date} -> name end),
+          coord: [Date.to_iso8601(date), 0]
+        }
+      end)
+
     %{
       grid: %{left: 8, right: 16, top: 16, bottom: 8},
       tooltip: %{trigger: "axis", axisPointer: %{type: "line", lineStyle: %{color: @hairline}}},
@@ -397,7 +441,42 @@ defmodule SanctumWeb.StatsLive.Index do
           symbolSize: 8,
           showSymbol: false,
           itemStyle: %{color: @gold, borderColor: @surface, borderWidth: 2},
-          areaStyle: %{color: @gold, opacity: 0.1}
+          areaStyle: %{color: @gold, opacity: 0.1},
+          # Big-box set releases as vertical markers — one step brighter than
+          # the grid so they read as annotations, not gridlines.
+          markLine: %{
+            symbol: "none",
+            lineStyle: %{color: "rgba(244, 241, 234, 0.25)", width: 1, type: "solid"},
+            label: %{
+              formatter: "{b}",
+              rotate: 90,
+              position: "insideEndTop",
+              color: @muted,
+              fontSize: 10
+            },
+            data:
+              Enum.map(big_boxes, fn {name, _type, date} ->
+                %{name: name, xAxis: Date.to_iso8601(date)}
+              end)
+          },
+          # Hero packs are too many for labeled lines (42 and counting) —
+          # they ride the baseline as diamonds, name(s) on hover.
+          markPoint: %{
+            symbol: "diamond",
+            symbolSize: 12,
+            itemStyle: %{color: @muted, borderColor: @surface, borderWidth: 2},
+            label: %{show: false},
+            emphasis: %{
+              label: %{
+                show: true,
+                formatter: "{b}",
+                position: "top",
+                color: "#f4f1ea",
+                fontSize: 11
+              }
+            },
+            data: hero_pack_markers
+          }
         }
       ]
     }
@@ -428,27 +507,13 @@ defmodule SanctumWeb.StatsLive.Index do
           universalTransition: %{enabled: true, divideShape: "clone"},
           data:
             Enum.map(rows, fn row ->
-              {from, to} = hero_gradient(row)
-
               %{
                 value: row.count,
                 # groupId ties each bar to its drill-down series; drill is
                 # our own payload, pushed back on click by the Chart hook.
                 groupId: row.id,
                 drill: %{heroId: row.id},
-                itemStyle: %{
-                  color: %{
-                    type: "linear",
-                    x: 0,
-                    y: 0,
-                    x2: 1,
-                    y2: 0,
-                    colorStops: [
-                      %{offset: 0, color: from},
-                      %{offset: 1, color: to}
-                    ]
-                  }
-                }
+                itemStyle: %{color: hero_color(row)}
               }
             end),
           barWidth: 14,
@@ -459,17 +524,20 @@ defmodule SanctumWeb.StatsLive.Index do
     }
   end
 
-  # The hero's brand gradient (the deck browser's convention), with each hex
-  # endpoint lightened until it clears a minimum contrast against the panel —
-  # several heroes' palettes are near-black (Black Widow: #140b09) and would
-  # otherwise paint an invisible bar. hsl() fallback gradients are already
-  # mid-lightness and pass through untouched.
-  defp hero_gradient(%{primary: from, secondary: to})
-       when is_binary(from) and is_binary(to) do
-    {visible_on_surface(from), visible_on_surface(to)}
+  # One color per hero: whichever of the hero's brand pair reads better
+  # against the panel — several primaries are near-black (Black Widow:
+  # #140b09), and her red secondary is the recognizable choice. The winner is
+  # then lightened until it clears the minimum contrast. Heroes without
+  # stored colors use the deck browser's set-hash fallback (hsl, already
+  # mid-lightness).
+  defp hero_color(%{primary: primary, secondary: secondary})
+       when is_binary(primary) and is_binary(secondary) do
+    [primary, secondary]
+    |> Enum.max_by(&contrast_vs_surface/1)
+    |> visible_on_surface()
   end
 
-  defp hero_gradient(%{set: set}), do: CardComponent.fallback_gradient(set)
+  defp hero_color(%{set: set}), do: CardComponent.fallback_gradient(set) |> elem(0)
 
   @min_bar_contrast 1.8
 
@@ -509,7 +577,7 @@ defmodule SanctumWeb.StatsLive.Index do
     Enum.map([r, g, b], &String.to_integer(&1, 16))
   end
 
-  defp by_aspect_option(rows, opts \\ []) do
+  defp by_aspect_option(rows, opts) do
     rows = Enum.reverse(rows)
     drill_from = Keyword.get(opts, :drill_from)
 
@@ -550,6 +618,34 @@ defmodule SanctumWeb.StatsLive.Index do
     }
   end
 
+  # The standalone aspect split as a donut. Segments keep the canonical
+  # aspect order (the order the palette's adjacency was validated in) and a
+  # 2px surface-colored border does the separating.
+  defp aspect_pie_option(rows) do
+    %{
+      tooltip: %{trigger: "item"},
+      series: [
+        %{
+          name: "Decks",
+          type: "pie",
+          radius: ["45%", "72%"],
+          data:
+            Enum.map(rows, fn {key, count} ->
+              %{
+                name: aspect_label(key),
+                value: count,
+                itemStyle: %{color: aspect_color(key)}
+              }
+            end),
+          itemStyle: %{borderColor: @surface, borderWidth: 2, borderRadius: 4},
+          label: %{color: @muted, fontSize: 12, formatter: "{b}  {c} ({d}%)"},
+          labelLine: %{lineStyle: %{color: @hairline}},
+          emphasis: %{scaleSize: 4}
+        }
+      ]
+    }
+  end
+
   defp top_cards_option(rows, aspect_key) do
     rows = Enum.reverse(rows)
 
@@ -559,7 +655,7 @@ defmodule SanctumWeb.StatsLive.Index do
       xAxis: %{type: "value", minInterval: 1},
       yAxis: %{
         type: "category",
-        data: Enum.map(rows, &elem(&1, 0)),
+        data: Enum.map(rows, fn {_id, name, _count} -> name end),
         axisLabel: %{interval: 0}
       },
       series: [
@@ -570,8 +666,11 @@ defmodule SanctumWeb.StatsLive.Index do
           universalTransition: %{enabled: true, divideShape: "clone"},
           # Morph out of (and back into) the aspect bar that was clicked.
           dataGroupId: aspect_key,
-          cursor: "default",
-          data: Enum.map(rows, &elem(&1, 1)),
+          data:
+            Enum.map(rows, fn {id, _name, count} ->
+              # Clicking a card bar navigates to its detail page.
+              %{value: count, drill: %{cardId: id}}
+            end),
           barWidth: 16,
           itemStyle: %{color: aspect_color(aspect_key), borderRadius: [0, 4, 4, 0]},
           label: %{show: true, position: "right", color: @muted, fontSize: 12}

--- a/lib/sanctum_web/live/stats_live/index.ex
+++ b/lib/sanctum_web/live/stats_live/index.ex
@@ -1,0 +1,320 @@
+defmodule SanctumWeb.StatsLive.Index do
+  @moduledoc """
+  Public "Vault Stats" page — deck-collection rollups (growth over time,
+  decks per hero, aspect splits) rendered as ECharts via the `Chart` hook.
+  Every chart has a data-table twin so no value is gated behind the canvas.
+  """
+  use SanctumWeb, :live_view
+
+  on_mount {SanctumWeb.LiveUserAuth, :live_user_optional}
+
+  alias Sanctum.Decks.Stats
+
+  @hero_limit 15
+
+  # Design tokens (assets/css/app.css) the chart options reference directly —
+  # ECharts renders to canvas, so CSS variables can't reach it.
+  @gold "#dbcb36"
+  @surface "#15151a"
+  @muted "rgba(244, 241, 234, 0.55)"
+  @hairline "#2a2a30"
+
+  # Chart-local variants of the aspect tokens, snapped into the dataviz
+  # dark-mode band (OKLCH L 0.48–0.67, C ≥ 0.10) and validated against the
+  # base-200 surface: adjacent-pair CVD ΔE ≥ 8 and normal-vision ΔE ≥ 15 in
+  # this display order. "Basic" is deliberately the de-emphasis gray — every
+  # bar's identity is carried by its axis label, never color alone.
+  @aspect_colors [
+    {"aggression", "Aggression", "#b21f26"},
+    {"justice", "Justice", "#a59318"},
+    {"leadership", "Leadership", "#2fa4af"},
+    {"protection", "Protection", "#4c9800"},
+    {"pool", "Pool", "#cd6e9d"},
+    {"basic", "Basic", "#5c5b66"}
+  ]
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app current_user={@current_user} flash={@flash} active_tab={:stats}>
+      <.header>
+        Vault Stats
+        <:subtitle>
+          The deck vault by the numbers — growth over time, hero popularity, and aspect splits.
+        </:subtitle>
+      </.header>
+
+      <div :if={@stats == nil} class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div :for={_ <- 1..4} class="h-20 animate-pulse border-[3px] border-neutral bg-base-300" />
+      </div>
+
+      <div :if={@stats != nil} class="flex flex-col gap-6">
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <.stat_tile label="Decks" value={@stats.totals.decks} />
+          <.stat_tile label="Heroes built" value={@stats.totals.heroes} />
+          <.stat_tile label="Added this month" value={@stats.totals.this_month} />
+          <.text_tile label="Most built hero" value={top_hero_name(@stats.per_hero)} />
+        </div>
+
+        <.chart_panel
+          :if={@stats.totals.decks > 0}
+          id="decks-by-month"
+          title="Decks added over time"
+          subtitle="New decks per month, by their MarvelCDB publish date."
+          option={by_month_option(@stats.by_month)}
+          height="h-80"
+        >
+          <:table_head>
+            <th class="pr-6 text-left">Month</th>
+            <th class="text-right">Decks</th>
+          </:table_head>
+          <tr :for={{month, count} <- Enum.reverse(@stats.by_month)}>
+            <td class="pr-6">{Calendar.strftime(month, "%b %Y")}</td>
+            <td class="text-right tabular-nums">{count}</td>
+          </tr>
+        </.chart_panel>
+
+        <.chart_panel
+          :if={@stats.totals.decks > 0}
+          id="decks-per-hero"
+          title={"Top #{length(@stats.per_hero)} heroes"}
+          subtitle={"Heroes with the most decks in the vault, of #{@stats.totals.heroes} heroes built."}
+          option={per_hero_option(@stats.per_hero)}
+          height="h-[560px]"
+        >
+          <:table_head>
+            <th class="pr-6 text-left">Hero</th>
+            <th class="text-right">Decks</th>
+          </:table_head>
+          <tr :for={{name, count} <- @stats.per_hero}>
+            <td class="pr-6">{name}</td>
+            <td class="text-right tabular-nums">{count}</td>
+          </tr>
+        </.chart_panel>
+
+        <.chart_panel
+          :if={@stats.totals.decks > 0}
+          id="decks-by-aspect"
+          title="Decks by aspect"
+          subtitle="Multi-aspect decks count once under each aspect; basic decks run no aspect."
+          option={by_aspect_option(@stats.by_aspect)}
+          height="h-72"
+        >
+          <:table_head>
+            <th class="pr-6 text-left">Aspect</th>
+            <th class="text-right">Decks</th>
+          </:table_head>
+          <tr :for={{aspect, count} <- @stats.by_aspect}>
+            <td class="pr-6">{aspect_label(aspect)}</td>
+            <td class="text-right tabular-nums">{count}</td>
+          </tr>
+        </.chart_panel>
+
+        <.panel :if={@stats.totals.decks == 0} class="p-8 text-center">
+          <p class="font-anton text-lg uppercase tracking-[0.05em] text-base-content/60">
+            No decks in the vault yet
+          </p>
+        </.panel>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :title, :string, required: true
+  attr :subtitle, :string, required: true
+  attr :option, :map, required: true
+  attr :height, :string, required: true
+  slot :table_head, required: true
+  slot :inner_block, required: true
+
+  defp chart_panel(assigns) do
+    ~H"""
+    <.panel class="p-4 sm:p-5">
+      <h2 class="font-anton text-lg uppercase tracking-[0.05em]">{@title}</h2>
+      <p class="mb-3 font-barlow-condensed text-sm text-base-content/55">{@subtitle}</p>
+      <div
+        id={"#{@id}-chart"}
+        phx-hook="Chart"
+        phx-update="ignore"
+        data-option={Jason.encode!(@option)}
+        class={["w-full", @height]}
+        role="img"
+        aria-label={"#{@title} chart — the same data is in the table below."}
+      >
+      </div>
+      <details class="mt-3">
+        <summary class="cursor-pointer font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+          View data
+        </summary>
+        <div class="mt-2 max-h-64 overflow-y-auto">
+          <table class="font-barlow-condensed text-sm">
+            <thead>
+              <tr class="font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+                {render_slot(@table_head)}
+              </tr>
+            </thead>
+            <tbody>
+              {render_slot(@inner_block)}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </.panel>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :integer, required: true
+
+  defp stat_tile(assigns) do
+    ~H"""
+    <div class="border-[3px] border-neutral bg-base-300 px-4 py-3">
+      <div class="font-bangers text-3xl leading-none text-primary">{@value}</div>
+      <div class="mt-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+        {@label}
+      </div>
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+
+  defp text_tile(assigns) do
+    ~H"""
+    <div class="border-[3px] border-neutral bg-base-300 px-4 py-3">
+      <div class="truncate font-barlow-condensed text-xl font-bold leading-none text-primary">
+        {@value}
+      </div>
+      <div class="mt-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+        {@label}
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket = assign(socket, page_title: "Vault Stats", stats: nil)
+
+    # Defer the rollup queries past the static render so the shell paints
+    # immediately (same pattern as the admin health snapshot).
+    socket =
+      if connected?(socket), do: start_async(socket, :load_stats, &load_stats/0), else: socket
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_async(:load_stats, {:ok, stats}, socket) do
+    {:noreply, assign(socket, :stats, stats)}
+  end
+
+  def handle_async(:load_stats, {:exit, reason}, socket) do
+    {:noreply,
+     socket
+     |> assign(:stats, %{
+       totals: %{decks: 0, heroes: 0, this_month: 0},
+       by_month: [],
+       per_hero: [],
+       by_aspect: []
+     })
+     |> put_flash(:error, "Stats failed to load: #{inspect(reason)}")}
+  end
+
+  defp load_stats do
+    %{
+      totals: Stats.totals(),
+      by_month: Stats.by_month(),
+      per_hero: Stats.per_hero(@hero_limit),
+      by_aspect: Stats.by_aspect()
+    }
+  end
+
+  defp top_hero_name([{name, _count} | _]), do: name
+  defp top_hero_name([]), do: "—"
+
+  defp aspect_label(key) do
+    {_, label, _} = List.keyfind!(@aspect_colors, key, 0)
+    label
+  end
+
+  defp aspect_color(key) do
+    {_, _, color} = List.keyfind!(@aspect_colors, key, 0)
+    color
+  end
+
+  # ── ECharts options ──────────────────────────────────────────────────────
+  # Chrome (axis hairlines, text, tooltip surface) lives in the hook's
+  # registered theme; these carry data and per-chart geometry.
+
+  defp by_month_option(rows) do
+    %{
+      grid: %{left: 8, right: 16, top: 16, bottom: 8, containLabel: true},
+      tooltip: %{trigger: "axis", axisPointer: %{type: "line", lineStyle: %{color: @hairline}}},
+      xAxis: %{type: "time"},
+      yAxis: %{type: "value", minInterval: 1},
+      series: [
+        %{
+          name: "Decks added",
+          type: "line",
+          data: Enum.map(rows, fn {month, count} -> [Date.to_iso8601(month), count] end),
+          lineStyle: %{width: 2, color: @gold, cap: "round", join: "round"},
+          # 8px marker with a 2px surface ring, shown on hover/emphasis.
+          symbol: "circle",
+          symbolSize: 8,
+          showSymbol: false,
+          itemStyle: %{color: @gold, borderColor: @surface, borderWidth: 2},
+          areaStyle: %{color: @gold, opacity: 0.1}
+        }
+      ]
+    }
+  end
+
+  defp per_hero_option(rows) do
+    # ECharts category axes run bottom-up; reverse so rank 1 sits on top.
+    rows = Enum.reverse(rows)
+
+    %{
+      grid: %{left: 8, right: 40, top: 8, bottom: 8, containLabel: true},
+      tooltip: %{trigger: "item"},
+      xAxis: %{type: "value", minInterval: 1},
+      yAxis: %{type: "category", data: Enum.map(rows, &elem(&1, 0))},
+      series: [
+        %{
+          name: "Decks",
+          type: "bar",
+          data: Enum.map(rows, &elem(&1, 1)),
+          barWidth: 16,
+          itemStyle: %{color: @gold, borderRadius: [0, 4, 4, 0]},
+          label: %{show: true, position: "right", color: @muted, fontSize: 12}
+        }
+      ]
+    }
+  end
+
+  defp by_aspect_option(rows) do
+    rows = Enum.reverse(rows)
+
+    %{
+      grid: %{left: 8, right: 40, top: 8, bottom: 8, containLabel: true},
+      tooltip: %{trigger: "item"},
+      xAxis: %{type: "value", minInterval: 1},
+      yAxis: %{type: "category", data: Enum.map(rows, fn {key, _} -> aspect_label(key) end)},
+      series: [
+        %{
+          name: "Decks",
+          type: "bar",
+          data:
+            Enum.map(rows, fn {key, count} ->
+              %{value: count, itemStyle: %{color: aspect_color(key)}}
+            end),
+          barWidth: 16,
+          itemStyle: %{borderRadius: [0, 4, 4, 0]},
+          label: %{show: true, position: "right", color: @muted, fontSize: 12}
+        }
+      ]
+    }
+  end
+end

--- a/lib/sanctum_web/live/stats_live/index.ex
+++ b/lib/sanctum_web/live/stats_live/index.ex
@@ -9,8 +9,7 @@ defmodule SanctumWeb.StatsLive.Index do
   on_mount {SanctumWeb.LiveUserAuth, :live_user_optional}
 
   alias Sanctum.Decks.Stats
-
-  @hero_limit 15
+  alias SanctumWeb.Components.Card, as: CardComponent
 
   # Design tokens (assets/css/app.css) the chart options reference directly —
   # ECharts renders to canvas, so CSS variables can't reach it.
@@ -62,7 +61,7 @@ defmodule SanctumWeb.StatsLive.Index do
           title="Decks added over time"
           subtitle="New decks per month, by their MarvelCDB publish date."
           option={by_month_option(@stats.by_month)}
-          height="h-80"
+          height="320px"
         >
           <:table_head>
             <th class="pr-6 text-left">Month</th>
@@ -77,18 +76,18 @@ defmodule SanctumWeb.StatsLive.Index do
         <.chart_panel
           :if={@stats.totals.decks > 0}
           id="decks-per-hero"
-          title={"Top #{length(@stats.per_hero)} heroes"}
-          subtitle={"Heroes with the most decks in the vault, of #{@stats.totals.heroes} heroes built."}
+          title="Decks per hero"
+          subtitle={"Every hero with a deck in the vault — all #{@stats.totals.heroes} of them, each bar in the hero's own colors."}
           option={per_hero_option(@stats.per_hero)}
-          height="h-[560px]"
+          height={"#{length(@stats.per_hero) * 24 + 70}px"}
         >
           <:table_head>
             <th class="pr-6 text-left">Hero</th>
             <th class="text-right">Decks</th>
           </:table_head>
-          <tr :for={{name, count} <- @stats.per_hero}>
-            <td class="pr-6">{name}</td>
-            <td class="text-right tabular-nums">{count}</td>
+          <tr :for={row <- @stats.per_hero}>
+            <td class="pr-6">{row.name}</td>
+            <td class="text-right tabular-nums">{row.count}</td>
           </tr>
         </.chart_panel>
 
@@ -98,7 +97,7 @@ defmodule SanctumWeb.StatsLive.Index do
           title="Decks by aspect"
           subtitle="Multi-aspect decks count once under each aspect; basic decks run no aspect."
           option={by_aspect_option(@stats.by_aspect)}
-          height="h-72"
+          height="288px"
         >
           <:table_head>
             <th class="pr-6 text-left">Aspect</th>
@@ -138,7 +137,8 @@ defmodule SanctumWeb.StatsLive.Index do
         phx-hook="Chart"
         phx-update="ignore"
         data-option={Jason.encode!(@option)}
-        class={["w-full", @height]}
+        class="w-full"
+        style={"height: #{@height}"}
         role="img"
         aria-label={"#{@title} chart — the same data is in the table below."}
       >
@@ -227,12 +227,12 @@ defmodule SanctumWeb.StatsLive.Index do
     %{
       totals: Stats.totals(),
       by_month: Stats.by_month(),
-      per_hero: Stats.per_hero(@hero_limit),
+      per_hero: Stats.per_hero(),
       by_aspect: Stats.by_aspect()
     }
   end
 
-  defp top_hero_name([{name, _count} | _]), do: name
+  defp top_hero_name([%{name: name} | _]), do: name
   defp top_hero_name([]), do: "—"
 
   defp aspect_label(key) do
@@ -280,18 +280,93 @@ defmodule SanctumWeb.StatsLive.Index do
       grid: %{left: 8, right: 40, top: 8, bottom: 8, containLabel: true},
       tooltip: %{trigger: "item"},
       xAxis: %{type: "value", minInterval: 1},
-      yAxis: %{type: "category", data: Enum.map(rows, &elem(&1, 0))},
+      yAxis: %{
+        type: "category",
+        data: Enum.map(rows, & &1.name),
+        # Never skip hero names — the axis label is each bar's identity.
+        axisLabel: %{interval: 0}
+      },
       series: [
         %{
           name: "Decks",
           type: "bar",
-          data: Enum.map(rows, &elem(&1, 1)),
-          barWidth: 16,
-          itemStyle: %{color: @gold, borderRadius: [0, 4, 4, 0]},
+          data:
+            Enum.map(rows, fn row ->
+              {from, to} = hero_gradient(row)
+
+              %{
+                value: row.count,
+                itemStyle: %{
+                  color: %{
+                    type: "linear",
+                    x: 0,
+                    y: 0,
+                    x2: 1,
+                    y2: 0,
+                    colorStops: [
+                      %{offset: 0, color: from},
+                      %{offset: 1, color: to}
+                    ]
+                  }
+                }
+              }
+            end),
+          barWidth: 14,
+          itemStyle: %{borderRadius: [0, 4, 4, 0]},
           label: %{show: true, position: "right", color: @muted, fontSize: 12}
         }
       ]
     }
+  end
+
+  # The hero's brand gradient (the deck browser's convention), with each hex
+  # endpoint lightened until it clears a minimum contrast against the panel —
+  # several heroes' palettes are near-black (Black Widow: #140b09) and would
+  # otherwise paint an invisible bar. hsl() fallback gradients are already
+  # mid-lightness and pass through untouched.
+  defp hero_gradient(%{primary: from, secondary: to})
+       when is_binary(from) and is_binary(to) do
+    {visible_on_surface(from), visible_on_surface(to)}
+  end
+
+  defp hero_gradient(%{set: set}), do: CardComponent.fallback_gradient(set)
+
+  @min_bar_contrast 1.8
+
+  defp visible_on_surface(<<"#", _::binary-size(6)>> = hex) do
+    if contrast_vs_surface(hex) >= @min_bar_contrast do
+      hex
+    else
+      hex |> lighten(0.12) |> visible_on_surface()
+    end
+  end
+
+  defp visible_on_surface(_other), do: @gold
+
+  defp contrast_vs_surface(hex) do
+    {l1, l2} = {rel_luminance(hex), rel_luminance(@surface)}
+    (max(l1, l2) + 0.05) / (min(l1, l2) + 0.05)
+  end
+
+  defp rel_luminance(hex) do
+    [r, g, b] =
+      hex
+      |> rgb()
+      |> Enum.map(fn c ->
+        v = c / 255
+        if v <= 0.04045, do: v / 12.92, else: ((v + 0.055) / 1.055) ** 2.4
+      end)
+
+    0.2126 * r + 0.7152 * g + 0.0722 * b
+  end
+
+  defp lighten(hex, amount) do
+    [r, g, b] = hex |> rgb() |> Enum.map(&round(&1 + (255 - &1) * amount))
+    "#" <> Base.encode16(<<r, g, b>>, case: :lower)
+  end
+
+  defp rgb(<<"#", r::binary-2, g::binary-2, b::binary-2>>) do
+    Enum.map([r, g, b], &String.to_integer(&1, 16))
   end
 
   defp by_aspect_option(rows) do

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -87,6 +87,9 @@ defmodule SanctumWeb.Router do
       # Public "Flavor Town" flavor-text guessing mini-game.
       live "/flavor-town", GuessLive.Play, :index
 
+      # Public deck-collection stats.
+      live "/stats", StatsLive.Index, :index
+
       # Dev playground for refining the comic stat badges.
       live "/dev/stat-badges", DevLive.StatBadges, :index
     end


### PR DESCRIPTION
## Summary

Adds a public **Vault Stats** page at `/stats` (linked in the sidebar), built on Apache ECharts via a new `Chart` LiveView hook themed to the comic-dossier design system.

- **KPI tiles** — decks, unique cards, heroes, villains, decks added this month, with per-tile accent colors from existing design tokens.
- **Decks added over time** — monthly line chart keyed to MarvelCDB publish dates (with `inserted_at` fallback for native decks), annotated with labeled marklines for big-box set releases and hoverable baseline diamonds for hero packs (grouped when two packs share a release date).
- **Decks by aspect** — donut with counts and percentages, using chart-local aspect color variants validated for colorblind separation against the dark surface.
- **Decks per hero** — every hero with a deck, each bar in the hero's own brand color (contrast-floored so near-black palettes stay visible), with a three-level drill-down: hero → aspect split → top 10 cards of that aspect (click a card bar to open its detail page). Levels morph via ECharts universal transitions.
- **Drill state lives in the URL** (`?hero=<id>&aspect=<key>`) — browser back/forward walks the levels, deep links work, and returning from a card page restores the view.
- Every chart has a "View data" table twin, so no value is gated behind the canvas or a hover.

## Implementation notes

- `Sanctum.Decks.Stats` — read-only schemaless-Ecto rollups (same pattern as the admin health snapshot); deck reads are public so no policy is bypassed.
- The `Chart` hook is generic: options serialized to `data-option`, heights via `data-height` (`phx-update="ignore"` only patches `data-*` attributes), canvas resized before `setOption` (resizing mid-morph corrupts the transition layout), and a generic per-mark `drill` click payload.
- ECharts is tree-shaken via `echarts/core` (bar/line/pie + grid/tooltip/markLine/markPoint only).

## Testing

- `mix ck` clean, full test suite passing.
- Exercised in the browser (playwright): all three drill levels and morphs, back buttons, browser back/forward, deep links, malformed URL params, card navigation, tooltips, and marker hovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)