### PR TITLE
fix(cards): render printed X values instead of -1 and make search X-aware

### DIFF
--- a/lib/sanctum/search/builders.ex
+++ b/lib/sanctum/search/builders.ex
@@ -20,12 +20,24 @@ defmodule Sanctum.Search.Builders do
   def cmp(target, :gte, value), do: expr(^target >= ^value)
 
   @doc """
+  Comparison against a printed number where `-1` encodes a printed X
+  (MarvelCDB's sentinel). An X value is unknowable, so it satisfies no
+  upper bound — `cost<=2` must not match an X-cost card. Lower bounds and
+  (in)equality need no guard: `-1` already sits below every real value.
+  """
+  def x_cmp(target, op, value) when op in [:lt, :lte] do
+    expr(^cmp(target, op, value) and ^target != -1)
+  end
+
+  def x_cmp(target, op, value), do: cmp(target, op, value)
+
+  @doc """
   Comparison against the printed number of a `Sanctum.Games.Stat` jsonb
-  attribute. Sides where the stat (or its value — a `⭐`/`X` printing) is
-  absent compare as SQL NULL and drop out of the results.
+  attribute (X-aware — see `x_cmp/3`). Sides where the stat is absent
+  compare as SQL NULL and drop out of the results.
   """
   def stat_cmp(attr, op, value) do
-    cmp(expr(fragment("(? ->> 'value')::integer", ^ref(attr))), op, value)
+    x_cmp(expr(fragment("(? ->> 'value')::integer", ^ref(attr))), op, value)
   end
 
   @doc "Case-insensitive substring match, with ILIKE wildcards escaped."
@@ -63,6 +75,15 @@ defmodule Sanctum.Search.Builders do
     case Integer.parse(String.trim(raw)) do
       {n, ""} -> {:ok, n}
       _ -> {:error, ~s("#{raw}" is not a number)}
+    end
+  end
+
+  @doc ~s(Parse an integer, or "x" — a printed X value — as `:x`.)
+  def parse_int_or_x(raw) do
+    if raw |> String.trim() |> String.downcase() == "x" do
+      {:ok, :x}
+    else
+      parse_int(raw)
     end
   end
 

--- a/lib/sanctum/search/card_fields.ex
+++ b/lib/sanctum/search/card_fields.ex
@@ -38,7 +38,6 @@ defmodule Sanctum.Search.CardFields do
   ]
 
   @int_fields [
-    {"cost", ["c"], :cost, "cost<=2"},
     {"stage", [], :stage, "stage=3"},
     {"boost", ["b"], :boost, "boost>=2"},
     {"hand_size", ["hand"], :hand_size, "hand_size>=6"},
@@ -70,10 +69,8 @@ defmodule Sanctum.Search.CardFields do
   # what an empty search box offers.
   @impl true
   def fields do
-    {cost_fields, other_int_fields} = Enum.split_with(int_fields(), &(&1.name == "cost"))
-
     primary_fields() ++
-      cost_fields ++ stat_fields() ++ other_int_fields ++ misc_fields()
+      [cost_field()] ++ stat_fields() ++ int_fields() ++ misc_fields()
   end
 
   # -- field groups --------------------------------------------------------
@@ -215,6 +212,24 @@ defmodule Sanctum.Search.CardFields do
     ]
   end
 
+  # Cost is int-shaped but X-aware: a few player cards print an X cost
+  # (stored as MarvelCDB's -1 sentinel), searchable as `cost:x`.
+  defp cost_field do
+    %Field{
+      name: "cost",
+      aliases: ["c"],
+      kind: :integer,
+      example: "cost<=2",
+      hint: ~s(printed cost; "x" matches X-cost cards),
+      ops: @all_ops,
+      build: fn op, value ->
+        with {:ok, n} <- parse_printed_number(op, value) do
+          {:ok, Builders.x_cmp(expr(cost), op, n)}
+        end
+      end
+    }
+  end
+
   defp stat_fields do
     for {name, aliases, attr, example} <- @stat_fields do
       %Field{
@@ -224,11 +239,21 @@ defmodule Sanctum.Search.CardFields do
         example: example,
         ops: @all_ops,
         build: fn op, value ->
-          with {:ok, n} <- Builders.parse_int(value) do
+          with {:ok, n} <- parse_printed_number(op, value) do
             {:ok, Builders.stat_cmp(attr, op, n)}
           end
         end
       }
+    end
+  end
+
+  # A printed X (stored as -1) only makes sense as an exact (in)equality —
+  # an X value satisfies no numeric bound.
+  defp parse_printed_number(op, raw) do
+    case Builders.parse_int_or_x(raw) do
+      {:ok, :x} when op in [:eq, :neq] -> {:ok, -1}
+      {:ok, :x} -> {:error, ~s(X values only support ":" or "!=")}
+      other -> other
     end
   end
 

--- a/lib/sanctum_web/components/card.ex
+++ b/lib/sanctum_web/components/card.ex
@@ -68,6 +68,13 @@ defmodule SanctumWeb.Components.Card do
   @doc "Whether a card type is printed in landscape orientation."
   def landscape_type?(type), do: type in @landscape_types
 
+  @doc """
+  Display form of a printed card value: MarvelCDB encodes a printed X
+  (X cost, X attack, X threat, …) as `-1` — map it back to `"X"`.
+  """
+  def display_value(-1), do: "X"
+  def display_value(value), do: value
+
   # Fallback gradient when a hero has no stored palette (non-hero sets,
   # un-synced heroes). Hero colors themselves come from MarvelCDB and are
   # passed in via gradient_from/gradient_to.
@@ -131,6 +138,7 @@ defmodule SanctumWeb.Components.Card do
 
     assigns =
       assign(assigns,
+        cost: display_value(assigns.cost),
         aspect_classes: aspect_classes,
         hero?: hero?,
         dims: dims,

--- a/lib/sanctum_web/components/card_side_tile.ex
+++ b/lib/sanctum_web/components/card_side_tile.ex
@@ -277,7 +277,7 @@ defmodule SanctumWeb.Components.CardSideTile do
       name: side.name,
       type: side.type,
       is_landscape: landscape_type?(side.type),
-      cost: side.cost,
+      cost: display_value(side.cost),
       show_cost: side.type != :resource and not is_nil(side.cost),
       aspect_key: aspect_key,
       aspect_name: aspect_name(aspect_key, card.set),
@@ -304,7 +304,7 @@ defmodule SanctumWeb.Components.CardSideTile do
       defense: stat_value(side.defense),
       health: stat_value(side.health),
       health_per_player: stat_per_player(side.health),
-      scheme: side.scheme,
+      scheme: display_value(side.scheme),
       is_main_scheme: side.type == :main_scheme,
       threat_target: threat_target(side),
       threat_per_player: threat_target_per_player?(side),
@@ -345,7 +345,7 @@ defmodule SanctumWeb.Components.CardSideTile do
   end
 
   defp stat_value(nil), do: nil
-  defp stat_value(%{value: value}), do: value
+  defp stat_value(%{value: value}), do: display_value(value)
 
   defp stat_consequential(%{consequential: n}) when is_integer(n), do: n
   defp stat_consequential(_), do: 0
@@ -359,8 +359,8 @@ defmodule SanctumWeb.Components.CardSideTile do
 
   # A scheme's threat target: main schemes carry it in `max_threat`; side schemes
   # (and player side schemes) carry it in `base_threat`.
-  defp threat_target(%{max_threat: %{value: v}}), do: v
-  defp threat_target(%{base_threat: %{value: v}}), do: v
+  defp threat_target(%{max_threat: %{value: v}}), do: display_value(v)
+  defp threat_target(%{base_threat: %{value: v}}), do: display_value(v)
   defp threat_target(_), do: nil
 
   defp threat_target_per_player?(%{max_threat: stat}) when not is_nil(stat),

--- a/lib/sanctum_web/components/deck_cards.ex
+++ b/lib/sanctum_web/components/deck_cards.ex
@@ -38,7 +38,7 @@ defmodule SanctumWeb.Components.DeckCards do
       card_id: card.id,
       qty: qty,
       name: side.name,
-      cost: side.cost,
+      cost: CardComponent.display_value(side.cost),
       type: side.type,
       hero?: side.ownership == :hero,
       aspect_key: aspect_key,

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -449,7 +449,7 @@ defmodule SanctumWeb.CardLive.Show do
       object_key: CardImages.key_from_url(side.image_url),
       name: side.name,
       subname: side.subname,
-      cost: side.cost,
+      cost: CardComponent.display_value(side.cost),
       side_identifier: side.side_identifier,
       is_primary_side: side.is_primary_side,
       type: side.type,
@@ -497,11 +497,11 @@ defmodule SanctumWeb.CardLive.Show do
 
   defp typed_meta(side) do
     [
-      {"Cost", side.cost},
+      {"Cost", CardComponent.display_value(side.cost)},
       {"Hand Size", side.hand_size},
       {"Recover", stat_meta(side.recover)},
       {"Stage", side.stage},
-      {"Scheme", side.scheme},
+      {"Scheme", CardComponent.display_value(side.scheme)},
       {"Health Scaling", scaling_label(side.health)},
       {"Base Threat", stat_meta(side.base_threat)},
       {"Escalation", stat_meta(side.escalation_threat)},
@@ -519,12 +519,13 @@ defmodule SanctumWeb.CardLive.Show do
   defp stat_value(_), do: nil
 
   defp stat_box_value(%{value: value, star: star}) when not is_nil(value),
-    do: "#{value}#{if star, do: "★", else: ""}"
+    do: "#{CardComponent.display_value(value)}#{if star, do: "★", else: ""}"
 
   defp stat_box_value(_), do: nil
 
   defp stat_meta(%{value: value, star: star, scaling: scaling}) when not is_nil(value),
-    do: "#{value}#{if star, do: "★", else: ""}#{scaling_suffix(scaling)}"
+    do:
+      "#{CardComponent.display_value(value)}#{if star, do: "★", else: ""}#{scaling_suffix(scaling)}"
 
   defp stat_meta(_), do: nil
 

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -530,7 +530,7 @@ defmodule SanctumWeb.DeckLive.Build do
       card_id: card.id,
       card: card,
       name: side.name,
-      cost: side.cost,
+      cost: display_value(side.cost),
       type: side.type,
       aspect_key: display_aspect(side),
       resources: resources,

--- a/test/sanctum/search/browse_integration_test.exs
+++ b/test/sanctum/search/browse_integration_test.exs
@@ -96,6 +96,39 @@ defmodule Sanctum.Search.BrowseIntegrationTest do
       assert browse_names("attack<=1") == ["Cheap Ally"]
     end
 
+    test "an X printing (stored as -1) never satisfies an upper bound" do
+      insert_side(%{
+        name: "X Event",
+        type: :event,
+        aspect: :aggression,
+        ownership: :player,
+        cost: -1,
+        attack: nil,
+        traits: [],
+        text: "Do X things."
+      })
+
+      refute "X Event" in browse_names("cost<=2")
+      refute "X Event" in browse_names("cost<0")
+      assert browse_names("cost:x") == ["X Event"]
+    end
+
+    test "an X stat printing matches stat:x but no bounds" do
+      insert_side(%{
+        name: "X Ally",
+        type: :ally,
+        aspect: :aggression,
+        ownership: :player,
+        cost: 3,
+        attack: %{value: -1},
+        traits: [],
+        text: ""
+      })
+
+      refute "X Ally" in browse_names("attack<=1")
+      assert browse_names("attack:x") == ["X Ally"]
+    end
+
     test "trait match is case-insensitive" do
       assert browse_names("trait:avenger") == ["Cheap Ally"]
       assert browse_names("k:AVENGER") == ["Cheap Ally"]

--- a/test/sanctum/search/compiler_test.exs
+++ b/test/sanctum/search/compiler_test.exs
@@ -73,6 +73,20 @@ defmodule Sanctum.Search.CompilerTest do
       assert codes(result) == [:invalid_value]
     end
 
+    test "x matches a printed X on cost and stat fields" do
+      assert %{expr: expr, diagnostics: []} = compile("cost:x")
+      assert inspect(expr) =~ "-1"
+
+      assert %{expr: expr, diagnostics: []} = compile("attack!=X")
+      assert inspect(expr) =~ "-1"
+    end
+
+    test "x rejects numeric bounds" do
+      result = compile("cost<x")
+      assert result.expr == false
+      assert codes(result) == [:invalid_value]
+    end
+
     test "unsupported operator on a field" do
       result = compile("aspect>2")
       assert result.expr == nil


### PR DESCRIPTION
## Problem

MarvelCDB encodes a printed **X** value as the integer `-1`, and Sanctum passed it through untouched — so X-cost cards like Lethal Intent showed **-1** in the deck list, hover preview, pool grid, and card pages.

The scope was wider than cost (verified against the DB):

- 3 X-cost events (Lethal Intent, Speed Cyclone, Everywhere All at Once)
- 13 card sides with X stats (X ATK/THW allies like Gambit and Spider-Man Noir, X escalation threat on main schemes)
- 4 attachments with "Scheme X", 1 X max-threat

Search was also wrong: X-cost cards matched every `cost<=N` query (X was treated as *cheaper than 0*), and there was no way to search for X printings.

## Fix

`-1` stays in the DB as the sentinel (it matches upstream MarvelCDB, so sync remains a verbatim passthrough); it's mapped at the edges:

**Display** — a shared `CardComponent.display_value/1` (`-1 → "X"`) applied at every render path: the `mc_card` cost bubble (normalized internally, covering all callers), `side_view`'s cost/scheme/stat values/threat target, the deck list and builder display maps, and the admin card page's meta rows and stat boxes.

**Search** — `Builders.x_cmp/3` excludes `-1` from `<`/`<=` comparisons (an unknowable X satisfies no upper bound; lower bounds already excluded it naturally), `stat_cmp` routes through it, and cost/stat fields accept `x` as an exact match (`cost:x`, `attack:x`) with a clear error on bounds like `cost<x`. Global search reuses these fields, so it's covered too.

## Testing

- New compiler tests (`cost:x` / `attack!=X` compile to `-1` matches; `cost<x` errors) and Postgres integration tests (X printings excluded from upper bounds, matched by `:x`)
- Full suite passes (494 tests); `mix ck` clean
- Verified in the running app: deck list row and hover preview show **X** for Lethal Intent, Gambit renders ATK X / THW X badges, `cost:x` returns exactly the 3 X-cost events, `lethal cost<=2` no longer matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)