### PR TITLE
style(collection): subtle check mark + tooltip for the owned badge

### DIFF
--- a/lib/sanctum_web/components/collection.ex
+++ b/lib/sanctum_web/components/collection.ex
@@ -9,20 +9,20 @@ defmodule SanctumWeb.Components.Collection do
   import SanctumWeb.CoreComponents, only: [icon: 1]
 
   @doc """
-  A small comic-style chip marking something as in the user's collection.
+  A subtle check mark marking something as in the user's collection, with the
+  explanation in a hover tooltip.
   """
   attr :class, :any, default: nil
-  attr :label, :string, default: "Owned"
+  attr :title, :string, default: "In your collection"
 
   def owned_badge(assigns) do
     ~H"""
-    <span class={[
-      "inline-flex flex-none items-center gap-0.5 border border-primary/60 bg-primary/15 px-1.5 py-px",
-      "font-ibm-mono text-[9px] uppercase leading-4 tracking-[0.14em] text-primary",
-      @class
-    ]}>
-      <.icon name="hero-check" class="size-2.5" />
-      {@label}
+    <span
+      title={@title}
+      class={["inline-flex flex-none items-center justify-center text-success", @class]}
+    >
+      <.icon name="hero-check" class="size-3.5" />
+      <span class="sr-only">{@title}</span>
     </span>
     """
   end

--- a/lib/sanctum_web/live/browse_live/index.ex
+++ b/lib/sanctum_web/live/browse_live/index.ex
@@ -240,7 +240,8 @@ defmodule SanctumWeb.BrowseLive.Index do
           </span>
           <.owned_badge
             :if={MapSet.member?(@owned_pack_ids, pack.id)}
-            class="absolute right-1.5 top-1.5 bg-base-100/90"
+            title="Pack in your collection"
+            class="absolute right-1.5 top-1.5 size-5 rounded-[4px] bg-base-100/85"
           />
         </div>
         <div class="flex flex-1 flex-col gap-1 p-2.5">

--- a/test/sanctum_web/live/browse_live/browse_test.exs
+++ b/test/sanctum_web/live/browse_live/browse_test.exs
@@ -106,9 +106,9 @@ defmodule SanctumWeb.BrowseLiveTest do
       assert html =~ "1 / 1 owned"
       assert Sanctum.Collections.pack_owned?(pack.id, user)
 
-      # The browse index shows the owned chip on the pack tile.
+      # The browse index shows the owned check on the pack tile.
       {:ok, index, _html} = live(conn, ~p"/browse")
-      assert render_async(index) =~ "Owned"
+      assert render_async(index) =~ "Pack in your collection"
     end
 
     test "a per-card toggle records an override without touching the pack", %{

--- a/test/sanctum_web/live/card_live/detail_test.exs
+++ b/test/sanctum_web/live/card_live/detail_test.exs
@@ -187,12 +187,12 @@ defmodule SanctumWeb.CardLive.DetailTest do
       Sanctum.Collections.add_pack!(pack.id, actor: user)
 
       {:ok, lv, _html} = live(conn, ~p"/cards")
-      assert render_async(lv) =~ "Owned"
+      assert render_async(lv) =~ "In your collection"
 
       {:ok, anon_lv, _html} = live(build_conn(), ~p"/cards")
       anon_html = render_async(anon_lv)
       assert anon_html =~ ~p"/cards/#{card.id}"
-      refute anon_html =~ "Owned"
+      refute anon_html =~ "In your collection"
     end
   end
 end


### PR DESCRIPTION
## Summary

- Replace the bordered "✓ OWNED" chip (`owned_badge`) with a small green check icon; the meaning moves to a hover tooltip plus an `sr-only` label for screen readers
- Default tooltip is "In your collection"; the browse pack grid passes "Pack in your collection" and keeps a translucent backdrop chip so the check stays readable over cover art
- Matches the check-icon pattern already used on the deck show page

All three call sites verified in the running app: browse pack grid, card pool tiles, and the card detail Collection section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)