### PR TITLE
feat: site-wide search (⌘K palette across cards, decks, packs, heroes, villains, scenarios, sets)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -836,6 +836,19 @@ textarea::placeholder {
   white-space: nowrap;
 }
 
+/* Global search bar (GlobalSearch hook): navigable result rows share the
+   qi-option chrome; gs-active mirrors qi-active for the virtual list. */
+.qi-kind-result {
+  color: var(--color-base-content);
+}
+a.qi-option {
+  text-decoration: none;
+}
+[data-gs-nav].gs-active {
+  background: var(--color-base-300);
+  box-shadow: inset 3px 0 0 var(--color-primary);
+}
+
 /* Search-syntax help page tables (SearchHelpLive) */
 .qh-table {
   width: 100%;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -847,11 +847,15 @@ textarea::placeholder {
     transform: translateY(0);
   }
 }
-.gs-sheet {
+/* Applied by the GlobalSearch hook only while opening (removed on
+   animationend): LiveView patches re-toggle the overlay's `hidden` class,
+   and a display flip restarts any always-on animation — the sheet would
+   replay its slide-up on every result patch while typing. */
+.gs-sheet-opening {
   animation: gs-slide-up 0.22s ease-out;
 }
 @media (min-width: 640px) {
-  .gs-sheet {
+  .gs-sheet-opening {
     animation: none;
   }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -836,8 +836,26 @@ textarea::placeholder {
   white-space: nowrap;
 }
 
-/* Global search bar (GlobalSearch hook): navigable result rows share the
-   qi-option chrome; gs-active mirrors qi-active for the virtual list. */
+/* Global search overlay (GlobalSearch hook): slide-up sheet on mobile,
+   static centered dialog on sm+. Navigable result rows share the qi-option
+   chrome; gs-active mirrors qi-active for the virtual list. */
+@keyframes gs-slide-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+.gs-sheet {
+  animation: gs-slide-up 0.22s ease-out;
+}
+@media (min-width: 640px) {
+  .gs-sheet {
+    animation: none;
+  }
+}
+
 .qi-kind-result {
   color: var(--color-base-content);
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -61,6 +61,17 @@ const liveSocket = new LiveSocket("/live", Socket, {
 // LiveView DOM patches).
 window.addEventListener("sanctum:close-drawer", e => { e.target.checked = false })
 
+// Scroll to the URL fragment once async content exists. Pushed by pages that
+// render their anchor targets after mount (e.g. /browse/:pack#<set_code>) —
+// the browser's native fragment scroll fires too early for those.
+window.addEventListener("phx:sanctum:scroll-to-hash", () => {
+  const id = decodeURIComponent(window.location.hash.slice(1))
+  if (!id) return
+  requestAnimationFrame(() =>
+    document.getElementById(id)?.scrollIntoView({behavior: "smooth", block: "start"})
+  )
+})
+
 // Show progress bar on live navigation and form submits
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
 window.addEventListener("phx:page-loading-start", _info => topbar.show(300))

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,6 +28,7 @@ import topbar from "../vendor/topbar"
 import CardDrag from "./hooks/card-drag";
 import Chart from "./hooks/chart";
 import DragDrop from "./hooks/drag-drop";
+import GlobalSearch from "./hooks/global-search";
 import LayoutHand from "./hooks/layout-hand";
 import QueryInput from "./hooks/query-input";
 import ResponsivePlaceholder from "./hooks/responsive-placeholder";
@@ -52,7 +53,7 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks, CardDrag, Chart, DragDrop, LayoutHand, QueryInput, ResponsivePlaceholder, ScrollRestore},
+  hooks: {...colocatedHooks, CardDrag, Chart, DragDrop, GlobalSearch, LayoutHand, QueryInput, ResponsivePlaceholder, ScrollRestore},
 })
 
 // Uncheck the daisyUI drawer toggle when a sidebar link is clicked, so the

--- a/assets/js/hooks/global-search.js
+++ b/assets/js/hooks/global-search.js
@@ -1,0 +1,271 @@
+// Site-wide search bar: the QueryInput pattern (syntax-highlight mirror +
+// server-driven suggestions) extended with a server-rendered results panel.
+//
+// The dropdown panel stacks two sections:
+//
+//   * a JS-managed suggestion listbox (phx-update="ignore", filled from the
+//     "suggest" reply — text-insert items, exactly like QueryInput)
+//   * server-rendered result rows/links marked with [data-gs-nav], patched by
+//     LiveView as the debounced "search" form event returns groups
+//
+// Keyboard nav walks one virtual list across both sections: indexes below
+// items.length are suggestions (Enter splices the insert text), the rest are
+// result anchors (Enter clicks them). Enter with nothing active opens the
+// first result. The hook lives inside a LiveComponent, so all events go
+// through pushEventTo(this.el, ...).
+//
+// Also owns the app's global search shortcut: Cmd/Ctrl+K focuses the input.
+
+import {paintMirror} from "./query-syntax"
+
+export default {
+  mounted() {
+    this.input = this.el.querySelector("input")
+    this.mirror = document.getElementById(`${this.el.id}-mirror`)
+    this.listbox = document.getElementById(`${this.el.id}-listbox`)
+    this.panel = document.getElementById(`${this.el.id}-panel`)
+    this.knownFields = new Set(JSON.parse(this.el.dataset.fields || "[]"))
+    this.items = []
+    this.navEls = []
+    this.active = -1
+    this.open = false
+    this.suggestTimer = null
+
+    this.paint()
+    this.scanResults()
+
+    this.onInput = () => { this.paint(); this.queueSuggest(); this.show() }
+    this.onScroll = () => { this.mirror.scrollLeft = this.input.scrollLeft }
+    this.onFocus = () => { this.queueSuggest(); this.show() }
+    this.onClick = () => this.queueSuggest()
+    this.onBlur = () => setTimeout(() => this.hide(), 120)
+    this.onKeydown = (e) => this.handleKey(e)
+
+    this.input.addEventListener("input", this.onInput)
+    this.input.addEventListener("scroll", this.onScroll)
+    this.input.addEventListener("focus", this.onFocus)
+    this.input.addEventListener("click", this.onClick)
+    this.input.addEventListener("blur", this.onBlur)
+    this.input.addEventListener("keydown", this.onKeydown)
+
+    this.onGlobalKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault()
+        this.input.focus()
+        this.input.select()
+      }
+    }
+    window.addEventListener("keydown", this.onGlobalKey)
+  },
+
+  // LiveView patched the component (new result groups, cleared input, …):
+  // repaint, rescan the result anchors, and re-assert panel visibility (the
+  // patch resets the server-rendered "hidden" class).
+  updated() {
+    this.paint()
+    this.scanResults()
+    this.syncPanel()
+  },
+
+  destroyed() {
+    clearTimeout(this.suggestTimer)
+    window.removeEventListener("keydown", this.onGlobalKey)
+  },
+
+  paint() {
+    paintMirror(this.mirror, this.input.value, this.knownFields)
+    this.mirror.scrollLeft = this.input.scrollLeft
+  },
+
+  // -- results section ---------------------------------------------------------
+
+  scanResults() {
+    this.navEls = Array.from(this.el.querySelectorAll("[data-gs-nav]"))
+    this.navEls.forEach((el, i) => {
+      el.id = `${this.el.id}-res-${i}`
+      el.classList.remove("gs-active")
+      el.addEventListener("mousemove", () => this.setActive(this.items.length + i))
+    })
+    // Result rows changed under the cursor — a result index no longer points
+    // where it did. Suggestion indexes are still valid.
+    if (this.active >= this.items.length) this.setActive(-1)
+  },
+
+  // -- suggestions section -------------------------------------------------------
+
+  queueSuggest() {
+    clearTimeout(this.suggestTimer)
+    this.suggestTimer = setTimeout(() => {
+      this.pushEventTo(this.el, "suggest",
+        {value: this.input.value, cursor: this.input.selectionStart ?? 0},
+        (reply) => this.showSuggestions(reply)
+      )
+    }, 120)
+  },
+
+  showSuggestions(reply) {
+    if (document.activeElement !== this.input) return
+    this.items = reply.items || []
+    this.replaceStart = reply.start
+    this.replaceLength = reply.length
+    this.setActive(-1)
+
+    this.listbox.textContent = ""
+    this.listbox.classList.toggle("hidden", this.items.length === 0)
+
+    this.items.forEach((item, i) => {
+      const li = document.createElement("div")
+      li.id = `${this.el.id}-opt-${i}`
+      li.setAttribute("role", "option")
+      li.className = "qi-option"
+      li.dataset.index = i
+
+      const label = document.createElement("span")
+      label.className = `qi-option-label qi-kind-${item.kind}`
+      label.textContent = item.label
+      li.appendChild(label)
+
+      if (item.detail) {
+        const detail = document.createElement("span")
+        detail.className = "qi-option-detail"
+        detail.textContent = item.detail
+        li.appendChild(detail)
+      }
+
+      // mousedown (not click) so the input never loses focus.
+      li.addEventListener("mousedown", (e) => {
+        e.preventDefault()
+        this.accept(i)
+      })
+      li.addEventListener("mousemove", () => this.setActive(i))
+
+      this.listbox.appendChild(li)
+    })
+
+    this.show()
+  },
+
+  accept(i) {
+    const item = this.items[i]
+    if (!item) return
+
+    const v = this.input.value
+    const before = v.slice(0, this.replaceStart)
+    const after = v.slice(this.replaceStart + this.replaceLength)
+    this.input.value = before + item.insert + after
+
+    const caret = this.replaceStart + item.insert.length
+    this.input.setSelectionRange(caret, caret)
+    this.paint()
+    this.items = []
+    this.listbox.textContent = ""
+    this.listbox.classList.add("hidden")
+    this.setActive(-1)
+
+    // Bubble a real input event so the form's phx-change fires (debounced
+    // results refresh), then offer the next completion step.
+    this.input.dispatchEvent(new Event("input", {bubbles: true}))
+  },
+
+  // -- panel + virtual list -------------------------------------------------------
+
+  show() {
+    this.open = true
+    this.syncPanel()
+  },
+
+  hide() {
+    this.open = false
+    this.setActive(-1)
+    this.syncPanel()
+  },
+
+  syncPanel() {
+    if (!this.panel) return
+    const empty = this.items.length === 0 && this.panel.querySelector("[data-gs-content]") == null
+    this.panel.classList.toggle("hidden", !this.open || empty)
+    this.listbox.classList.toggle("hidden", this.items.length === 0)
+    this.input.setAttribute("aria-expanded", this.open ? "true" : "false")
+  },
+
+  total() {
+    return this.items.length + this.navEls.length
+  },
+
+  setActive(i) {
+    this.active = i
+
+    for (const li of this.listbox.children) {
+      li.classList.toggle("qi-active", Number(li.dataset.index) === i)
+    }
+    this.navEls.forEach((el, j) => {
+      el.classList.toggle("gs-active", this.items.length + j === i)
+    })
+
+    if (i >= 0 && i < this.items.length) {
+      this.input.setAttribute("aria-activedescendant", `${this.el.id}-opt-${i}`)
+      this.listbox.children[i]?.scrollIntoView({block: "nearest"})
+    } else if (i >= this.items.length && i < this.total()) {
+      const el = this.navEls[i - this.items.length]
+      this.input.setAttribute("aria-activedescendant", el.id)
+      el.scrollIntoView({block: "nearest"})
+    } else {
+      this.input.removeAttribute("aria-activedescendant")
+    }
+  },
+
+  handleKey(e) {
+    const isOpen = this.open && !this.panel.classList.contains("hidden")
+
+    if (!isOpen) {
+      if (e.key === "ArrowDown") {
+        this.queueSuggest()
+        this.show()
+      }
+      return
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault()
+        if (this.total() > 0) this.setActive((this.active + 1) % this.total())
+        break
+      case "ArrowUp":
+        e.preventDefault()
+        if (this.total() > 0) this.setActive((this.active - 1 + this.total()) % this.total())
+        break
+      case "Enter":
+        if (this.active >= 0 && this.active < this.items.length) {
+          e.preventDefault()
+          this.accept(this.active)
+        } else if (this.active >= this.items.length && this.navEls[this.active - this.items.length]) {
+          e.preventDefault()
+          this.navEls[this.active - this.items.length].click()
+        } else if (this.navEls.length > 0) {
+          // nothing highlighted: open the first result
+          e.preventDefault()
+          this.navEls[0].click()
+        }
+        // otherwise fall through to the form's phx-submit
+        break
+      case "Tab":
+        if (this.active >= 0 && this.active < this.items.length) {
+          e.preventDefault()
+          this.accept(this.active)
+        } else if (this.items.length > 0) {
+          e.preventDefault()
+          this.accept(0)
+        }
+        break
+      case "Escape":
+        e.preventDefault()
+        if (this.active >= 0) {
+          this.setActive(-1)
+        } else {
+          this.hide()
+          this.input.blur()
+        }
+        break
+    }
+  },
+}

--- a/assets/js/hooks/global-search.js
+++ b/assets/js/hooks/global-search.js
@@ -98,9 +98,25 @@ export default {
     this.open = true
     this.syncOverlay()
     this.syncPanel()
+    this.animateSheetIn()
     this.input.focus()
     this.input.select()
     this.queueSuggest()
+  },
+
+  // The slide-up runs off a temporary class so it plays exactly once per
+  // open — an always-on animation would replay every time a LiveView patch
+  // re-toggles the overlay's `hidden` class (a display flip resets CSS
+  // animations).
+  animateSheetIn() {
+    const sheet = this.overlay?.querySelector(".gs-sheet")
+    if (!sheet) return
+    sheet.classList.add("gs-sheet-opening")
+    sheet.addEventListener(
+      "animationend",
+      () => sheet.classList.remove("gs-sheet-opening"),
+      {once: true}
+    )
   },
 
   closeOverlay() {

--- a/assets/js/hooks/global-search.js
+++ b/assets/js/hooks/global-search.js
@@ -1,20 +1,24 @@
-// Site-wide search bar: the QueryInput pattern (syntax-highlight mirror +
-// server-driven suggestions) extended with a server-rendered results panel.
+// Site-wide search overlay: the QueryInput pattern (syntax-highlight mirror +
+// server-driven suggestions) inside a command-palette dialog — centered modal
+// on desktop, slide-up sheet on mobile.
 //
-// The dropdown panel stacks two sections:
+// Opening/closing is fully client-side: trigger buttons dispatch a
+// `sanctum:open-search` window event (see Layouts.open_search/1), Cmd/Ctrl+K
+// toggles, Escape and the backdrop close. The hook re-asserts visibility in
+// updated() because LiveView patches reset the server-rendered `hidden`
+// classes.
+//
+// Inside the panel, two result sections share one virtual keyboard list:
 //
 //   * a JS-managed suggestion listbox (phx-update="ignore", filled from the
 //     "suggest" reply — text-insert items, exactly like QueryInput)
 //   * server-rendered result rows/links marked with [data-gs-nav], patched by
 //     LiveView as the debounced "search" form event returns groups
 //
-// Keyboard nav walks one virtual list across both sections: indexes below
-// items.length are suggestions (Enter splices the insert text), the rest are
-// result anchors (Enter clicks them). Enter with nothing active opens the
-// first result. The hook lives inside a LiveComponent, so all events go
-// through pushEventTo(this.el, ...).
-//
-// Also owns the app's global search shortcut: Cmd/Ctrl+K focuses the input.
+// Indexes below items.length are suggestions (Enter splices the insert
+// text); the rest are result anchors (Enter clicks them). Enter with nothing
+// active opens the first result. The hook lives inside a LiveComponent, so
+// all events go through pushEventTo(this.el, ...).
 
 import {paintMirror} from "./query-syntax"
 
@@ -24,11 +28,13 @@ export default {
     this.mirror = document.getElementById(`${this.el.id}-mirror`)
     this.listbox = document.getElementById(`${this.el.id}-listbox`)
     this.panel = document.getElementById(`${this.el.id}-panel`)
+    this.overlay = this.el.closest("[data-gs-overlay]")
     this.knownFields = new Set(JSON.parse(this.el.dataset.fields || "[]"))
     this.items = []
     this.navEls = []
     this.active = -1
     this.open = false
+    this.overlayOpen = false
     this.suggestTimer = null
 
     this.paint()
@@ -36,45 +42,82 @@ export default {
 
     this.onInput = () => { this.paint(); this.queueSuggest(); this.show() }
     this.onScroll = () => { this.mirror.scrollLeft = this.input.scrollLeft }
-    this.onFocus = () => { this.queueSuggest(); this.show() }
+    this.onFocus = () => this.queueSuggest()
     this.onClick = () => this.queueSuggest()
-    this.onBlur = () => setTimeout(() => this.hide(), 120)
     this.onKeydown = (e) => this.handleKey(e)
 
     this.input.addEventListener("input", this.onInput)
     this.input.addEventListener("scroll", this.onScroll)
     this.input.addEventListener("focus", this.onFocus)
     this.input.addEventListener("click", this.onClick)
-    this.input.addEventListener("blur", this.onBlur)
     this.input.addEventListener("keydown", this.onKeydown)
+
+    this.onBackdrop = () => this.closeOverlay()
+    this.overlay
+      ?.querySelector("[data-gs-close]")
+      ?.addEventListener("click", this.onBackdrop)
+
+    this.onOpenEvent = () => this.openOverlay()
+    window.addEventListener("sanctum:open-search", this.onOpenEvent)
 
     this.onGlobalKey = (e) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault()
-        this.input.focus()
-        this.input.select()
+        this.overlayOpen ? this.closeOverlay() : this.openOverlay()
       }
     }
     window.addEventListener("keydown", this.onGlobalKey)
   },
 
   // LiveView patched the component (new result groups, cleared input, …):
-  // repaint, rescan the result anchors, and re-assert panel visibility (the
-  // patch resets the server-rendered "hidden" class).
+  // repaint, rescan the result anchors, and re-assert overlay/panel
+  // visibility (the patch resets the server-rendered "hidden" classes).
   updated() {
     this.paint()
     this.scanResults()
+    this.syncOverlay()
     this.syncPanel()
   },
 
   destroyed() {
     clearTimeout(this.suggestTimer)
+    window.removeEventListener("sanctum:open-search", this.onOpenEvent)
     window.removeEventListener("keydown", this.onGlobalKey)
+    document.body.classList.remove("overflow-hidden")
   },
 
   paint() {
     paintMirror(this.mirror, this.input.value, this.knownFields)
     this.mirror.scrollLeft = this.input.scrollLeft
+  },
+
+  // -- overlay -------------------------------------------------------------------
+
+  openOverlay() {
+    this.overlayOpen = true
+    this.open = true
+    this.syncOverlay()
+    this.syncPanel()
+    this.input.focus()
+    this.input.select()
+    this.queueSuggest()
+  },
+
+  closeOverlay() {
+    this.overlayOpen = false
+    this.open = false
+    this.setActive(-1)
+    this.items = []
+    this.listbox.textContent = ""
+    this.syncOverlay()
+    this.syncPanel()
+    this.input.blur()
+  },
+
+  syncOverlay() {
+    if (!this.overlay) return
+    this.overlay.classList.toggle("hidden", !this.overlayOpen)
+    document.body.classList.toggle("overflow-hidden", this.overlayOpen)
   },
 
   // -- results section ---------------------------------------------------------
@@ -104,7 +147,7 @@ export default {
   },
 
   showSuggestions(reply) {
-    if (document.activeElement !== this.input) return
+    if (!this.overlayOpen || document.activeElement !== this.input) return
     this.items = reply.items || []
     this.replaceStart = reply.start
     this.replaceLength = reply.length
@@ -174,12 +217,6 @@ export default {
     this.syncPanel()
   },
 
-  hide() {
-    this.open = false
-    this.setActive(-1)
-    this.syncPanel()
-  },
-
   syncPanel() {
     if (!this.panel) return
     const empty = this.items.length === 0 && this.panel.querySelector("[data-gs-content]") == null
@@ -215,16 +252,6 @@ export default {
   },
 
   handleKey(e) {
-    const isOpen = this.open && !this.panel.classList.contains("hidden")
-
-    if (!isOpen) {
-      if (e.key === "ArrowDown") {
-        this.queueSuggest()
-        this.show()
-      }
-      return
-    }
-
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault()
@@ -262,8 +289,7 @@ export default {
         if (this.active >= 0) {
           this.setActive(-1)
         } else {
-          this.hide()
-          this.input.blur()
+          this.closeOverlay()
         }
         break
     }

--- a/assets/js/hooks/global-search.js
+++ b/assets/js/hooks/global-search.js
@@ -83,7 +83,10 @@ export default {
     clearTimeout(this.suggestTimer)
     window.removeEventListener("sanctum:open-search", this.onOpenEvent)
     window.removeEventListener("keydown", this.onGlobalKey)
-    document.body.classList.remove("overflow-hidden")
+    // Navigating from a result destroys the hook with the overlay still
+    // open — release the body lock (without scroll restore: the next page
+    // owns its own position) or the new page can't scroll at all.
+    if (this.scrollLocked) this.unlockScroll(false)
   },
 
   paint() {

--- a/assets/js/hooks/global-search.js
+++ b/assets/js/hooks/global-search.js
@@ -122,12 +122,20 @@ export default {
 
   // -- results section ---------------------------------------------------------
 
+  // Collect the server-rendered result anchors. Read-only: their ids come
+  // from the server (mutating ids on LiveView-managed elements corrupts DOM
+  // patching), and listeners bind once per element.
   scanResults() {
     this.navEls = Array.from(this.el.querySelectorAll("[data-gs-nav]"))
-    this.navEls.forEach((el, i) => {
-      el.id = `${this.el.id}-res-${i}`
+    this.navEls.forEach((el) => {
       el.classList.remove("gs-active")
-      el.addEventListener("mousemove", () => this.setActive(this.items.length + i))
+      if (!el.__gsBound) {
+        el.__gsBound = true
+        el.addEventListener("mousemove", () => {
+          const i = this.navEls.indexOf(el)
+          if (i >= 0) this.setActive(this.items.length + i)
+        })
+      }
     })
     // Result rows changed under the cursor — a result index no longer points
     // where it did. Suggestion indexes are still valid.

--- a/assets/js/hooks/global-search.js
+++ b/assets/js/hooks/global-search.js
@@ -117,7 +117,37 @@ export default {
   syncOverlay() {
     if (!this.overlay) return
     this.overlay.classList.toggle("hidden", !this.overlayOpen)
-    document.body.classList.toggle("overflow-hidden", this.overlayOpen)
+    if (this.overlayOpen && !this.scrollLocked) this.lockScroll()
+    if (!this.overlayOpen && this.scrollLocked) this.unlockScroll(true)
+  },
+
+  // `overflow: hidden` on <body> doesn't stop touch scrolling on iOS — the
+  // page behind the sheet keeps panning. Pinning the body with position:fixed
+  // (offset to the current scroll) is the reliable lock; the offset is
+  // restored on close.
+  lockScroll() {
+    this.scrollLocked = true
+    this.savedScrollY = window.scrollY
+    const style = document.body.style
+    style.position = "fixed"
+    style.top = `-${this.savedScrollY}px`
+    style.left = "0"
+    style.right = "0"
+    style.width = "100%"
+  },
+
+  // `restore` scrolls back to the pre-lock position — wanted when the user
+  // closes the overlay in place, not when the hook dies mid-navigation (the
+  // next page starts fresh).
+  unlockScroll(restore) {
+    this.scrollLocked = false
+    const style = document.body.style
+    style.position = ""
+    style.top = ""
+    style.left = ""
+    style.right = ""
+    style.width = ""
+    if (restore) window.scrollTo(0, this.savedScrollY ?? 0)
   },
 
   // -- results section ---------------------------------------------------------

--- a/assets/js/hooks/query-input.js
+++ b/assets/js/hooks/query-input.js
@@ -8,76 +8,10 @@
 // — the client only tokenizes for instant colors; the server owns the
 // grammar, the field registry, and value completion.
 //
-// The tokenizer must stay in sync with Sanctum.Search.Lexer: quoted strings,
-// operators (<= >= != < > = : !), parens, pipe, `-` negation, words.
+// The tokenizer lives in query-syntax.js (shared with the GlobalSearch hook)
+// and must stay in sync with Sanctum.Search.Lexer.
 
-const TOKEN_RE = /(\s+)|("(?:[^"]*)"?)|(<=|>=|!=|[<>=:!])|([()])|(\|)|([^\s"()|:<>=!]+)/g
-
-const KEYWORDS = new Set(["and", "or", "not"])
-
-function tokenize(text) {
-  const tokens = []
-  let match
-  TOKEN_RE.lastIndex = 0
-  while ((match = TOKEN_RE.exec(text)) !== null) {
-    const [full, ws, str, op, paren, pipe, word] = match
-    if (ws != null) tokens.push({type: "ws", text: full})
-    else if (str != null) tokens.push({type: "string", text: full})
-    else if (op != null) tokens.push({type: "op", text: full})
-    else if (paren != null) tokens.push({type: "paren", text: full})
-    else if (pipe != null) tokens.push({type: "pipe", text: full})
-    else if (word != null) tokens.push({type: "word", text: full})
-  }
-  return tokens
-}
-
-// Second pass: words become field / keyword / number / value / plain text.
-function classify(tokens, knownFields) {
-  const out = []
-  for (let i = 0; i < tokens.length; i++) {
-    const t = tokens[i]
-    if (t.type !== "word") {
-      out.push({cls: clsFor(t.type), text: t.text})
-      continue
-    }
-
-    const next = nextNonWs(tokens, i)
-    const prev = prevNonWs(tokens, i)
-    const lower = t.text.toLowerCase()
-
-    if (next && next.type === "op" && next.text !== "!") {
-      const known = knownFields.has(lower.replace(/-/g, "_"))
-      out.push({cls: known ? "qi-field" : "qi-field qi-unknown", text: t.text})
-    } else if (prev && (prev.type === "op" || prev.type === "pipe")) {
-      out.push({cls: /^\d+$/.test(t.text) ? "qi-number" : "qi-value", text: t.text})
-    } else if (KEYWORDS.has(lower)) {
-      out.push({cls: "qi-keyword", text: t.text})
-    } else {
-      out.push({cls: null, text: t.text})
-    }
-  }
-  return out
-}
-
-function clsFor(type) {
-  switch (type) {
-    case "string": return "qi-string"
-    case "op": return "qi-op"
-    case "paren": return "qi-paren"
-    case "pipe": return "qi-op"
-    default: return null
-  }
-}
-
-function nextNonWs(tokens, i) {
-  for (let j = i + 1; j < tokens.length; j++) if (tokens[j].type !== "ws") return tokens[j]
-  return null
-}
-
-function prevNonWs(tokens, i) {
-  for (let j = i - 1; j >= 0; j--) if (tokens[j].type !== "ws") return tokens[j]
-  return null
-}
+import {paintMirror} from "./query-syntax"
 
 export default {
   mounted() {
@@ -117,18 +51,7 @@ export default {
   },
 
   paint() {
-    const spans = classify(tokenize(this.input.value), this.knownFields)
-    this.mirror.textContent = ""
-    for (const {cls, text} of spans) {
-      if (cls) {
-        const span = document.createElement("span")
-        span.className = cls
-        span.textContent = text
-        this.mirror.appendChild(span)
-      } else {
-        this.mirror.appendChild(document.createTextNode(text))
-      }
-    }
+    paintMirror(this.mirror, this.input.value, this.knownFields)
     this.mirror.scrollLeft = this.input.scrollLeft
   },
 

--- a/assets/js/hooks/query-syntax.js
+++ b/assets/js/hooks/query-syntax.js
@@ -1,0 +1,88 @@
+// Client-side tokenizer + classifier for the search query language, shared by
+// the QueryInput and GlobalSearch hooks. Must stay in sync with
+// Sanctum.Search.Lexer: quoted strings, operators (<= >= != < > = : !),
+// parens, pipe, `-` negation, words.
+
+const TOKEN_RE = /(\s+)|("(?:[^"]*)"?)|(<=|>=|!=|[<>=:!])|([()])|(\|)|([^\s"()|:<>=!]+)/g
+
+const KEYWORDS = new Set(["and", "or", "not"])
+
+export function tokenize(text) {
+  const tokens = []
+  let match
+  TOKEN_RE.lastIndex = 0
+  while ((match = TOKEN_RE.exec(text)) !== null) {
+    const [full, ws, str, op, paren, pipe, word] = match
+    if (ws != null) tokens.push({type: "ws", text: full})
+    else if (str != null) tokens.push({type: "string", text: full})
+    else if (op != null) tokens.push({type: "op", text: full})
+    else if (paren != null) tokens.push({type: "paren", text: full})
+    else if (pipe != null) tokens.push({type: "pipe", text: full})
+    else if (word != null) tokens.push({type: "word", text: full})
+  }
+  return tokens
+}
+
+// Second pass: words become field / keyword / number / value / plain text.
+export function classify(tokens, knownFields) {
+  const out = []
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i]
+    if (t.type !== "word") {
+      out.push({cls: clsFor(t.type), text: t.text})
+      continue
+    }
+
+    const next = nextNonWs(tokens, i)
+    const prev = prevNonWs(tokens, i)
+    const lower = t.text.toLowerCase()
+
+    if (next && next.type === "op" && next.text !== "!") {
+      const known = knownFields.has(lower.replace(/-/g, "_"))
+      out.push({cls: known ? "qi-field" : "qi-field qi-unknown", text: t.text})
+    } else if (prev && (prev.type === "op" || prev.type === "pipe")) {
+      out.push({cls: /^\d+$/.test(t.text) ? "qi-number" : "qi-value", text: t.text})
+    } else if (KEYWORDS.has(lower)) {
+      out.push({cls: "qi-keyword", text: t.text})
+    } else {
+      out.push({cls: null, text: t.text})
+    }
+  }
+  return out
+}
+
+function clsFor(type) {
+  switch (type) {
+    case "string": return "qi-string"
+    case "op": return "qi-op"
+    case "paren": return "qi-paren"
+    case "pipe": return "qi-op"
+    default: return null
+  }
+}
+
+function nextNonWs(tokens, i) {
+  for (let j = i + 1; j < tokens.length; j++) if (tokens[j].type !== "ws") return tokens[j]
+  return null
+}
+
+function prevNonWs(tokens, i) {
+  for (let j = i - 1; j >= 0; j--) if (tokens[j].type !== "ws") return tokens[j]
+  return null
+}
+
+// Render classified spans into a mirror element.
+export function paintMirror(mirror, value, knownFields) {
+  const spans = classify(tokenize(value), knownFields)
+  mirror.textContent = ""
+  for (const {cls, text} of spans) {
+    if (cls) {
+      const span = document.createElement("span")
+      span.className = cls
+      span.textContent = text
+      mirror.appendChild(span)
+    } else {
+      mirror.appendChild(document.createTextNode(text))
+    }
+  }
+}

--- a/assets/js/hooks/scroll-restore.js
+++ b/assets/js/hooks/scroll-restore.js
@@ -69,6 +69,10 @@ export default {
     }
     window.addEventListener("scroll", this.onScroll, {passive: true})
 
+    // An explicit URL fragment (e.g. a global-search set link landing on
+    // /browse/:pack#<set_code>) wins over a saved scroll position.
+    if (window.location.hash) return
+
     const saved = sessionStorage.getItem(storageKey())
     if (!saved) return
 

--- a/lib/sanctum/search/builders.ex
+++ b/lib/sanctum/search/builders.ex
@@ -33,6 +33,18 @@ defmodule Sanctum.Search.Builders do
     expr(ilike(^target, ^pattern(raw)))
   end
 
+  @doc """
+  Standard `build` function for a text field: substring match on `:eq`,
+  negated on `:neq`. `to_expr` turns an escaped ILIKE pattern into an
+  expression.
+  """
+  def text_build(to_expr) do
+    fn
+      :eq, value -> {:ok, to_expr.(pattern(value))}
+      :neq, value -> {:ok, expr(not (^to_expr.(pattern(value))))}
+    end
+  end
+
   @doc "`%…%` ILIKE pattern for user input, escaping `%`, `_`, and `\\`."
   def pattern(raw) do
     escaped =

--- a/lib/sanctum/search/card_set_fields.ex
+++ b/lib/sanctum/search/card_set_fields.ex
@@ -1,0 +1,46 @@
+defmodule Sanctum.Search.CardSetFields do
+  @moduledoc """
+  Search-field registry for card sets (queries run against
+  `Sanctum.Catalog.CardSet`). Minimal on purpose — card sets only surface in
+  the global search bar.
+  """
+
+  @behaviour Sanctum.Search.Registry
+
+  import Ash.Expr
+
+  alias Sanctum.Catalog.SetType
+  alias Sanctum.Search.{Builders, Field}
+
+  @impl true
+  def bare_word(value) do
+    expr(ilike(name, ^Builders.pattern(value)))
+  end
+
+  @impl true
+  def fields do
+    [
+      %Field{
+        name: "name",
+        aliases: ["n"],
+        kind: :text,
+        example: ~s(name:"weapon x"),
+        hint: "card set name",
+        build: Builders.text_build(fn pattern -> expr(ilike(name, ^pattern)) end)
+      },
+      %Field{
+        name: "set_type",
+        aliases: ["settype"],
+        kind: :enum,
+        values: Enum.map(SetType.values(), &to_string/1),
+        example: "set_type:modular",
+        hint: "role of the set (modular, nemesis, …)",
+        build: fn op, value ->
+          with {:ok, atom} <- Builders.coerce_enum(value, SetType.values()) do
+            {:ok, Builders.cmp(expr(set_type), op, atom)}
+          end
+        end
+      }
+    ]
+  end
+end

--- a/lib/sanctum/search/card_set_fields.ex
+++ b/lib/sanctum/search/card_set_fields.ex
@@ -5,42 +5,32 @@ defmodule Sanctum.Search.CardSetFields do
   the global search bar.
   """
 
-  @behaviour Sanctum.Search.Registry
-
-  import Ash.Expr
+  use Sanctum.Search.NameRegistry,
+    example: ~s(name:"weapon x"),
+    hint: "card set name"
 
   alias Sanctum.Catalog.SetType
   alias Sanctum.Search.{Builders, Field}
 
   @impl true
-  def bare_word(value) do
-    expr(ilike(name, ^Builders.pattern(value)))
+  def fields do
+    super() ++
+      [
+        %Field{
+          name: "set_type",
+          aliases: ["settype"],
+          kind: :enum,
+          values: Enum.map(SetType.values(), &to_string/1),
+          example: "set_type:modular",
+          hint: "role of the set (modular, nemesis, …)",
+          build: fn op, value ->
+            with {:ok, atom} <- Builders.coerce_enum(value, SetType.values()) do
+              {:ok, Builders.cmp(expr(set_type), op, atom)}
+            end
+          end
+        }
+      ]
   end
 
-  @impl true
-  def fields do
-    [
-      %Field{
-        name: "name",
-        aliases: ["n"],
-        kind: :text,
-        example: ~s(name:"weapon x"),
-        hint: "card set name",
-        build: Builders.text_build(fn pattern -> expr(ilike(name, ^pattern)) end)
-      },
-      %Field{
-        name: "set_type",
-        aliases: ["settype"],
-        kind: :enum,
-        values: Enum.map(SetType.values(), &to_string/1),
-        example: "set_type:modular",
-        hint: "role of the set (modular, nemesis, …)",
-        build: fn op, value ->
-          with {:ok, atom} <- Builders.coerce_enum(value, SetType.values()) do
-            {:ok, Builders.cmp(expr(set_type), op, atom)}
-          end
-        end
-      }
-    ]
-  end
+  defp name_expr(pattern), do: expr(ilike(name, ^pattern))
 end

--- a/lib/sanctum/search/diagnostic.ex
+++ b/lib/sanctum/search/diagnostic.ex
@@ -17,6 +17,8 @@ defmodule Sanctum.Search.Diagnostic do
           | :invalid_value
           | :stray_token
           | :unclosed_paren
+          | :misplaced_scope
+          | :unknown_type
 
   @type t :: %__MODULE__{
           severity: :warning | :error,

--- a/lib/sanctum/search/global.ex
+++ b/lib/sanctum/search/global.ex
@@ -514,7 +514,7 @@ defmodule Sanctum.Search.Global do
         id: set.id,
         title: set.name || set.code,
         subtitle: join_subtitle([humanize(set.set_type), set.pack && set.pack.name]),
-        href: set.pack && "/browse/#{set.pack.code}",
+        href: set.pack && browse_href(set.pack.code, set.code),
         kind: :card_set
       }
     end)
@@ -528,7 +528,7 @@ defmodule Sanctum.Search.Global do
         id: villain.id,
         title: villain.villain_name,
         subtitle: "Villain",
-        href: browse_href(packs[villain.set]),
+        href: browse_href(packs[villain.set], villain.set),
         kind: :villain
       }
     end)
@@ -542,7 +542,7 @@ defmodule Sanctum.Search.Global do
         id: scenario.id,
         title: scenario.name,
         subtitle: "Scenario",
-        href: browse_href(packs[scenario.set]),
+        href: browse_href(packs[scenario.set], scenario.set),
         kind: :scenario
       }
     end)
@@ -570,8 +570,11 @@ defmodule Sanctum.Search.Global do
       %{}
   end
 
-  defp browse_href(nil), do: nil
-  defp browse_href(pack_code), do: "/browse/#{pack_code}"
+  # Set-scoped results land on the pack's browse page with the card-set code
+  # as the fragment; the pack page renders set sections with matching DOM ids
+  # and scrolls the fragment into view once its async load renders.
+  defp browse_href(nil, _set_code), do: nil
+  defp browse_href(pack_code, set_code), do: "/browse/#{pack_code}##{set_code}"
 
   defp more_url(:cards, rest), do: "/cards" <> query_param(rest)
   defp more_url(:decks, rest), do: "/decks" <> query_param(rest)

--- a/lib/sanctum/search/global.ex
+++ b/lib/sanctum/search/global.ex
@@ -1,0 +1,598 @@
+defmodule Sanctum.Search.Global do
+  @moduledoc """
+  Site-wide search: one query string fanned out across every content type.
+
+  Reuses the `Sanctum.Search` query language with cross-type semantics:
+
+    * a reserved **top-level `in:` qualifier** scopes the search to specific
+      types (`in:cards`, `in:decks|heroes`); it is extracted before
+      compilation and never reaches a registry
+    * the remaining query is compiled once per type registry; a type is
+      **excluded** when any clause references a field, operator, or value its
+      registry doesn't understand — so `cost<=2` implicitly narrows to cards
+      while `aspect:aggression` spans cards and decks
+    * bare words fall through to each registry's name matching, so `spider`
+      finds cards, decks, heroes, packs, …
+
+  Returns display-ready result groups in a fixed order with per-type limits.
+  Queries run against lightweight default `:read` actions (not the heavy
+  `:browse` actions the pool/deck browsers use).
+  """
+
+  require Ash.Query
+  require Logger
+
+  alias Sanctum.Search.{Compiler, Diagnostic, Field, Parser, Registry, Token}
+
+  alias Sanctum.Search.{
+    CardFields,
+    CardSetFields,
+    DeckFields,
+    HeroFields,
+    PackFields,
+    ScenarioFields,
+    VillainFields
+  }
+
+  @default_limit 5
+  @scoped_limit 15
+
+  # Fixed display order of result groups.
+  @types [
+    %{key: :cards, label: "Cards", registry: CardFields},
+    %{key: :decks, label: "Decks", registry: DeckFields},
+    %{key: :heroes, label: "Heroes", registry: HeroFields},
+    %{key: :packs, label: "Packs", registry: PackFields},
+    %{key: :card_sets, label: "Card Sets", registry: CardSetFields},
+    %{key: :villains, label: "Villains", registry: VillainFields},
+    %{key: :scenarios, label: "Scenarios", registry: ScenarioFields}
+  ]
+
+  @type_aliases %{
+    "card" => :cards,
+    "cards" => :cards,
+    "deck" => :decks,
+    "decks" => :decks,
+    "hero" => :heroes,
+    "heroes" => :heroes,
+    "pack" => :packs,
+    "packs" => :packs,
+    "set" => :card_sets,
+    "sets" => :card_sets,
+    "card_set" => :card_sets,
+    "card_sets" => :card_sets,
+    "villain" => :villains,
+    "villains" => :villains,
+    "scenario" => :scenarios,
+    "scenarios" => :scenarios
+  }
+
+  @type result :: %{
+          id: term(),
+          title: String.t(),
+          subtitle: String.t() | nil,
+          href: String.t() | nil,
+          kind: atom()
+        }
+
+  @type group :: %{
+          type: atom(),
+          label: String.t(),
+          results: [result()],
+          more?: boolean(),
+          more_url: String.t() | nil
+        }
+
+  @doc "The canonical `in:` values, for autocomplete and docs."
+  @spec type_values() :: [String.t()]
+  def type_values, do: Enum.map(@types, &to_string(&1.key))
+
+  @doc "The per-type registries in display order, as `{key, label, registry}`."
+  @spec types() :: [%{key: atom(), label: String.t(), registry: module()}]
+  def types, do: @types
+
+  @doc """
+  Cursor-context autocomplete for the global search bar.
+
+  When the query is scoped to exactly one type via `in:`, suggestions come
+  from that type's registry; otherwise from `Sanctum.Search.GlobalFields`
+  (the `in:` qualifier plus the union of every registry's fields). Reply
+  shape matches `Sanctum.Search.Suggest.suggest/3`.
+  """
+  @spec suggest(String.t(), non_neg_integer()) :: map()
+  def suggest(input, cursor_utf16) when is_binary(input) do
+    {ast, _diags} = Parser.parse(input)
+    {scope, _rest, _spans, _diags} = extract_scope(ast)
+
+    registry =
+      with types when types != :all <- scope,
+           [single] <- MapSet.to_list(types),
+           %{registry: registry} <- Enum.find(@types, &(&1.key == single)) do
+        registry
+      else
+        _ -> Sanctum.Search.GlobalFields
+      end
+
+    Sanctum.Search.Suggest.suggest(input, cursor_utf16, registry)
+  end
+
+  @doc """
+  Run a global search. Returns `%{groups:, diagnostics:}` where `groups` only
+  contains types with at least one result. Empty/whitespace input — or a
+  query with no usable terms and no `in:` scope — returns no groups.
+  """
+  @spec search(String.t(), term(), keyword()) :: %{
+          groups: [group()],
+          diagnostics: [Diagnostic.t()]
+        }
+  def search(input, actor, opts \\ []) when is_binary(input) do
+    if String.trim(input) == "" do
+      %{groups: [], diagnostics: []}
+    else
+      do_search(input, actor, opts)
+    end
+  end
+
+  defp do_search(input, actor, opts) do
+    {ast, parse_diags} = Parser.parse(input)
+    {scope, rest_ast, spans, scope_diags} = extract_scope(ast)
+    rest = remainder(input, spans)
+
+    requested =
+      case scope do
+        :all -> Enum.map(@types, & &1.key)
+        set -> Enum.filter(Enum.map(@types, & &1.key), &(&1 in set))
+      end
+
+    limit =
+      Keyword.get_lazy(opts, :limit, fn ->
+        if length(requested) == 1, do: @scoped_limit, else: @default_limit
+      end)
+
+    if rest_ast == nil and scope == :all do
+      # Nothing usable was typed (yet): don't list the whole catalog.
+      %{groups: [], diagnostics: parse_diags ++ scope_diags}
+    else
+      {groups, compile_diags} = run(requested, rest_ast, rest, actor, limit)
+
+      # Per-type compile diagnostics (partially-invalid values) are only
+      # meaningful when the search is scoped to one type; across types they
+      # contradict the groups that did match.
+      diags =
+        if length(requested) == 1,
+          do: parse_diags ++ scope_diags ++ compile_diags,
+          else: parse_diags ++ scope_diags
+
+      %{groups: groups, diagnostics: Enum.uniq(diags)}
+    end
+  end
+
+  defp run(requested, ast, rest, actor, limit) do
+    Enum.reduce(@types, {[], []}, fn spec, {groups, diags} ->
+      if spec.key in requested and applicable?(ast, spec.registry) do
+        {expr, compile_diags} = Compiler.compile(ast, spec.registry)
+        records = fetch(spec.key, expr, actor, limit + 1)
+        results = records |> Enum.take(limit) |> to_results(spec.key, actor)
+
+        group = %{
+          type: spec.key,
+          label: spec.label,
+          results: results,
+          more?: length(records) > limit,
+          more_url: more_url(spec.key, rest)
+        }
+
+        {if(results == [], do: groups, else: groups ++ [group]), diags ++ compile_diags}
+      else
+        {groups, diags}
+      end
+    end)
+  end
+
+  # -- scope extraction --------------------------------------------------------
+
+  @doc """
+  Extract top-level `in:` qualifiers from a parsed AST.
+
+  Returns `{scope, remainder_ast, removed_spans, diagnostics}` where `scope`
+  is `:all` or a `MapSet` of type keys, and `removed_spans` are byte spans of
+  the extracted clauses in the original input (for `remainder/2`).
+  """
+  @spec extract_scope(Parser.ast() | nil) ::
+          {:all | MapSet.t(atom()), Parser.ast() | nil, [{non_neg_integer(), non_neg_integer()}],
+           [Diagnostic.t()]}
+  def extract_scope(nil), do: {:all, nil, [], []}
+
+  def extract_scope(ast) do
+    {scope_clauses, rest_ast} =
+      case ast do
+        {:clause, _} = clause ->
+          if in_clause?(clause), do: {[clause], nil}, else: {[], ast}
+
+        {:and, children} ->
+          {ins, rest} = Enum.split_with(children, &in_clause?/1)
+          {ins, and_node(rest)}
+
+        other ->
+          {[], other}
+      end
+
+    {rest_ast, nested_spans, nested_diags} = scrub_nested(rest_ast)
+
+    {types, type_diags} =
+      scope_clauses
+      |> Enum.flat_map(fn {:clause, %{values: values}} -> values end)
+      |> Enum.reduce({[], []}, fn %Token{} = tok, {types, diags} ->
+        case Map.get(@type_aliases, Registry.normalize(tok.value)) do
+          nil -> {types, diags ++ [unknown_type(tok)]}
+          key -> {types ++ [key], diags}
+        end
+      end)
+
+    spans = Enum.map(scope_clauses, &clause_span/1) ++ nested_spans
+    scope = if types == [], do: :all, else: MapSet.new(types)
+
+    {scope, rest_ast, spans, type_diags ++ nested_diags}
+  end
+
+  defp in_clause?({:clause, %{field: %Token{value: v}}}), do: Registry.normalize(v) == "in"
+  defp in_clause?(_node), do: false
+
+  defp clause_span({:clause, %{field: field_tok, values: values}}) do
+    last = List.last(values)
+    {field_tok.start, last.start + last.length - field_tok.start}
+  end
+
+  # Remove `in:` clauses hiding below the top level (inside or/not/parens):
+  # scoping a disjunct has no defensible meaning, so warn and drop.
+  defp scrub_nested(nil), do: {nil, [], []}
+
+  defp scrub_nested({:and, children}), do: scrub_children(:and, children)
+  defp scrub_nested({:or, children}), do: scrub_children(:or, children)
+
+  defp scrub_nested({:not, child}) do
+    {node, spans, diags} = scrub_nested(child)
+    {if(node, do: {:not, node}), spans, diags}
+  end
+
+  defp scrub_nested({:clause, _} = clause) do
+    if in_clause?(clause) do
+      {start, length} = clause_span(clause)
+
+      diag =
+        Diagnostic.new(
+          :warning,
+          :misplaced_scope,
+          ~s("in:" only works as a top-level filter),
+          start,
+          length
+        )
+
+      {nil, [{start, length}], [diag]}
+    else
+      {clause, [], []}
+    end
+  end
+
+  defp scrub_nested({:word, _} = word), do: {word, [], []}
+
+  defp scrub_children(kind, children) do
+    {nodes, spans, diags} =
+      Enum.reduce(children, {[], [], []}, fn child, {nodes, spans, diags} ->
+        {node, s, d} = scrub_nested(child)
+        {if(node, do: nodes ++ [node], else: nodes), spans ++ s, diags ++ d}
+      end)
+
+    node =
+      case nodes do
+        [] -> nil
+        [one] -> one
+        many -> {kind, many}
+      end
+
+    {node, spans, diags}
+  end
+
+  defp and_node([]), do: nil
+  defp and_node([one]), do: one
+  defp and_node(children), do: {:and, children}
+
+  defp unknown_type(%Token{} = tok) do
+    Diagnostic.new(
+      :warning,
+      :unknown_type,
+      ~s("#{tok.value}" isn't a searchable type — try #{Enum.join(type_values(), ", ")}),
+      tok.start,
+      tok.length
+    )
+  end
+
+  # -- per-type applicability ---------------------------------------------------
+
+  @doc """
+  Whether every clause in `ast` is understood by `registry` (field known,
+  operator supported, at least one value valid). Types failing this check are
+  excluded from the fan-out rather than compiled leniently — `cost<=2` should
+  narrow the search to cards, not show a decks group that matches nothing.
+  """
+  @spec applicable?(Parser.ast() | nil, module()) :: boolean()
+  def applicable?(nil, _registry), do: true
+  def applicable?({:and, children}, registry), do: Enum.all?(children, &applicable?(&1, registry))
+  def applicable?({:or, children}, registry), do: Enum.all?(children, &applicable?(&1, registry))
+  def applicable?({:not, child}, registry), do: applicable?(child, registry)
+  def applicable?({:word, _}, _registry), do: true
+
+  def applicable?({:clause, %{field: field_tok, op: op, values: values}}, registry) do
+    case Registry.lookup(registry, field_tok.value) do
+      nil ->
+        false
+
+      %Field{} = field ->
+        op in field.ops and
+          Enum.any?(values, fn %Token{value: v} -> match?({:ok, _}, field.build.(op, v)) end)
+    end
+  end
+
+  # -- remainder serialization ---------------------------------------------------
+
+  @doc """
+  The original input with the given byte spans (extracted `in:` clauses)
+  spliced out — suitable for `/cards?query=…` / `/decks?query=…` deep links
+  that recompile identically on the target page.
+  """
+  @spec remainder(String.t(), [{non_neg_integer(), non_neg_integer()}]) :: String.t()
+  def remainder(input, []), do: String.trim(input)
+
+  def remainder(input, spans) do
+    spans
+    |> Enum.sort_by(&elem(&1, 0), :desc)
+    |> Enum.reduce(input, &splice(&2, &1))
+    |> String.trim()
+  end
+
+  # Splice out a span plus one adjacent whitespace run, so the remainder never
+  # gains doubled spaces (and quoted values keep their inner whitespace).
+  defp splice(input, {start, length}) do
+    stop = start + length
+    trailing_ws = count_ws(input, stop, byte_size(input))
+    leading_ws = if trailing_ws == 0, do: count_ws_before(input, start), else: 0
+
+    prefix = binary_part(input, 0, start - leading_ws)
+    rest_start = stop + trailing_ws
+    prefix <> binary_part(input, rest_start, byte_size(input) - rest_start)
+  end
+
+  defp count_ws(input, at, size) when at < size do
+    case binary_part(input, at, 1) do
+      ws when ws in [" ", "\t"] -> 1 + count_ws(input, at + 1, size)
+      _ -> 0
+    end
+  end
+
+  defp count_ws(_input, _at, _size), do: 0
+
+  defp count_ws_before(input, at) when at > 0 do
+    case binary_part(input, at - 1, 1) do
+      ws when ws in [" ", "\t"] -> 1 + count_ws_before(input, at - 1)
+      _ -> 0
+    end
+  end
+
+  defp count_ws_before(_input, _at), do: 0
+
+  # -- fetch + result shaping ----------------------------------------------------
+
+  defp fetch(key, expr, actor, limit) do
+    do_fetch(key, expr, actor, limit)
+  rescue
+    error ->
+      Logger.error(
+        "global search #{key} query failed: #{Exception.format(:error, error, __STACKTRACE__)}"
+      )
+
+      []
+  end
+
+  defp do_fetch(:cards, expr, actor, limit) do
+    Sanctum.Games.CardSide
+    |> base_query(expr)
+    |> Ash.Query.sort(code: :asc)
+    |> Ash.Query.limit(limit)
+    |> Ash.Query.load(card: [:pack_ref])
+    |> Ash.read!(actor: actor)
+  end
+
+  defp do_fetch(:decks, expr, actor, limit) do
+    Sanctum.Decks.Deck
+    |> base_query(expr)
+    |> Ash.Query.sort(updated_at: :desc)
+    |> Ash.Query.limit(limit)
+    |> Ash.Query.load(hero: [:display_name])
+    |> Ash.read!(actor: actor)
+  end
+
+  defp do_fetch(:heroes, expr, actor, limit) do
+    Sanctum.Heroes.Hero
+    |> base_query(expr)
+    |> Ash.Query.sort(hero_name: :asc)
+    |> Ash.Query.limit(limit)
+    |> Ash.Query.load(:display_name)
+    |> Ash.read!(actor: actor)
+  end
+
+  defp do_fetch(:packs, expr, actor, limit) do
+    Sanctum.Catalog.Pack
+    |> base_query(expr)
+    |> Ash.Query.sort(position: :asc_nils_last)
+    |> Ash.Query.limit(limit)
+    |> Ash.read!(actor: actor)
+  end
+
+  defp do_fetch(:card_sets, expr, actor, limit) do
+    Sanctum.Catalog.CardSet
+    |> base_query(expr)
+    |> Ash.Query.sort(name: :asc)
+    |> Ash.Query.limit(limit)
+    |> Ash.Query.load(:pack)
+    |> Ash.read!(actor: actor)
+  end
+
+  defp do_fetch(:villains, expr, actor, limit) do
+    Sanctum.Villains.Villain
+    |> base_query(expr)
+    |> Ash.Query.sort(villain_name: :asc)
+    |> Ash.Query.limit(limit)
+    |> Ash.read!(actor: actor)
+  end
+
+  defp do_fetch(:scenarios, expr, actor, limit) do
+    Sanctum.Games.Scenario
+    |> base_query(expr)
+    |> Ash.Query.sort(name: :asc)
+    |> Ash.Query.limit(limit)
+    |> Ash.read!(actor: actor)
+  end
+
+  defp base_query(resource, nil), do: Ash.Query.new(resource)
+  defp base_query(resource, expr), do: Ash.Query.filter(Ash.Query.new(resource), ^expr)
+
+  defp to_results(sides, :cards, _actor) do
+    Enum.map(sides, fn side ->
+      %{
+        id: side.card_id,
+        title: side.name,
+        subtitle:
+          join_subtitle([
+            humanize(side.type),
+            (side.card.pack_ref && side.card.pack_ref.name) || side.card.pack
+          ]),
+        href: "/cards/#{side.card_id}",
+        kind: :card
+      }
+    end)
+  end
+
+  defp to_results(decks, :decks, _actor) do
+    Enum.map(decks, fn deck ->
+      %{
+        id: deck.id,
+        title: deck.title || "Untitled deck",
+        subtitle: deck.hero && deck.hero.display_name,
+        href: "/decks/#{deck.id}",
+        kind: :deck
+      }
+    end)
+  end
+
+  defp to_results(heroes, :heroes, _actor) do
+    Enum.map(heroes, fn hero ->
+      %{
+        id: hero.id,
+        title: hero.display_name || hero.hero_name,
+        subtitle: hero.alter_ego_name,
+        href: "/decks?hero_id=#{hero.id}",
+        kind: :hero
+      }
+    end)
+  end
+
+  defp to_results(packs, :packs, _actor) do
+    Enum.map(packs, fn pack ->
+      %{
+        id: pack.id,
+        title: pack.name || pack.code,
+        subtitle: humanize(pack.product_type) || "Pack",
+        href: "/browse/#{pack.code}",
+        kind: :pack
+      }
+    end)
+  end
+
+  defp to_results(sets, :card_sets, _actor) do
+    Enum.map(sets, fn set ->
+      %{
+        id: set.id,
+        title: set.name || set.code,
+        subtitle: join_subtitle([humanize(set.set_type), set.pack && set.pack.name]),
+        href: set.pack && "/browse/#{set.pack.code}",
+        kind: :card_set
+      }
+    end)
+  end
+
+  defp to_results(villains, :villains, actor) do
+    packs = pack_codes_by_set(Enum.map(villains, & &1.set), actor)
+
+    Enum.map(villains, fn villain ->
+      %{
+        id: villain.id,
+        title: villain.villain_name,
+        subtitle: "Villain",
+        href: browse_href(packs[villain.set]),
+        kind: :villain
+      }
+    end)
+  end
+
+  defp to_results(scenarios, :scenarios, actor) do
+    packs = pack_codes_by_set(Enum.map(scenarios, & &1.set), actor)
+
+    Enum.map(scenarios, fn scenario ->
+      %{
+        id: scenario.id,
+        title: scenario.name,
+        subtitle: "Scenario",
+        href: browse_href(packs[scenario.set]),
+        kind: :scenario
+      }
+    end)
+  end
+
+  # Villains and scenarios carry a `set` slug that matches `card_sets.code`;
+  # resolve those to pack codes in one batch so results can link to the pack's
+  # browse page. Unmatched sets simply yield link-less results.
+  defp pack_codes_by_set([], _actor), do: %{}
+
+  defp pack_codes_by_set(sets, actor) do
+    codes = Enum.uniq(sets)
+
+    Sanctum.Catalog.CardSet
+    |> Ash.Query.filter(code in ^codes)
+    |> Ash.Query.load(:pack)
+    |> Ash.read!(actor: actor)
+    |> Map.new(fn set -> {set.code, set.pack && set.pack.code} end)
+  rescue
+    error ->
+      Logger.error(
+        "global search pack resolution failed: #{Exception.format(:error, error, __STACKTRACE__)}"
+      )
+
+      %{}
+  end
+
+  defp browse_href(nil), do: nil
+  defp browse_href(pack_code), do: "/browse/#{pack_code}"
+
+  defp more_url(:cards, rest), do: "/cards" <> query_param(rest)
+  defp more_url(:decks, rest), do: "/decks" <> query_param(rest)
+  defp more_url(_key, _rest), do: nil
+
+  defp query_param(""), do: ""
+  defp query_param(query), do: "?query=" <> URI.encode_www_form(query)
+
+  defp join_subtitle(parts) do
+    case Enum.reject(parts, &(&1 in [nil, ""])) do
+      [] -> nil
+      parts -> Enum.join(parts, " · ")
+    end
+  end
+
+  defp humanize(nil), do: nil
+
+  defp humanize(atom) when is_atom(atom) do
+    atom
+    |> to_string()
+    |> String.split("_")
+    |> Enum.map_join(" ", &String.capitalize/1)
+  end
+end

--- a/lib/sanctum/search/global_fields.ex
+++ b/lib/sanctum/search/global_fields.ex
@@ -1,0 +1,94 @@
+defmodule Sanctum.Search.GlobalFields do
+  @moduledoc """
+  Suggest-only registry for the global search bar: the reserved `in:` type
+  qualifier plus the union of every type registry's fields, merged by
+  canonical name (aliases/values/operators unioned, data-driven value funs
+  composed).
+
+  This registry is never compiled against — `Sanctum.Search.Global` always
+  compiles per type registry after extracting the `in:` scope — so
+  `bare_word/1` returns nil and merged `build` functions are never invoked.
+  It only exists to feed `Sanctum.Search.Suggest` when the query isn't scoped
+  to a single type.
+  """
+
+  @behaviour Sanctum.Search.Registry
+
+  alias Sanctum.Search.{Field, Global}
+
+  # Fields available on at most this many types get their hint suffixed with
+  # the surfaces they apply to ("cost" → "cards"); beyond that the field is
+  # effectively universal and the suffix is noise.
+  @surface_hint_max 3
+
+  @impl true
+  def bare_word(_value), do: nil
+
+  @impl true
+  def fields do
+    [in_field() | union_fields()]
+  end
+
+  defp in_field do
+    %Field{
+      name: "in",
+      kind: :enum,
+      values: Global.type_values(),
+      ops: [:eq],
+      example: "in:cards",
+      hint: "limit results to one type",
+      build: fn _op, _value -> {:error, ~s(the "in" filter is handled before compilation)} end
+    }
+  end
+
+  defp union_fields do
+    tagged =
+      Enum.flat_map(Global.types(), fn %{key: key, registry: registry} ->
+        Enum.map(registry.fields(), &{key, &1})
+      end)
+
+    # First-seen order is autocomplete priority, so the card fields (the
+    # biggest surface) lead, matching the pool's suggestions.
+    tagged
+    |> Enum.map(fn {_key, field} -> field.name end)
+    |> Enum.uniq()
+    |> Enum.map(fn name ->
+      tagged
+      |> Enum.filter(fn {_key, field} -> field.name == name end)
+      |> merge()
+    end)
+  end
+
+  defp merge([{_key, first} | _] = group) do
+    keys = group |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
+    fields = Enum.map(group, &elem(&1, 1))
+
+    %Field{
+      first
+      | aliases: fields |> Enum.flat_map(& &1.aliases) |> Enum.uniq(),
+        values: fields |> Enum.flat_map(& &1.values) |> Enum.uniq(),
+        values_fun: fields |> Enum.map(& &1.values_fun) |> compose_values_funs(),
+        ops: fields |> Enum.flat_map(& &1.ops) |> Enum.uniq(),
+        hint: scoped_hint(first, keys)
+    }
+  end
+
+  defp scoped_hint(%Field{} = field, keys) when length(keys) <= @surface_hint_max do
+    [field.hint || field.example, Enum.map_join(keys, " · ", &surface_label/1)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" — ")
+  end
+
+  defp scoped_hint(%Field{} = field, _keys), do: field.hint
+
+  defp surface_label(:card_sets), do: "sets"
+  defp surface_label(key), do: to_string(key)
+
+  defp compose_values_funs(funs) do
+    case Enum.reject(funs, &is_nil/1) do
+      [] -> nil
+      [one] -> one
+      many -> fn -> many |> Enum.flat_map(& &1.()) |> Enum.uniq() end
+    end
+  end
+end

--- a/lib/sanctum/search/hero_fields.ex
+++ b/lib/sanctum/search/hero_fields.ex
@@ -4,31 +4,10 @@ defmodule Sanctum.Search.HeroFields do
   Minimal on purpose — heroes only surface in the global search bar.
   """
 
-  @behaviour Sanctum.Search.Registry
-
-  import Ash.Expr
-
-  alias Sanctum.Search.{Builders, Field}
-
-  @impl true
-  def bare_word(value) do
-    name_expr(Builders.pattern(value))
-  end
-
-  @impl true
-  def fields do
-    [
-      %Field{
-        name: "name",
-        aliases: ["n"],
-        kind: :text,
-        example: "name:spider-man",
-        hint: "hero or alter-ego name",
-        values_fun: &Sanctum.Search.Values.heroes/0,
-        build: Builders.text_build(&name_expr/1)
-      }
-    ]
-  end
+  use Sanctum.Search.NameRegistry,
+    example: "name:spider-man",
+    hint: "hero or alter-ego name",
+    values_fun: &Sanctum.Search.Values.heroes/0
 
   # display_name always contains hero_name, so it subsumes a hero_name match
   # while also matching the disambiguated "Black Panther (T'Challa)" form.

--- a/lib/sanctum/search/hero_fields.ex
+++ b/lib/sanctum/search/hero_fields.ex
@@ -1,0 +1,38 @@
+defmodule Sanctum.Search.HeroFields do
+  @moduledoc """
+  Search-field registry for heroes (queries run against `Sanctum.Heroes.Hero`).
+  Minimal on purpose — heroes only surface in the global search bar.
+  """
+
+  @behaviour Sanctum.Search.Registry
+
+  import Ash.Expr
+
+  alias Sanctum.Search.{Builders, Field}
+
+  @impl true
+  def bare_word(value) do
+    name_expr(Builders.pattern(value))
+  end
+
+  @impl true
+  def fields do
+    [
+      %Field{
+        name: "name",
+        aliases: ["n"],
+        kind: :text,
+        example: "name:spider-man",
+        hint: "hero or alter-ego name",
+        values_fun: &Sanctum.Search.Values.heroes/0,
+        build: Builders.text_build(&name_expr/1)
+      }
+    ]
+  end
+
+  # display_name always contains hero_name, so it subsumes a hero_name match
+  # while also matching the disambiguated "Black Panther (T'Challa)" form.
+  defp name_expr(pattern) do
+    expr(ilike(display_name, ^pattern) or ilike(alter_ego_name, ^pattern))
+  end
+end

--- a/lib/sanctum/search/name_registry.ex
+++ b/lib/sanctum/search/name_registry.ex
@@ -1,0 +1,59 @@
+defmodule Sanctum.Search.NameRegistry do
+  @moduledoc """
+  Shared implementation for the minimal single-field registries the global
+  search fans out to (packs, heroes, villains, scenarios, card sets): one
+  `name` text field plus the bare-word fallback, both matching through the
+  same `pattern -> Ash expression` function.
+
+  Ash expression macros bind resource attributes at compile time, so each
+  registry defines only that expression:
+
+      use Sanctum.Search.NameRegistry, example: "name:klaw", hint: "villain name"
+
+      defp name_expr(pattern), do: expr(ilike(villain_name, ^pattern))
+
+  `fields/0` is overridable for registries with extra fields (card sets'
+  `set_type`) — append to `super()`.
+  """
+
+  alias Sanctum.Search.{Builders, Field}
+
+  defmacro __using__(opts) do
+    quote do
+      @behaviour Sanctum.Search.Registry
+
+      import Ash.Expr
+
+      alias Sanctum.Search.NameRegistry
+
+      @impl true
+      def bare_word(value), do: NameRegistry.bare_word(&name_expr/1, value)
+
+      @impl true
+      def fields do
+        [NameRegistry.name_field(&name_expr/1, unquote(opts))]
+      end
+
+      defoverridable fields: 0
+    end
+  end
+
+  @doc "The bare-word fallback: the registry's name expression, pattern-escaped."
+  def bare_word(to_expr, value), do: to_expr.(Builders.pattern(value))
+
+  @doc """
+  The `name` text field built on `to_expr`. Options: `:example` and `:hint`
+  (required), `:values_fun` (optional autocomplete source).
+  """
+  def name_field(to_expr, opts) do
+    %Field{
+      name: "name",
+      aliases: ["n"],
+      kind: :text,
+      example: Keyword.fetch!(opts, :example),
+      hint: Keyword.fetch!(opts, :hint),
+      values_fun: opts[:values_fun],
+      build: Builders.text_build(to_expr)
+    }
+  end
+end

--- a/lib/sanctum/search/pack_fields.ex
+++ b/lib/sanctum/search/pack_fields.ex
@@ -4,28 +4,9 @@ defmodule Sanctum.Search.PackFields do
   Minimal on purpose — packs only surface in the global search bar.
   """
 
-  @behaviour Sanctum.Search.Registry
+  use Sanctum.Search.NameRegistry,
+    example: ~s(name:"sinister motives"),
+    hint: "pack name"
 
-  import Ash.Expr
-
-  alias Sanctum.Search.{Builders, Field}
-
-  @impl true
-  def bare_word(value) do
-    expr(ilike(name, ^Builders.pattern(value)))
-  end
-
-  @impl true
-  def fields do
-    [
-      %Field{
-        name: "name",
-        aliases: ["n"],
-        kind: :text,
-        example: ~s(name:"sinister motives"),
-        hint: "pack name",
-        build: Builders.text_build(fn pattern -> expr(ilike(name, ^pattern)) end)
-      }
-    ]
-  end
+  defp name_expr(pattern), do: expr(ilike(name, ^pattern))
 end

--- a/lib/sanctum/search/pack_fields.ex
+++ b/lib/sanctum/search/pack_fields.ex
@@ -1,0 +1,31 @@
+defmodule Sanctum.Search.PackFields do
+  @moduledoc """
+  Search-field registry for packs (queries run against `Sanctum.Catalog.Pack`).
+  Minimal on purpose — packs only surface in the global search bar.
+  """
+
+  @behaviour Sanctum.Search.Registry
+
+  import Ash.Expr
+
+  alias Sanctum.Search.{Builders, Field}
+
+  @impl true
+  def bare_word(value) do
+    expr(ilike(name, ^Builders.pattern(value)))
+  end
+
+  @impl true
+  def fields do
+    [
+      %Field{
+        name: "name",
+        aliases: ["n"],
+        kind: :text,
+        example: ~s(name:"sinister motives"),
+        hint: "pack name",
+        build: Builders.text_build(fn pattern -> expr(ilike(name, ^pattern)) end)
+      }
+    ]
+  end
+end

--- a/lib/sanctum/search/scenario_fields.ex
+++ b/lib/sanctum/search/scenario_fields.ex
@@ -1,0 +1,32 @@
+defmodule Sanctum.Search.ScenarioFields do
+  @moduledoc """
+  Search-field registry for scenarios (queries run against
+  `Sanctum.Games.Scenario`). Minimal on purpose — scenarios only surface in
+  the global search bar.
+  """
+
+  @behaviour Sanctum.Search.Registry
+
+  import Ash.Expr
+
+  alias Sanctum.Search.{Builders, Field}
+
+  @impl true
+  def bare_word(value) do
+    expr(ilike(name, ^Builders.pattern(value)))
+  end
+
+  @impl true
+  def fields do
+    [
+      %Field{
+        name: "name",
+        aliases: ["n"],
+        kind: :text,
+        example: "name:rhino",
+        hint: "scenario name",
+        build: Builders.text_build(fn pattern -> expr(ilike(name, ^pattern)) end)
+      }
+    ]
+  end
+end

--- a/lib/sanctum/search/scenario_fields.ex
+++ b/lib/sanctum/search/scenario_fields.ex
@@ -5,28 +5,7 @@ defmodule Sanctum.Search.ScenarioFields do
   the global search bar.
   """
 
-  @behaviour Sanctum.Search.Registry
+  use Sanctum.Search.NameRegistry, example: "name:rhino", hint: "scenario name"
 
-  import Ash.Expr
-
-  alias Sanctum.Search.{Builders, Field}
-
-  @impl true
-  def bare_word(value) do
-    expr(ilike(name, ^Builders.pattern(value)))
-  end
-
-  @impl true
-  def fields do
-    [
-      %Field{
-        name: "name",
-        aliases: ["n"],
-        kind: :text,
-        example: "name:rhino",
-        hint: "scenario name",
-        build: Builders.text_build(fn pattern -> expr(ilike(name, ^pattern)) end)
-      }
-    ]
-  end
+  defp name_expr(pattern), do: expr(ilike(name, ^pattern))
 end

--- a/lib/sanctum/search/villain_fields.ex
+++ b/lib/sanctum/search/villain_fields.ex
@@ -1,0 +1,32 @@
+defmodule Sanctum.Search.VillainFields do
+  @moduledoc """
+  Search-field registry for villains (queries run against
+  `Sanctum.Villains.Villain`). Minimal on purpose — villains only surface in
+  the global search bar.
+  """
+
+  @behaviour Sanctum.Search.Registry
+
+  import Ash.Expr
+
+  alias Sanctum.Search.{Builders, Field}
+
+  @impl true
+  def bare_word(value) do
+    expr(ilike(villain_name, ^Builders.pattern(value)))
+  end
+
+  @impl true
+  def fields do
+    [
+      %Field{
+        name: "name",
+        aliases: ["n"],
+        kind: :text,
+        example: "name:klaw",
+        hint: "villain name",
+        build: Builders.text_build(fn pattern -> expr(ilike(villain_name, ^pattern)) end)
+      }
+    ]
+  end
+end

--- a/lib/sanctum/search/villain_fields.ex
+++ b/lib/sanctum/search/villain_fields.ex
@@ -5,28 +5,7 @@ defmodule Sanctum.Search.VillainFields do
   the global search bar.
   """
 
-  @behaviour Sanctum.Search.Registry
+  use Sanctum.Search.NameRegistry, example: "name:klaw", hint: "villain name"
 
-  import Ash.Expr
-
-  alias Sanctum.Search.{Builders, Field}
-
-  @impl true
-  def bare_word(value) do
-    expr(ilike(villain_name, ^Builders.pattern(value)))
-  end
-
-  @impl true
-  def fields do
-    [
-      %Field{
-        name: "name",
-        aliases: ["n"],
-        kind: :text,
-        example: "name:klaw",
-        hint: "villain name",
-        build: Builders.text_build(fn pattern -> expr(ilike(villain_name, ^pattern)) end)
-      }
-    ]
-  end
+  defp name_expr(pattern), do: expr(ilike(villain_name, ^pattern))
 end

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -98,19 +98,48 @@ defmodule SanctumWeb.Layouts do
       <div class="drawer-content relative flex min-h-screen flex-col">
         <div class="pointer-events-none fixed inset-0 z-0 bg-halftone"></div>
 
-        <!-- slim top bar (mobile only) -->
-        <header class="sticky top-0 z-30 border-b-[3px] border-neutral bg-base-100/90 backdrop-blur lg:hidden">
-          <div class="flex items-center justify-between px-4 py-3.5">
+        <!-- slim top bar: logo + menu on mobile, global search on all sizes.
+             Sticky only below lg (the pre-existing mobile behavior); on desktop
+             the search bar scrolls away with the page. -->
+        <header class="sticky top-0 z-30 border-b-[3px] border-neutral bg-base-100/90 backdrop-blur lg:static">
+          <input id="global-search-toggle" type="checkbox" class="peer hidden" />
+          <div class="flex items-center justify-between gap-3 px-4 py-3.5 lg:hidden">
             <a href="/" class="font-bangers text-[28px] leading-none tracking-wide text-primary">
               SANCTUM
             </a>
-            <label
-              for="app-drawer"
-              class="drawer-button flex size-11 cursor-pointer items-center justify-center border-2 border-neutral bg-base-300 text-base-content"
-              aria-label="Open menu"
-            >
-              <.icon name="hero-bars-3" class="size-6" />
-            </label>
+            <div class="flex items-center gap-2">
+              <label
+                for="global-search-toggle"
+                class="flex size-11 cursor-pointer items-center justify-center border-2 border-neutral bg-base-300 text-base-content"
+                aria-label="Toggle search"
+              >
+                <.icon name="hero-magnifying-glass" class="size-5" />
+              </label>
+              <label
+                for="app-drawer"
+                class="drawer-button flex size-11 cursor-pointer items-center justify-center border-2 border-neutral bg-base-300 text-base-content"
+                aria-label="Open menu"
+              >
+                <.icon name="hero-bars-3" class="size-6" />
+              </label>
+            </div>
+          </div>
+          <div class="hidden px-4 pb-3 peer-checked:block lg:block lg:px-6 lg:py-2.5">
+            <div class="mx-auto w-full max-w-[1480px]">
+              <div class="flex items-center gap-3 lg:max-w-[560px]">
+                <.live_component
+                  module={SanctumWeb.GlobalSearchComponent}
+                  id="global-search-bar"
+                  current_user={@current_user}
+                />
+                <kbd
+                  class="hidden shrink-0 border border-base-content/25 px-1.5 py-0.5 font-ibm-mono text-[11px] text-base-content/45 lg:block"
+                  title="Focus search"
+                >
+                  ⌘K
+                </kbd>
+              </div>
+            </div>
           </div>
         </header>
 

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -98,23 +98,21 @@ defmodule SanctumWeb.Layouts do
       <div class="drawer-content relative flex min-h-screen flex-col">
         <div class="pointer-events-none fixed inset-0 z-0 bg-halftone"></div>
 
-        <!-- slim top bar: logo + menu on mobile, global search on all sizes.
-             Sticky only below lg (the pre-existing mobile behavior); on desktop
-             the search bar scrolls away with the page. -->
-        <header class="sticky top-0 z-30 border-b-[3px] border-neutral bg-base-100/90 backdrop-blur lg:static">
-          <input id="global-search-toggle" type="checkbox" class="peer hidden" />
-          <div class="flex items-center justify-between gap-3 px-4 py-3.5 lg:hidden">
+        <!-- slim top bar (mobile only) -->
+        <header class="sticky top-0 z-30 border-b-[3px] border-neutral bg-base-100/90 backdrop-blur lg:hidden">
+          <div class="flex items-center justify-between gap-3 px-4 py-3.5">
             <a href="/" class="font-bangers text-[28px] leading-none tracking-wide text-primary">
               SANCTUM
             </a>
             <div class="flex items-center gap-2">
-              <label
-                for="global-search-toggle"
+              <button
+                type="button"
+                phx-click={open_search()}
                 class="flex size-11 cursor-pointer items-center justify-center border-2 border-neutral bg-base-300 text-base-content"
-                aria-label="Toggle search"
+                aria-label="Search"
               >
                 <.icon name="hero-magnifying-glass" class="size-5" />
-              </label>
+              </button>
               <label
                 for="app-drawer"
                 class="drawer-button flex size-11 cursor-pointer items-center justify-center border-2 border-neutral bg-base-300 text-base-content"
@@ -168,6 +166,18 @@ defmodule SanctumWeb.Layouts do
             </label>
           </div>
           <nav class="mt-6 flex flex-col flex-1 gap-1.5 lg:mt-4 lg:gap-1">
+            <button
+              type="button"
+              phx-click={open_search()}
+              class="hidden cursor-pointer items-center justify-between border-2 border-transparent px-3 py-2 font-barlow-condensed text-[15px] font-bold uppercase tracking-[0.1em] text-base-content/55 transition-colors hover:text-white lg:flex lg:px-2.5 lg:py-1.5 lg:text-[13px]"
+            >
+              <span class="flex items-center gap-2">
+                <.icon name="hero-magnifying-glass" class="size-3.5" /> Search
+              </span>
+              <kbd class="border border-base-content/20 px-1 font-ibm-mono text-[10px] normal-case tracking-normal text-base-content/35">
+                ⌘K
+              </kbd>
+            </button>
             <.sidebar_link navigate={~p"/browse"} active={@active_tab == :browse}>
               Packs
             </.sidebar_link>
@@ -238,6 +248,12 @@ defmodule SanctumWeb.Layouts do
   # navigating on mobile (handled by a window listener in app.js).
   defp close_drawer(js \\ %JS{}) do
     JS.dispatch(js, "sanctum:close-drawer", to: "#app-drawer")
+  end
+
+  # Opens the global search overlay (handled by the GlobalSearch hook, which
+  # listens for this event on window — same pattern as sanctum:close-drawer).
+  defp open_search(js \\ %JS{}) do
+    JS.dispatch(js, "sanctum:open-search")
   end
 
   attr :active, :boolean, default: false

--- a/lib/sanctum_web/components/query_input.ex
+++ b/lib/sanctum_web/components/query_input.ex
@@ -38,6 +38,10 @@ defmodule SanctumWeb.Components.QueryInput do
     default: "QueryInput",
     doc: "the JS hook driving the input (the global bar uses GlobalSearch)"
 
+  attr :debounce, :integer,
+    default: 200,
+    doc: "phx-debounce for the surrounding form's change event"
+
   slot :results,
     doc: """
     server-rendered results shown beneath the suggestions inside a shared
@@ -79,7 +83,7 @@ defmodule SanctumWeb.Components.QueryInput do
             id={@id <> "-input"}
             name={@name}
             value={@value}
-            phx-debounce="200"
+            phx-debounce={@debounce}
             autocomplete="off"
             spellcheck="false"
             autocapitalize="off"

--- a/lib/sanctum_web/components/query_input.ex
+++ b/lib/sanctum_web/components/query_input.ex
@@ -34,6 +34,17 @@ defmodule SanctumWeb.Components.QueryInput do
     default: nil,
     doc: "when set, renders a “?” link to the search-syntax reference"
 
+  attr :hook, :string,
+    default: "QueryInput",
+    doc: "the JS hook driving the input (the global bar uses GlobalSearch)"
+
+  slot :results,
+    doc: """
+    server-rendered results shown beneath the suggestions inside a shared
+    dropdown panel (the GlobalSearch pattern). Without it the suggestions
+    listbox drops down alone, exactly as on /cards and /decks.
+    """
+
   def query_input(assigns) do
     assigns = assign(assigns, :field_names, field_names(assigns.registry))
 
@@ -42,7 +53,7 @@ defmodule SanctumWeb.Components.QueryInput do
     # for the help link.
     ~H"""
     <div class="relative min-w-[260px] flex-1">
-      <div id={@id} phx-hook="QueryInput" data-fields={Jason.encode!(@field_names)}>
+      <div id={@id} phx-hook={@hook} data-fields={Jason.encode!(@field_names)}>
         <span class="pointer-events-none absolute left-3.5 top-[21px] z-20 -translate-y-1/2 text-[17px] text-base-content/40">
           ⌕
         </span>
@@ -83,11 +94,28 @@ defmodule SanctumWeb.Components.QueryInput do
           </.link>
         </div>
         <div
+          :if={@results == []}
           id={@id <> "-listbox"}
           phx-update="ignore"
           role="listbox"
           class="qi-listbox absolute left-0 right-0 top-full z-30 mt-1.5 hidden max-h-72 overflow-y-auto border-2 border-neutral bg-base-200 shadow-comic"
         >
+        </div>
+        <div
+          :if={@results != []}
+          id={@id <> "-panel"}
+          class="absolute left-0 right-0 top-full z-30 mt-1.5 hidden border-2 border-neutral bg-base-200 shadow-comic"
+        >
+          <div
+            id={@id <> "-listbox"}
+            phx-update="ignore"
+            role="listbox"
+            class="qi-listbox hidden max-h-56 overflow-y-auto border-b-2 border-line"
+          >
+          </div>
+          <div class="max-h-[60vh] overflow-y-auto">
+            {render_slot(@results)}
+          </div>
         </div>
       </div>
       <div

--- a/lib/sanctum_web/components/query_input.ex
+++ b/lib/sanctum_web/components/query_input.ex
@@ -41,8 +41,17 @@ defmodule SanctumWeb.Components.QueryInput do
   slot :results,
     doc: """
     server-rendered results shown beneath the suggestions inside a shared
-    dropdown panel (the GlobalSearch pattern). Without it the suggestions
-    listbox drops down alone, exactly as on /cards and /decks.
+    panel (the GlobalSearch pattern). Without it the suggestions listbox
+    drops down alone, exactly as on /cards and /decks.
+    """
+
+  attr :panel_class, :string,
+    default:
+      "absolute left-0 right-0 top-full z-30 mt-1.5 hidden border-2 border-neutral bg-base-200 shadow-comic",
+    doc: """
+    chrome/positioning of the suggestions+results panel (only used with the
+    `results` slot). The default is an anchored dropdown; the search overlay
+    passes in-flow classes instead. Keep `hidden` — the hook owns visibility.
     """
 
   def query_input(assigns) do
@@ -101,11 +110,7 @@ defmodule SanctumWeb.Components.QueryInput do
           class="qi-listbox absolute left-0 right-0 top-full z-30 mt-1.5 hidden max-h-72 overflow-y-auto border-2 border-neutral bg-base-200 shadow-comic"
         >
         </div>
-        <div
-          :if={@results != []}
-          id={@id <> "-panel"}
-          class="absolute left-0 right-0 top-full z-30 mt-1.5 hidden border-2 border-neutral bg-base-200 shadow-comic"
-        >
+        <div :if={@results != []} id={@id <> "-panel"} class={@panel_class}>
           <div
             id={@id <> "-listbox"}
             phx-update="ignore"

--- a/lib/sanctum_web/components/query_input.ex
+++ b/lib/sanctum_web/components/query_input.ex
@@ -110,15 +110,19 @@ defmodule SanctumWeb.Components.QueryInput do
           class="qi-listbox absolute left-0 right-0 top-full z-30 mt-1.5 hidden max-h-72 overflow-y-auto border-2 border-neutral bg-base-200 shadow-comic"
         >
         </div>
+        <%!-- The panel is the single scroll region (see panel_class);
+             suggestions and results scroll together. The inner bottom padding
+             keeps the last row clear of the phone's screen edge / home
+             indicator. --%>
         <div :if={@results != []} id={@id <> "-panel"} class={@panel_class}>
           <div
             id={@id <> "-listbox"}
             phx-update="ignore"
             role="listbox"
-            class="qi-listbox hidden max-h-56 overflow-y-auto border-b-2 border-line"
+            class="qi-listbox hidden border-b-2 border-line"
           >
           </div>
-          <div class="max-h-[60vh] overflow-y-auto">
+          <div class="pb-[max(env(safe-area-inset-bottom),1.25rem)] sm:pb-0">
             {render_slot(@results)}
           </div>
         </div>

--- a/lib/sanctum_web/live/browse_live/show.ex
+++ b/lib/sanctum_web/live/browse_live/show.ex
@@ -123,7 +123,12 @@ defmodule SanctumWeb.BrowseLive.Show do
         socket
       end
 
-    {:noreply, socket}
+    # Sections carry their card-set code as a DOM id (/browse/cw#spider_man),
+    # but the fragment never reaches the server and the anchor target only
+    # exists now that the async load has rendered — nudge the client to honor
+    # it (a no-op without a fragment; ScrollRestore skips saved positions when
+    # one is present).
+    {:noreply, push_event(socket, "sanctum:scroll-to-hash", %{})}
   end
 
   def handle_async(:load_pack, {:ok, {:error, code}}, socket) do
@@ -244,6 +249,7 @@ defmodule SanctumWeb.BrowseLive.Show do
             title={section.title}
             subtitle={section.subtitle}
             cards={section.cards}
+            anchor={section.code}
             owned_ids={@owned_ids}
           />
 
@@ -303,6 +309,7 @@ defmodule SanctumWeb.BrowseLive.Show do
           title={group.title}
           cards={group.cards}
           level={:sub}
+          anchor={group[:code]}
           owned_ids={@owned_ids}
         />
       </div>
@@ -316,9 +323,13 @@ defmodule SanctumWeb.BrowseLive.Show do
   attr :level, :atom, default: :top
   attr :owned_ids, :any, default: nil, doc: "MapSet of owned card ids; nil hides collection UI"
 
+  attr :anchor, :string,
+    default: nil,
+    doc: "card-set code used as the section's DOM id, so /browse/:pack#<code> can land here"
+
   defp card_section(assigns) do
     ~H"""
-    <section>
+    <section id={@anchor} class="scroll-mt-24 lg:scroll-mt-6">
       <div class="mb-3.5 flex flex-wrap items-baseline gap-x-3 border-b-2 border-neutral pb-2">
         <h2 class={[
           "font-anton uppercase leading-none tracking-[0.03em]",
@@ -388,10 +399,16 @@ defmodule SanctumWeb.BrowseLive.Show do
     hero_sets = Enum.filter(sets, &(&1.set_type == :hero))
     paired_nemesis_ids = nemesis_ids_for(sets, hero_sets)
 
+    main_scheme_sets = Enum.filter(sets, &(&1.set_type == :main_scheme))
+
     main_scheme_sections =
-      case cards_of_type(sets, :main_scheme, hero_colors) do
-        [] -> []
-        cards -> [%{title: "Main Scheme", subtitle: nil, cards: cards}]
+      case cards_from_sets(main_scheme_sets, hero_colors) do
+        [] ->
+          []
+
+        cards ->
+          code = main_scheme_sets |> List.first() |> then(&(&1 && &1.code))
+          [%{title: "Main Scheme", subtitle: nil, cards: cards, code: code}]
       end
 
     hero_sections = Enum.flat_map(hero_sets, &hero_and_nemesis_sections(&1, sets, hero_colors))
@@ -403,7 +420,8 @@ defmodule SanctumWeb.BrowseLive.Show do
         &%{
           title: &1.name || "Nemesis",
           subtitle: "Nemesis",
-          cards: view_cards(&1.cards, hero_colors)
+          cards: view_cards(&1.cards, hero_colors),
+          code: &1.code
         }
       )
 
@@ -418,7 +436,8 @@ defmodule SanctumWeb.BrowseLive.Show do
     hero_section = %{
       title: hero_set.name || "Hero",
       subtitle: "Hero",
-      cards: view_cards(hero_set.cards, hero_colors)
+      cards: view_cards(hero_set.cards, hero_colors),
+      code: hero_set.code
     }
 
     nemesis_section =
@@ -427,7 +446,8 @@ defmodule SanctumWeb.BrowseLive.Show do
           %{
             title: nemesis.name || "Nemesis",
             subtitle: "Nemesis",
-            cards: view_cards(nemesis.cards, hero_colors)
+            cards: view_cards(nemesis.cards, hero_colors),
+            code: nemesis.code
           }
         ]
       else
@@ -441,10 +461,6 @@ defmodule SanctumWeb.BrowseLive.Show do
     hero_ids = MapSet.new(hero_sets, & &1.id)
 
     for s <- sets, s.set_type == :nemesis, s.hero_set_id in hero_ids, into: MapSet.new(), do: s.id
-  end
-
-  defp cards_of_type(sets, type, hero_colors) do
-    sets |> Enum.filter(&(&1.set_type == type)) |> cards_from_sets(hero_colors)
   end
 
   defp cards_from_sets(sets, hero_colors) do
@@ -471,7 +487,9 @@ defmodule SanctumWeb.BrowseLive.Show do
     # Order by each set's lowest card code — roughly the pack's printed order, so
     # the headline set leads rather than whatever sorts alphabetically.
     |> Enum.sort_by(&min_card_code/1)
-    |> Enum.map(&%{title: &1.name || &1.code, cards: view_cards(&1.cards, hero_colors)})
+    |> Enum.map(
+      &%{title: &1.name || &1.code, cards: view_cards(&1.cards, hero_colors), code: &1.code}
+    )
     |> Enum.reject(&(&1.cards == []))
   end
 

--- a/lib/sanctum_web/live/global_search_component.ex
+++ b/lib/sanctum_web/live/global_search_component.ex
@@ -1,0 +1,158 @@
+defmodule SanctumWeb.GlobalSearchComponent do
+  @moduledoc """
+  The site-wide search bar: a `query_input` wired to `Sanctum.Search.Global`,
+  rendered once from `Layouts.app/1`.
+
+  A LiveComponent (not layout markup handled by the host LiveView) because
+  the pool and deck browser already define their own `"search"`/`"suggest"`
+  events — `phx-target={@myself}` keeps the global bar's events isolated no
+  matter which LiveView is mounted. Result fetching runs in `start_async` so
+  slow queries never block the socket; a `req_id` guard drops stale replies.
+  """
+
+  use SanctumWeb, :live_component
+
+  import SanctumWeb.Components.QueryInput
+
+  alias Sanctum.Search.Global
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     assign(socket,
+       query: "",
+       groups: [],
+       diagnostics: [],
+       loading?: false,
+       req_id: 0
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="relative w-full">
+      <form
+        id="global-search-form"
+        phx-change="search"
+        phx-submit="submit"
+        phx-target={@myself}
+        autocomplete="off"
+        class="w-full"
+      >
+        <.query_input
+          id="global-search"
+          hook="GlobalSearch"
+          name="query"
+          value={@query}
+          registry={Sanctum.Search.GlobalFields}
+          placeholder="Search cards, decks, heroes… (try in:cards cost<=2)"
+          placeholder_short="Search…"
+          help_path={~p"/search-help"}
+        >
+          <:results>
+            <div :if={@groups != []} data-gs-content>
+              <div :for={group <- @groups}>
+                <div class="flex items-baseline justify-between border-b border-line bg-base-300/60 px-3 py-1">
+                  <span class="font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.14em] text-base-content/60">
+                    {group.label}
+                  </span>
+                  <.link
+                    :if={group.more_url}
+                    navigate={group.more_url}
+                    data-gs-nav
+                    class="gs-more font-barlow-condensed text-[12px] uppercase tracking-wide text-primary/80 hover:text-primary"
+                  >
+                    all {String.downcase(group.label)} results →
+                  </.link>
+                </div>
+                <%= for result <- group.results do %>
+                  <.link :if={result.href} navigate={result.href} data-gs-nav class="qi-option">
+                    <span class="qi-option-label qi-kind-result">{result.title}</span>
+                    <span :if={result.subtitle} class="qi-option-detail">{result.subtitle}</span>
+                  </.link>
+                  <div :if={is_nil(result.href)} class="qi-option cursor-default">
+                    <span class="qi-option-label qi-kind-result">{result.title}</span>
+                    <span :if={result.subtitle} class="qi-option-detail">{result.subtitle}</span>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+            <div
+              :if={@groups == [] and @loading?}
+              data-gs-content
+              class="px-3 py-2.5 font-barlow text-[13px] text-base-content/50"
+            >
+              Searching…
+            </div>
+            <div
+              :if={@groups == [] and not @loading? and String.trim(@query) != ""}
+              data-gs-content
+              class="px-3 py-2.5 font-barlow text-[13px] text-base-content/50"
+            >
+              <span :if={@diagnostics == []}>No matches for this search.</span>
+              <span :if={@diagnostics != []} class="text-primary/90">
+                ⚠ {hd(@diagnostics).message}
+              </span>
+            </div>
+          </:results>
+        </.query_input>
+      </form>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("search", %{"query" => query}, socket) do
+    if String.trim(query) == "" do
+      {:noreply, assign(socket, query: query, groups: [], diagnostics: [], loading?: false)}
+    else
+      req_id = socket.assigns.req_id + 1
+      actor = socket.assigns[:current_user]
+
+      {:noreply,
+       socket
+       |> assign(query: query, req_id: req_id, loading?: true)
+       |> start_async({:search, req_id}, fn -> Global.search(query, actor) end)}
+    end
+  end
+
+  def handle_event("suggest", %{"value" => value, "cursor" => cursor}, socket) do
+    {:reply, Global.suggest(value, cursor), socket}
+  end
+
+  def handle_event("suggest", _params, socket), do: {:reply, %{items: []}, socket}
+
+  # Enter with nothing highlighted and no results rendered yet: fall back to
+  # navigating to the first result of a fresh search.
+  def handle_event("submit", _params, socket) do
+    case first_href(socket.assigns.groups) do
+      nil -> {:noreply, socket}
+      href -> {:noreply, push_navigate(socket, to: href)}
+    end
+  end
+
+  @impl true
+  def handle_async({:search, req_id}, {:ok, result}, socket) do
+    if req_id == socket.assigns.req_id do
+      {:noreply,
+       assign(socket, groups: result.groups, diagnostics: result.diagnostics, loading?: false)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_async({:search, req_id}, {:exit, _reason}, socket) do
+    if req_id == socket.assigns.req_id do
+      {:noreply, assign(socket, loading?: false)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp first_href(groups) do
+    Enum.find_value(groups, fn group ->
+      Enum.find_value(group.results, & &1.href)
+    end)
+  end
+end

--- a/lib/sanctum_web/live/global_search_component.ex
+++ b/lib/sanctum_web/live/global_search_component.ex
@@ -1,7 +1,11 @@
 defmodule SanctumWeb.GlobalSearchComponent do
   @moduledoc """
-  The site-wide search bar: a `query_input` wired to `Sanctum.Search.Global`,
-  rendered once from `Layouts.app/1`.
+  The site-wide search overlay: a `query_input` wired to
+  `Sanctum.Search.Global`, rendered once from `Layouts.app/1` as a
+  command-palette dialog — centered modal on desktop, slide-up sheet on
+  mobile. Trigger buttons (sidebar, mobile header) and Cmd/Ctrl+K open it via
+  a `sanctum:open-search` window event handled by the GlobalSearch hook;
+  open/close state never touches the server.
 
   A LiveComponent (not layout markup handled by the host LiveView) because
   the pool and deck browser already define their own `"search"`/`"suggest"`
@@ -31,73 +35,84 @@ defmodule SanctumWeb.GlobalSearchComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="relative w-full">
-      <form
-        id="global-search-form"
-        phx-change="search"
-        phx-submit="submit"
-        phx-target={@myself}
-        autocomplete="off"
-        class="w-full"
-      >
-        <.query_input
-          id="global-search"
-          hook="GlobalSearch"
-          name="query"
-          value={@query}
-          registry={Sanctum.Search.GlobalFields}
-          placeholder="Search cards, decks, heroes… (try in:cards cost<=2)"
-          placeholder_short="Search…"
-          help_path={~p"/search-help"}
+    <div
+      id="global-search-overlay"
+      data-gs-overlay
+      class="fixed inset-0 z-50 hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Site search"
+    >
+      <div class="absolute inset-0 bg-black/60" data-gs-close aria-hidden="true"></div>
+      <div class="gs-sheet absolute inset-x-0 bottom-0 max-h-[85vh] border-t-[3px] border-neutral bg-base-100 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-[12vh] sm:w-[min(92vw,620px)] sm:-translate-x-1/2 sm:border-2 sm:shadow-comic-lg">
+        <form
+          id="global-search-form"
+          phx-change="search"
+          phx-submit="submit"
+          phx-target={@myself}
+          autocomplete="off"
+          class="w-full"
         >
-          <:results>
-            <div :if={@groups != []} data-gs-content>
-              <div :for={group <- @groups}>
-                <div class="flex items-baseline justify-between border-b border-line bg-base-300/60 px-3 py-1">
-                  <span class="font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.14em] text-base-content/60">
-                    {group.label}
-                  </span>
-                  <.link
-                    :if={group.more_url}
-                    navigate={group.more_url}
-                    data-gs-nav
-                    class="gs-more font-barlow-condensed text-[12px] uppercase tracking-wide text-primary/80 hover:text-primary"
-                  >
-                    all {String.downcase(group.label)} results →
-                  </.link>
-                </div>
-                <%= for result <- group.results do %>
-                  <.link :if={result.href} navigate={result.href} data-gs-nav class="qi-option">
-                    <span class="qi-option-label qi-kind-result">{result.title}</span>
-                    <span :if={result.subtitle} class="qi-option-detail">{result.subtitle}</span>
-                  </.link>
-                  <div :if={is_nil(result.href)} class="qi-option cursor-default">
-                    <span class="qi-option-label qi-kind-result">{result.title}</span>
-                    <span :if={result.subtitle} class="qi-option-detail">{result.subtitle}</span>
+          <.query_input
+            id="global-search"
+            hook="GlobalSearch"
+            name="query"
+            value={@query}
+            registry={Sanctum.Search.GlobalFields}
+            placeholder="Search cards, decks, heroes… (try in:cards cost<=2)"
+            placeholder_short="Search…"
+            help_path={~p"/search-help"}
+            panel_class="mt-3 hidden border-t-2 border-line"
+          >
+            <:results>
+              <div :if={@groups != []} data-gs-content>
+                <div :for={group <- @groups}>
+                  <div class="flex items-baseline justify-between border-b border-line bg-base-300/60 px-3 py-1">
+                    <span class="font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.14em] text-base-content/60">
+                      {group.label}
+                    </span>
+                    <.link
+                      :if={group.more_url}
+                      navigate={group.more_url}
+                      data-gs-nav
+                      class="gs-more font-barlow-condensed text-[12px] uppercase tracking-wide text-primary/80 hover:text-primary"
+                    >
+                      all {String.downcase(group.label)} results →
+                    </.link>
                   </div>
-                <% end %>
+                  <%= for result <- group.results do %>
+                    <.link :if={result.href} navigate={result.href} data-gs-nav class="qi-option">
+                      <span class="qi-option-label qi-kind-result">{result.title}</span>
+                      <span :if={result.subtitle} class="qi-option-detail">{result.subtitle}</span>
+                    </.link>
+                    <div :if={is_nil(result.href)} class="qi-option cursor-default">
+                      <span class="qi-option-label qi-kind-result">{result.title}</span>
+                      <span :if={result.subtitle} class="qi-option-detail">{result.subtitle}</span>
+                    </div>
+                  <% end %>
+                </div>
               </div>
-            </div>
-            <div
-              :if={@groups == [] and @loading?}
-              data-gs-content
-              class="px-3 py-2.5 font-barlow text-[13px] text-base-content/50"
-            >
-              Searching…
-            </div>
-            <div
-              :if={@groups == [] and not @loading? and String.trim(@query) != ""}
-              data-gs-content
-              class="px-3 py-2.5 font-barlow text-[13px] text-base-content/50"
-            >
-              <span :if={@diagnostics == []}>No matches for this search.</span>
-              <span :if={@diagnostics != []} class="text-primary/90">
-                ⚠ {hd(@diagnostics).message}
-              </span>
-            </div>
-          </:results>
-        </.query_input>
-      </form>
+              <div
+                :if={@groups == [] and @loading?}
+                data-gs-content
+                class="px-3 py-2.5 font-barlow text-[13px] text-base-content/50"
+              >
+                Searching…
+              </div>
+              <div
+                :if={@groups == [] and not @loading? and String.trim(@query) != ""}
+                data-gs-content
+                class="px-3 py-2.5 font-barlow text-[13px] text-base-content/50"
+              >
+                <span :if={@diagnostics == []}>No matches for this search.</span>
+                <span :if={@diagnostics != []} class="text-primary/90">
+                  ⚠ {hd(@diagnostics).message}
+                </span>
+              </div>
+            </:results>
+          </.query_input>
+        </form>
+      </div>
     </div>
     """
   end

--- a/lib/sanctum_web/live/global_search_component.ex
+++ b/lib/sanctum_web/live/global_search_component.ex
@@ -44,7 +44,11 @@ defmodule SanctumWeb.GlobalSearchComponent do
       aria-label="Site search"
     >
       <div class="absolute inset-0 bg-black/60" data-gs-close aria-hidden="true"></div>
-      <div class="gs-sheet absolute inset-x-0 bottom-0 max-h-[85vh] border-t-[3px] border-neutral bg-base-100 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-[12vh] sm:w-[min(92vw,620px)] sm:-translate-x-1/2 sm:border-2 sm:shadow-comic-lg">
+      <%!-- Mobile: a fixed-height bottom sheet (dvh so browser chrome is
+           accounted for) — it doesn't grow/shrink with results, and the
+           results region scrolls inside it. Desktop: centered dialog sized
+           by content. --%>
+      <div class="gs-sheet absolute inset-x-0 bottom-0 h-[85dvh] overflow-hidden border-t-[3px] border-neutral bg-base-100 p-3 sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-[12vh] sm:h-auto sm:w-[min(92vw,620px)] sm:-translate-x-1/2 sm:overflow-visible sm:border-2 sm:shadow-comic-lg">
         <form
           id="global-search-form"
           phx-change="search"
@@ -62,7 +66,7 @@ defmodule SanctumWeb.GlobalSearchComponent do
             placeholder="Search cards, decks, heroes… (try in:cards cost<=2)"
             placeholder_short="Search…"
             help_path={~p"/search-help"}
-            panel_class="mt-3 hidden border-t-2 border-line"
+            panel_class="mt-3 hidden max-h-[calc(85dvh-6rem)] overflow-y-auto overscroll-contain border-t-2 border-line sm:max-h-[60vh]"
           >
             <:results>
               <%!-- Navigable rows carry server-rendered ids (for

--- a/lib/sanctum_web/live/global_search_component.ex
+++ b/lib/sanctum_web/live/global_search_component.ex
@@ -66,6 +66,7 @@ defmodule SanctumWeb.GlobalSearchComponent do
             placeholder="Search cards, decks, heroes… (try in:cards cost<=2)"
             placeholder_short="Search…"
             help_path={~p"/search-help"}
+            debounce={350}
             panel_class="mt-3 hidden max-h-[calc(85dvh-6rem)] overflow-y-auto overscroll-contain border-t-2 border-line sm:max-h-[60vh]"
           >
             <:results>

--- a/lib/sanctum_web/live/global_search_component.ex
+++ b/lib/sanctum_web/live/global_search_component.ex
@@ -65,6 +65,10 @@ defmodule SanctumWeb.GlobalSearchComponent do
             panel_class="mt-3 hidden border-t-2 border-line"
           >
             <:results>
+              <%!-- Navigable rows carry server-rendered ids (for
+                   aria-activedescendant): the hook must never assign ids to
+                   LiveView-managed elements — the DOM patcher tracks nodes by
+                   id, and client-mutated ids corrupt the next diff. --%>
               <div :if={@groups != []} data-gs-content>
                 <div :for={group <- @groups}>
                   <div class="flex items-baseline justify-between border-b border-line bg-base-300/60 px-3 py-1">
@@ -74,14 +78,21 @@ defmodule SanctumWeb.GlobalSearchComponent do
                     <.link
                       :if={group.more_url}
                       navigate={group.more_url}
+                      id={"gs-more-#{group.type}"}
                       data-gs-nav
                       class="gs-more font-barlow-condensed text-[12px] uppercase tracking-wide text-primary/80 hover:text-primary"
                     >
                       all {String.downcase(group.label)} results →
                     </.link>
                   </div>
-                  <%= for result <- group.results do %>
-                    <.link :if={result.href} navigate={result.href} data-gs-nav class="qi-option">
+                  <%= for {result, index} <- Enum.with_index(group.results) do %>
+                    <.link
+                      :if={result.href}
+                      navigate={result.href}
+                      id={"gs-res-#{group.type}-#{index}"}
+                      data-gs-nav
+                      class="qi-option"
+                    >
                       <span class="qi-option-label qi-kind-result">{result.title}</span>
                       <span :if={result.subtitle} class="qi-option-detail">{result.subtitle}</span>
                     </.link>

--- a/lib/sanctum_web/live/search_help_live.ex
+++ b/lib/sanctum_web/live/search_help_live.ex
@@ -100,7 +100,8 @@ defmodule SanctumWeb.SearchHelpLive do
           <.section_title>Global search</.section_title>
           <div class="space-y-2.5 font-barlow text-[15px] leading-relaxed text-base-content/85">
             <p>
-              The search bar in the header (press <.q c="⌘K" /> anywhere) searches the whole
+              The Search button (in the sidebar or the mobile header — or press <.q c="⌘K" />
+              anywhere) opens a search palette that searches the whole
               site at once — cards, decks, heroes, packs, card sets, villains, and
               scenarios — with this same query language, grouped by type.
             </p>

--- a/lib/sanctum_web/live/search_help_live.ex
+++ b/lib/sanctum_web/live/search_help_live.ex
@@ -96,6 +96,27 @@ defmodule SanctumWeb.SearchHelpLive do
           </table>
         </section>
 
+        <section id="global">
+          <.section_title>Global search</.section_title>
+          <div class="space-y-2.5 font-barlow text-[15px] leading-relaxed text-base-content/85">
+            <p>
+              The search bar in the header (press <.q c="⌘K" /> anywhere) searches the whole
+              site at once — cards, decks, heroes, packs, card sets, villains, and
+              scenarios — with this same query language, grouped by type.
+            </p>
+            <p>
+              Add <.q c="in:" /> to limit results to specific types:
+              <.q c="in:decks spider" />, or several at once with <.q c="in:cards|decks" />. Types:
+              <span :for={type <- @global_types} class="mr-1"><.q c={type} /></span>
+            </p>
+            <p>
+              A typed filter also narrows the search on its own, to the types that
+              understand it — <.q c="cost<=2" /> only ever matches cards, so only card
+              results appear; <.q c="aspect:aggression" /> means both cards and decks.
+            </p>
+          </div>
+        </section>
+
         <section id="cards">
           <.section_title>Card fields</.section_title>
           <.fields_table fields={@card_fields} base_path="/cards" />
@@ -190,6 +211,7 @@ defmodule SanctumWeb.SearchHelpLive do
       |> assign(:page_title, "Search Syntax")
       |> assign(:card_fields, CardFields.fields())
       |> assign(:deck_fields, DeckFields.fields())
+      |> assign(:global_types, Sanctum.Search.Global.type_values())
       |> assign(:card_examples, @card_examples)
       |> assign(:deck_examples, @deck_examples)
 

--- a/test/sanctum/search/global_test.exs
+++ b/test/sanctum/search/global_test.exs
@@ -325,12 +325,16 @@ defmodule Sanctum.Search.GlobalTest do
       found_pack = Enum.find(group(result, :packs).results, &(&1.title == "#{@marker} Rising"))
       assert found_pack.href == "/browse/#{pack.code}"
 
-      # villain + scenario resolve their set slug to the pack's browse page
+      # set-scoped results carry the set code as a fragment so the pack page
+      # can scroll that section into view
+      [card_set] = group(result, :card_sets).results
+      assert card_set.href == "/browse/#{pack.code}#zz_villain"
+
       [villain] = group(result, :villains).results
-      assert villain.href == "/browse/#{pack.code}"
+      assert villain.href == "/browse/#{pack.code}#zz_villain"
 
       [scenario] = group(result, :scenarios).results
-      assert scenario.href == "/browse/#{pack.code}"
+      assert scenario.href == "/browse/#{pack.code}#zz_villain"
     end
 
     test "typed clauses implicitly narrow to the types that understand them" do

--- a/test/sanctum/search/global_test.exs
+++ b/test/sanctum/search/global_test.exs
@@ -1,0 +1,389 @@
+defmodule Sanctum.Search.GlobalTest do
+  @moduledoc """
+  The site-wide search: `in:` scope extraction, strict per-type applicability,
+  remainder serialization (pure), and the fan-out through real Ash queries
+  (DB-backed).
+  """
+
+  use Sanctum.DataCase, async: true
+
+  import Sanctum.Factory
+
+  alias Sanctum.Search.{CardFields, DeckFields, Global, HeroFields, Parser}
+
+  # -- scope extraction (pure) -------------------------------------------------
+
+  describe "extract_scope/1" do
+    defp extract(input) do
+      {ast, _diags} = Parser.parse(input)
+      Global.extract_scope(ast)
+    end
+
+    test "no in: clause leaves scope :all and the AST untouched" do
+      {scope, ast, spans, diags} = extract("spider cost<=2")
+
+      assert scope == :all
+      assert {:and, [_, _]} = ast
+      assert spans == []
+      assert diags == []
+    end
+
+    test "extracts a single type" do
+      {scope, ast, spans, diags} = extract("in:cards spider")
+
+      assert scope == MapSet.new([:cards])
+      assert {:word, _} = ast
+      assert [{0, 8}] = spans
+      assert diags == []
+    end
+
+    test "singular aliases and pipe values combine" do
+      {scope, _ast, _spans, []} = extract("in:card|decks spider")
+
+      assert scope == MapSet.new([:cards, :decks])
+    end
+
+    test "a lone in: clause leaves a nil remainder" do
+      {scope, ast, _spans, []} = extract("in:decks")
+
+      assert scope == MapSet.new([:decks])
+      assert ast == nil
+    end
+
+    test "unknown type value warns and falls back to :all" do
+      {scope, _ast, _spans, [diag]} = extract("in:foo spider")
+
+      assert scope == :all
+      assert diag.code == :unknown_type
+      assert diag.message =~ ~s("foo" isn't a searchable type)
+    end
+
+    test "in: nested under or/not is dropped with a diagnostic" do
+      {scope, ast, spans, [diag]} = extract("spider or in:cards web")
+
+      assert scope == :all
+      assert diag.code == :misplaced_scope
+      # the in: clause is gone from the AST but both words survive
+      assert {:or, [{:word, _}, {:word, _}]} = ast
+      assert length(spans) == 1
+    end
+  end
+
+  # -- per-type applicability (pure) --------------------------------------------
+
+  describe "applicable?/2" do
+    defp applicable?(input, registry) do
+      {ast, _} = Parser.parse(input)
+      Global.applicable?(ast, registry)
+    end
+
+    test "bare words apply to every registry" do
+      assert applicable?("spider", CardFields)
+      assert applicable?("spider", DeckFields)
+      assert applicable?("spider", HeroFields)
+    end
+
+    test "a field unknown to a registry excludes it" do
+      assert applicable?("cost<=2", CardFields)
+      refute applicable?("cost<=2", DeckFields)
+      refute applicable?("cost<=2", HeroFields)
+    end
+
+    test "a shared field applies to every registry that knows it" do
+      assert applicable?("aspect:aggression", CardFields)
+      assert applicable?("aspect:aggression", DeckFields)
+      refute applicable?("aspect:aggression", HeroFields)
+    end
+
+    test "value-level mismatch excludes the type" do
+      # "hero" is a valid card aspect-pool but not a deck aspect
+      assert applicable?("aspect:hero", CardFields)
+      refute applicable?("aspect:hero", DeckFields)
+    end
+
+    test "one valid alternative among piped values is enough" do
+      assert applicable?("aspect:hero|justice", DeckFields)
+    end
+
+    test "unsupported operator excludes the type" do
+      refute applicable?("title>2", DeckFields)
+    end
+
+    test "any foreign clause under and/or/not excludes the type" do
+      refute applicable?("spider or cost<=2", DeckFields)
+      refute applicable?("-cost<=2 spider", DeckFields)
+    end
+  end
+
+  # -- remainder serialization (pure) --------------------------------------------
+
+  describe "remainder/2" do
+    defp remainder_of(input) do
+      {ast, _} = Parser.parse(input)
+      {_scope, _ast, spans, _diags} = Global.extract_scope(ast)
+      Global.remainder(input, spans)
+    end
+
+    test "strips the in: clause and its surrounding whitespace" do
+      assert remainder_of("in:cards cost<=2") == "cost<=2"
+      assert remainder_of("cost<=2 in:cards") == "cost<=2"
+      assert remainder_of("spider in:cards cost<=2") == "spider cost<=2"
+    end
+
+    test "keeps quoted whitespace intact" do
+      assert remainder_of(~s(in:cards name:"foo  bar")) == ~s(name:"foo  bar")
+    end
+
+    test "a lone in: clause leaves an empty remainder" do
+      assert remainder_of("in:decks") == ""
+    end
+
+    test "no spans returns the trimmed input" do
+      assert remainder_of("  spider  ") == "spider"
+    end
+  end
+
+  # -- global autocomplete (pure) --------------------------------------------------
+
+  describe "suggest/2" do
+    defp labels(input) do
+      %{items: items} = Global.suggest(input, String.length(input))
+      Enum.map(items, & &1.label)
+    end
+
+    test "offers in: alongside the union of type fields" do
+      %{items: items} = Global.suggest("", 0)
+      all_labels = Enum.map(items, & &1.label)
+
+      assert "in" in all_labels
+      # card fields lead (registry order = priority)
+      assert "name" in all_labels
+    end
+
+    test "completes in: values with the type keys" do
+      assert labels("in:") == Global.type_values()
+      assert labels("in:vil") == ["villains"]
+    end
+
+    test "union covers fields from every registry, deduplicated" do
+      assert labels("tit") == ["title"]
+      assert labels("set_t") == ["set_type"]
+      assert Enum.count(labels("na"), &(&1 == "name")) == 1
+    end
+
+    test "ambiguous fields say which types they cover" do
+      %{items: [title]} = Global.suggest("tit", 3)
+      assert title.detail =~ "decks"
+    end
+
+    test "scoping to one type delegates to that registry" do
+      # "title" is a deck field; scoped to cards it should vanish
+      assert "title" in labels("tit")
+      assert labels("in:cards tit") == []
+      assert "cost" in labels("in:cards co")
+    end
+  end
+
+  # -- fan-out (DB-backed) --------------------------------------------------------
+
+  describe "search/3" do
+    # A marker string no factory-generated name will collide with.
+    @marker "Zzyzx"
+
+    defp insert_side(attrs) do
+      pack =
+        create(Sanctum.Catalog.Pack,
+          action: :upsert_from_marvelcdb,
+          attrs: %{code: "zz_pack", name: "Zzyzx Pack"}
+        )
+
+      card = create(Sanctum.Games.Card, attrs: %{pack_id: pack.id, pack: pack.code})
+
+      create(Sanctum.Games.CardSide,
+        attrs:
+          Map.merge(
+            %{card_id: card.id, code: card.code, side_identifier: "A", is_primary_side: true},
+            attrs
+          )
+      )
+    end
+
+    defp insert_hero(attrs) do
+      hero_card = create(Sanctum.Games.Card, attrs: %{})
+
+      create(Sanctum.Games.CardSide,
+        attrs: %{
+          card_id: hero_card.id,
+          name: attrs[:hero_name],
+          type: :hero,
+          code: hero_card.code,
+          side_identifier: "A",
+          is_primary_side: true
+        }
+      )
+
+      alter_ego_card = create(Sanctum.Games.Card, attrs: %{base_code: hero_card.base_code})
+
+      create(Sanctum.Games.CardSide,
+        attrs: %{
+          card_id: alter_ego_card.id,
+          name: attrs[:alter_ego_name],
+          type: :alter_ego,
+          code: alter_ego_card.code,
+          side_identifier: "B",
+          is_primary_side: true
+        }
+      )
+
+      {:ok, hero} =
+        Sanctum.Heroes.find_or_create_hero(
+          Map.merge(%{base_code: hero_card.base_code, card_id: hero_card.id}, attrs)
+        )
+
+      hero
+    end
+
+    defp insert_deck(attrs) do
+      Sanctum.Decks.Deck
+      |> Ash.Changeset.for_create(:create, attrs)
+      |> Ash.create!(authorize?: false)
+    end
+
+    defp insert_villain(attrs) do
+      Sanctum.Villains.Villain
+      |> Ash.Changeset.for_create(:create, attrs)
+      |> Ash.create!(authorize?: false)
+    end
+
+    defp insert_card_set(attrs) do
+      Sanctum.Catalog.CardSet
+      |> Ash.Changeset.for_create(:upsert, attrs)
+      |> Ash.create!(authorize?: false)
+    end
+
+    defp group_types(%{groups: groups}), do: Enum.map(groups, & &1.type)
+
+    defp group(result, type), do: Enum.find(result.groups, &(&1.type == type))
+
+    setup do
+      insert_side(%{name: "#{@marker} Blade", type: :ally, cost: 2, aspect: :aggression})
+
+      hero = insert_hero(%{hero_name: "#{@marker} Man", alter_ego_name: "Zed", set: "zz_hero"})
+      insert_deck(%{title: "#{@marker} Deck", hero_id: hero.id, aspects: [:aggression]})
+
+      pack =
+        create(Sanctum.Catalog.Pack,
+          action: :upsert_from_marvelcdb,
+          attrs: %{code: "zzp", name: "#{@marker} Rising"}
+        )
+
+      insert_card_set(%{
+        code: "zz_villain",
+        name: "#{@marker} Set",
+        set_type: :villain,
+        pack_id: pack.id
+      })
+
+      insert_villain(%{villain_name: "#{@marker} Prime", set: "zz_villain"})
+      create(Sanctum.Games.Scenario, attrs: %{name: "#{@marker} Scenario", set: "zz_villain"})
+
+      %{pack: pack}
+    end
+
+    test "a bare word fans out across every type in fixed order" do
+      result = Global.search(@marker, nil)
+
+      assert group_types(result) == [
+               :cards,
+               :decks,
+               :heroes,
+               :packs,
+               :card_sets,
+               :villains,
+               :scenarios
+             ]
+
+      assert result.diagnostics == []
+    end
+
+    test "result shapes link to the right destinations", %{pack: pack} do
+      result = Global.search(@marker, nil)
+
+      # the hero's identity side also matches the marker, so pick out the ally
+      card = Enum.find(group(result, :cards).results, &(&1.title == "#{@marker} Blade"))
+      assert card.href == "/cards/#{card.id}"
+      assert card.subtitle == "Ally · #{@marker} Pack"
+
+      [deck] = group(result, :decks).results
+      assert deck.title == "#{@marker} Deck"
+      assert deck.subtitle == "#{@marker} Man"
+      assert deck.href == "/decks/#{deck.id}"
+
+      [hero] = group(result, :heroes).results
+      assert hero.href == "/decks?hero_id=#{hero.id}"
+
+      found_pack = Enum.find(group(result, :packs).results, &(&1.title == "#{@marker} Rising"))
+      assert found_pack.href == "/browse/#{pack.code}"
+
+      # villain + scenario resolve their set slug to the pack's browse page
+      [villain] = group(result, :villains).results
+      assert villain.href == "/browse/#{pack.code}"
+
+      [scenario] = group(result, :scenarios).results
+      assert scenario.href == "/browse/#{pack.code}"
+    end
+
+    test "typed clauses implicitly narrow to the types that understand them" do
+      assert group_types(Global.search("#{@marker} cost<=2", nil)) == [:cards]
+
+      assert group_types(Global.search("#{@marker} aspect:aggression", nil)) == [
+               :cards,
+               :decks
+             ]
+    end
+
+    test "in: scopes explicitly and raises the per-type limit" do
+      result = Global.search("in:villains #{@marker}", nil)
+
+      assert group_types(result) == [:villains]
+    end
+
+    test "unmatched villain set degrades to a link-less result" do
+      insert_villain(%{villain_name: "#{@marker} Ghost", set: "no_such_set"})
+
+      villains = group(Global.search("in:villains #{@marker}", nil), :villains)
+      ghost = Enum.find(villains.results, &(&1.title == "#{@marker} Ghost"))
+
+      assert ghost.href == nil
+    end
+
+    test "more?/more_url carry the in:-stripped remainder for cards and decks" do
+      for n <- 1..6 do
+        insert_side(%{name: "#{@marker} Extra #{n}", type: :ally, cost: 1})
+      end
+
+      result = Global.search("in:cards #{@marker} cost<=2", nil, limit: 5)
+      cards = group(result, :cards)
+
+      assert cards.more?
+      assert length(cards.results) == 5
+      assert cards.more_url == "/cards?query=#{URI.encode_www_form("#{@marker} cost<=2")}"
+    end
+
+    test "groups with no matches are omitted" do
+      result = Global.search("#{@marker} Blade", nil)
+
+      assert group_types(result) == [:cards]
+    end
+
+    test "empty and unusable input return no groups" do
+      assert Global.search("", nil).groups == []
+      assert Global.search("   ", nil).groups == []
+
+      # nothing usable and no scope: don't list the catalog
+      result = Global.search("cost<", nil)
+      assert result.groups == []
+      assert Enum.any?(result.diagnostics, &(&1.code == :incomplete_clause))
+    end
+  end
+end

--- a/test/sanctum_web/live/browse_live/browse_test.exs
+++ b/test/sanctum_web/live/browse_live/browse_test.exs
@@ -86,7 +86,10 @@ defmodule SanctumWeb.BrowseLiveTest do
       html = render_async(view)
 
       refute html =~ "Add to Collection"
-      refute html =~ "owned"
+      # no ownership toggles anywhere ("owned" alone would match the global
+      # search bar's field list)
+      refute html =~ "toggle_pack_owned"
+      refute html =~ "toggle_card_owned"
     end
 
     test "adding the pack marks every card owned and shows progress", %{

--- a/test/sanctum_web/live/card_live/form_test.exs
+++ b/test/sanctum_web/live/card_live/form_test.exs
@@ -31,7 +31,7 @@ defmodule SanctumWeb.CardLive.FormTest do
       # Test card form validation
       html =
         view
-        |> element("form")
+        |> element("#card-form")
         |> render_change(%{"card" => %{"base_code" => ""}})
 
       assert html =~ "is required"

--- a/test/sanctum_web/live/guess_live/play_test.exs
+++ b/test/sanctum_web/live/guess_live/play_test.exs
@@ -50,7 +50,8 @@ defmodule SanctumWeb.GuessLive.PlayTest do
     {:ok, view, _html} = live(conn, ~p"/flavor-town")
     render_async(view)
 
-    html = view |> form("form", %{guess: "Definitely Wrong"}) |> render_submit()
+    html =
+      view |> form(~s(form[phx-submit="guess"]), %{guess: "Definitely Wrong"}) |> render_submit()
 
     assert html =~ "Hints"
     assert html =~ "This is a player card."
@@ -63,7 +64,7 @@ defmodule SanctumWeb.GuessLive.PlayTest do
     {:ok, view, _html} = live(conn, ~p"/flavor-town")
     render_async(view)
 
-    html = view |> form("form", %{guess: "nick fury"}) |> render_submit()
+    html = view |> form(~s(form[phx-submit="guess"]), %{guess: "nick fury"}) |> render_submit()
 
     assert html =~ "You got it!"
     assert html =~ "Nick Fury"


### PR DESCRIPTION
## What

A global search that covers every content type on the site, opened from a Search button in the sidebar / mobile header or with **⌘K / Ctrl+K** — a centered command-palette dialog on desktop, a slide-up sheet on mobile.

It speaks the full existing query language (`Sanctum.Search`) with cross-type semantics:

- **Bare words** match names across all seven types: cards, decks, heroes, packs, card sets, villains, scenarios.
- **Typed clauses implicitly narrow** to the types whose registry understands them: `cost<=2` → cards only; `aspect:aggression` → cards + decks.
- A reserved **`in:` qualifier** scopes explicitly (`in:decks spider`, `in:cards|decks`) and raises the per-type row limit.
- Group headers deep-link to the full browsers (`/cards?query=…`, `/decks?query=…`) with the `in:` clause stripped; set/villain/scenario results land on `/browse/:pack#<set_code>` and scroll that set's section into view once the async pack load renders.

## How

- `Sanctum.Search.Global` — scope extraction (top-level `in:` AST pre-pass), strict per-type applicability (a type is excluded when any clause references a field/op/value its registry doesn't know), span-based remainder serialization for deep links, and a sequential per-type fan-out over lightweight `:read` queries.
- Five minimal per-type registries generated by `Sanctum.Search.NameRegistry` (`__using__`), plus `GlobalFields`, a suggest-only union registry that feeds the existing `Suggest` autocomplete (including `in:` value completion) with zero changes to `Suggest` itself.
- `SanctumWeb.GlobalSearchComponent` (LiveComponent, `phx-target` isolation from host LiveViews) runs the fan-out in `start_async` with a stale-reply guard; the `GlobalSearch` hook drives one virtual keyboard list across autocomplete suggestions and server-rendered result links. Overlay open/close is fully client-side (`sanctum:open-search` window event, Escape, backdrop, scroll lock).
- The shared client tokenizer moved to `query-syntax.js`; `/cards` and `/decks` query inputs are unchanged consumers.

## Notable fixes

- **Vanishing results while typing**: the hook was assigning ids to LiveView-managed elements, corrupting DOM patching. Result anchors now get server-rendered ids and the hook is read-only over patched DOM.
- **Mobile double scroll**: `overflow: hidden` on body doesn't stop iOS touch scrolling — the lock is now the `position: fixed` technique, with the offset restored on close and released (not restored) when navigating from a result so the landing page stays scrollable.
- **Mobile sheet polish**: fixed 85dvh height (no grow/shrink with results), one overscroll-contained scroll region for suggestions + results, safe-area bottom padding so the last row clears the home indicator, and the slide-up animation plays once per open instead of replaying on every result patch.
- **Debounce**: results wait 350ms on the global palette (seven queries per pause) via a new `query_input` `debounce` attr; `/cards` and `/decks` keep 200ms, autocomplete stays at 120ms.

## Testing

- 30 new tests in `test/sanctum/search/global_test.exs` (scope extraction, applicability, remainder round-trips, suggest union, DB-backed fan-out incl. villain/scenario pack resolution); full suite green.
- Verified end-to-end in the browser at desktop + mobile viewports: grouped results, implicit narrowing, `in:` completion, keyboard nav, ⌘K, set-section anchor scrolling, and `/cards`–`/decks` search regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
