### PR TITLE
feat(decks): extend hover card previews to decklists

### DIFF
--- a/assets/js/hooks/card-link-preview.js
+++ b/assets/js/hooks/card-link-preview.js
@@ -1,8 +1,10 @@
 // Hover previews for `/cards/:id` links inside the hook element (deck
-// writeups). On hover-intent it asks the LiveView for the card
+// writeups and decklists). On hover-intent it asks the LiveView for the card
 // ("preview_card"), which renders a card tile into #card-link-preview; this
-// hook only positions and toggles that popover. Hover-only devices get the
-// feature; touch devices fall through to the normal link navigation.
+// hook only positions and toggles that popover. Several hook instances can
+// share the one popover — the card id it currently shows is tracked on the
+// popover element itself. Hover-only devices get the feature; touch devices
+// fall through to the normal link navigation.
 const SHOW_DELAY_MS = 150;
 const MARGIN = 8;
 
@@ -11,8 +13,6 @@ const CardLinkPreview = {
     if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
 
     this.timer = null;
-    // Card id currently rendered in the popover — re-hovers skip the server.
-    this.currentId = null;
     this.anchor = null;
 
     this.onOver = (e) => {
@@ -52,12 +52,14 @@ const CardLinkPreview = {
   },
 
   request(id, link) {
-    if (id === this.currentId) return this.show(link);
+    // Re-hovering the card the popover already holds skips the server.
+    if (this.popover()?.dataset.cardId === id) return this.show(link);
 
     this.pushEvent("preview_card", {id}, (reply) => {
       // Stale replies (mouse moved on, or an unresolvable id) are dropped.
       if (reply.error || this.anchor !== link) return;
-      this.currentId = id;
+      const pop = this.popover();
+      if (pop) pop.dataset.cardId = id;
       // The tile patch lands with the reply; wait a frame so we measure it.
       requestAnimationFrame(() => this.anchor === link && this.show(link));
     });

--- a/lib/sanctum_web/components/card_preview.ex
+++ b/lib/sanctum_web/components/card_preview.ex
@@ -1,0 +1,58 @@
+defmodule SanctumWeb.Components.CardPreview do
+  @moduledoc """
+  Hover "card peek" shared by pages with `/cards/:id` links (deck writeups and
+  decklists). The CardLinkPreview JS hook watches links under its element and
+  pushes `"preview_card"` on hover-intent; a LiveView delegates that event to
+  `handle_preview_event/2` and renders `card_preview_popover/1` once at the
+  page root. The hook positions and toggles the popover — LiveView only swaps
+  the card tile inside it.
+  """
+  use Phoenix.Component
+
+  import SanctumWeb.Components.CardSideTile
+
+  @doc "Seeds the assigns `card_preview_popover/1` reads; pipe in mount/seed."
+  def assign_card_preview(socket) do
+    socket
+    |> Phoenix.Component.assign(:card_preview, nil)
+    # set -> gradient palette for preview tiles, fetched once on first hover
+    |> Phoenix.Component.assign(:card_preview_colors, nil)
+  end
+
+  @doc """
+  Handles the hook's `"preview_card"` event: loads the card's primary face and
+  renders the same tile the card pool shows into the popover. The reply tells
+  the hook the tile is ready to position; unresolvable ids reply with an error
+  so the hook keeps the popover hidden.
+  """
+  def handle_preview_event(id, socket) do
+    actor = socket.assigns[:current_user]
+    side_loads = if actor, do: [:owned], else: []
+
+    case Ash.get(Sanctum.Games.Card, id, actor: actor, load: [primary_side: side_loads]) do
+      {:ok, %{primary_side: %Sanctum.Games.CardSide{} = side} = card} ->
+        colors = socket.assigns.card_preview_colors || Sanctum.Heroes.hero_color_map()
+
+        {:reply, %{},
+         socket
+         |> Phoenix.Component.assign(:card_preview_colors, colors)
+         |> Phoenix.Component.assign(:card_preview, side_view(%{side | card: card}, colors))}
+
+      _ ->
+        {:reply, %{error: true}, socket}
+    end
+  end
+
+  attr :side, :map, default: nil, doc: "display map built by side_view/2; nil until first hover"
+
+  def card_preview_popover(assigns) do
+    ~H"""
+    <div
+      id="card-link-preview"
+      class="pointer-events-none fixed left-0 top-0 z-50 hidden w-[480px] max-w-[calc(100vw-16px)]"
+    >
+      <.card_side_tile :if={@side} side={@side} />
+    </div>
+    """
+  end
+end

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -15,6 +15,7 @@ defmodule SanctumWeb.DeckLive.Build do
 
   require Ash.Query
 
+  import SanctumWeb.Components.CardPreview
   import SanctumWeb.Components.DeckCards
   import SanctumWeb.Components.QueryInput
 
@@ -82,6 +83,7 @@ defmodule SanctumWeb.DeckLive.Build do
     |> assign(:signature_ids, signature_ids)
     |> assign(:staples, load_staples())
     |> recompute_issues()
+    |> assign_card_preview()
     |> assign(:panel_open?, false)
     |> assign(:confirm_delete?, false)
     |> assign(:tab, "cards")
@@ -228,6 +230,11 @@ defmodule SanctumWeb.DeckLive.Build do
     else
       {:noreply, start_load(socket, socket.assigns.offset + @page_size)}
     end
+  end
+
+  # Pushed by the CardLinkPreview hook when a decklist tile/row is hovered.
+  def handle_event("preview_card", %{"id" => id}, socket) do
+    handle_preview_event(id, socket)
   end
 
   def handle_event("inc", %{"card-id" => card_id}, socket) do
@@ -1181,6 +1188,8 @@ defmodule SanctumWeb.DeckLive.Build do
           </span>
         </button>
       </div>
+
+      <.card_preview_popover side={@card_preview} />
     </Layouts.app>
     """
   end
@@ -1199,7 +1208,7 @@ defmodule SanctumWeb.DeckLive.Build do
     assigns = assign(assigns, :size, deck_size(assigns.entries))
 
     ~H"""
-    <div class="flex flex-col gap-4 p-4">
+    <div id={"deck-panel-#{@id}-body"} phx-hook="CardLinkPreview" class="flex flex-col gap-4 p-4">
       <!-- title + count -->
       <div>
         <form id={"rename-#{@id}"} phx-submit="rename" class="flex items-center gap-2">

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -5,7 +5,7 @@ defmodule SanctumWeb.DeckLive.Show do
   """
   use SanctumWeb, :live_view
 
-  import SanctumWeb.Components.CardSideTile
+  import SanctumWeb.Components.CardPreview
   import SanctumWeb.Components.DeckCards
 
   alias SanctumWeb.Components.DeckCards
@@ -119,13 +119,18 @@ defmodule SanctumWeb.DeckLive.Show do
             </div>
           </.panel>
 
-          <!-- body: writeup + card list -->
-          <div class="grid items-start gap-5 lg:grid-cols-[1.4fr_1fr]">
+          <!-- body: writeup + card list; the hook previews any /cards link
+               inside — writeup card mentions and decklist tiles/rows alike -->
+          <div
+            id="deck-body"
+            phx-hook="CardLinkPreview"
+            class="grid items-start gap-5 lg:grid-cols-[1.4fr_1fr]"
+          >
             <.panel class="min-w-0 p-5">
               <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
                 Deck Notes
               </div>
-              <div :if={@writeup} id="deck-writeup" phx-hook="CardLinkPreview" class="space-y-4">
+              <div :if={@writeup} class="space-y-4">
                 <div :for={seg <- @writeup}>
                   <div :if={seg.kind == :inline} class="deck-writeup">{seg.html}</div>
                   <iframe
@@ -307,14 +312,7 @@ defmodule SanctumWeb.DeckLive.Show do
         </div>
       </div>
 
-      <!-- hover preview for writeup card links; the CardLinkPreview hook
-           positions and toggles it, LiveView only swaps the tile inside -->
-      <div
-        id="card-link-preview"
-        class="pointer-events-none fixed left-0 top-0 z-50 hidden w-[480px] max-w-[calc(100vw-16px)]"
-      >
-        <.card_side_tile :if={@card_preview} side={@card_preview} />
-      </div>
+      <.card_preview_popover side={@card_preview} />
     </Layouts.app>
     """
   end
@@ -347,9 +345,7 @@ defmodule SanctumWeb.DeckLive.Show do
       |> assign(:card_view, "images")
       |> assign(:scroll_restore_pending?, false)
       |> assign(:owned_summary, nil)
-      |> assign(:card_preview, nil)
-      # set -> gradient palette for preview tiles, fetched once on first hover
-      |> assign(:hero_colors, nil)
+      |> assign_card_preview()
 
     actor = socket.assigns[:current_user]
 
@@ -369,27 +365,10 @@ defmodule SanctumWeb.DeckLive.Show do
     {:noreply, DeckCards.handle_card_view_event(event, params, socket)}
   end
 
-  # Pushed by the CardLinkPreview hook when a writeup card link is hovered.
-  # Loads the linked card's primary face and renders the same tile the card
-  # pool shows into the #card-link-preview popover; the reply tells the hook
-  # the tile is ready to position. Unresolvable ids reply with an error so the
-  # hook keeps the popover hidden.
+  # Pushed by the CardLinkPreview hook when a /cards link (writeup mention or
+  # decklist tile/row) is hovered.
   def handle_event("preview_card", %{"id" => id}, socket) do
-    actor = socket.assigns[:current_user]
-    side_loads = if actor, do: [:owned], else: []
-
-    case Ash.get(Sanctum.Games.Card, id, actor: actor, load: [primary_side: side_loads]) do
-      {:ok, %{primary_side: %Sanctum.Games.CardSide{} = side} = card} ->
-        hero_colors = socket.assigns.hero_colors || Sanctum.Heroes.hero_color_map()
-
-        {:reply, %{},
-         socket
-         |> assign(:hero_colors, hero_colors)
-         |> assign(:card_preview, side_view(%{side | card: card}, hero_colors))}
-
-      _ ->
-        {:reply, %{error: true}, socket}
-    end
+    handle_preview_event(id, socket)
   end
 
   # Pushed by the ScrollRestore hook when the user arrives with a saved scroll


### PR DESCRIPTION
## Summary

Hovering any card in a decklist now shows the same card tile the card pool uses — on top of the existing writeup-link previews:

- **Deck details**: the CardLinkPreview hook moved from the writeup div to the whole page body, so it covers writeup card mentions plus the "In This Deck" panel (image-view tiles and list-view rows).
- **Builder**: both deck-panel instances (desktop column, mobile pane) get the hook; the popover + `preview_card` handler are wired into the LiveView. Hover-only devices get the feature; touch falls through to link navigation.
- New shared `SanctumWeb.Components.CardPreview` module owns the assigns, event handler, and popover component for both LiveViews.
- The popover tracks the card it currently shows on its own element so several hook instances share it without stale content.
- Fixed a DOM id collision: the builder panel wrapper already used `deck-panel-desktop`, so the hook element is `deck-panel-{id}-body`.

## Testing

Verified in the browser against the dev server: deck-show decklist tiles and list rows, builder list rows and image tiles (signed in as a throwaway deck owner, cleaned up after), plus the original writeup links still working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)