### PR TITLE
fix(search): keep mobile search sheet on-screen when keyboard opens

### DIFF
--- a/assets/js/hooks/global-search.js
+++ b/assets/js/hooks/global-search.js
@@ -67,6 +67,8 @@ export default {
       }
     }
     window.addEventListener("keydown", this.onGlobalKey)
+
+    this.onViewport = () => this.syncViewport()
   },
 
   // LiveView patched the component (new result groups, cleared input, …):
@@ -77,12 +79,15 @@ export default {
     this.scanResults()
     this.syncOverlay()
     this.syncPanel()
+    this.syncViewport()
   },
 
   destroyed() {
     clearTimeout(this.suggestTimer)
     window.removeEventListener("sanctum:open-search", this.onOpenEvent)
     window.removeEventListener("keydown", this.onGlobalKey)
+    window.visualViewport?.removeEventListener("resize", this.onViewport)
+    window.visualViewport?.removeEventListener("scroll", this.onViewport)
     // Navigating from a result destroys the hook with the overlay still
     // open — release the body lock (without scroll restore: the next page
     // owns its own position) or the new page can't scroll at all.
@@ -102,7 +107,9 @@ export default {
     this.syncOverlay()
     this.syncPanel()
     this.animateSheetIn()
-    this.input.focus()
+    window.visualViewport?.addEventListener("resize", this.onViewport)
+    window.visualViewport?.addEventListener("scroll", this.onViewport)
+    this.input.focus({preventScroll: true})
     this.input.select()
     this.queueSuggest()
   },
@@ -130,6 +137,9 @@ export default {
     this.listbox.textContent = ""
     this.syncOverlay()
     this.syncPanel()
+    window.visualViewport?.removeEventListener("resize", this.onViewport)
+    window.visualViewport?.removeEventListener("scroll", this.onViewport)
+    this.syncViewport()
     this.input.blur()
   },
 
@@ -167,6 +177,31 @@ export default {
     style.right = ""
     style.width = ""
     if (restore) window.scrollTo(0, this.savedScrollY ?? 0)
+  },
+
+  // The mobile keyboard doesn't resize the layout viewport — it shrinks and
+  // scrolls the *visual* viewport while position:fixed elements stay glued
+  // to the layout viewport, so the sheet (input included) slides off the top
+  // of the screen. While the overlay is open, pin it to the visual viewport
+  // instead: offset it by the visual scroll and cap its height. --gs-vh lets
+  // the sheet/results CSS shrink to the space left above the keyboard.
+  syncViewport() {
+    if (!this.overlay) return
+    const vv = window.visualViewport
+    const layoutHeight = document.documentElement.clientHeight
+    const shifted = vv && (vv.offsetTop > 0 || vv.height < layoutHeight - 1)
+    const style = this.overlay.style
+    if (this.overlayOpen && shifted) {
+      style.transform = `translateY(${vv.offsetTop}px)`
+      style.height = `${vv.height}px`
+      style.bottom = "auto"
+      style.setProperty("--gs-vh", `${vv.height}px`)
+    } else {
+      style.transform = ""
+      style.height = ""
+      style.bottom = ""
+      style.removeProperty("--gs-vh")
+    }
   },
 
   // -- results section ---------------------------------------------------------

--- a/lib/sanctum_web/live/global_search_component.ex
+++ b/lib/sanctum_web/live/global_search_component.ex
@@ -46,9 +46,11 @@ defmodule SanctumWeb.GlobalSearchComponent do
       <div class="absolute inset-0 bg-black/60" data-gs-close aria-hidden="true"></div>
       <%!-- Mobile: a fixed-height bottom sheet (dvh so browser chrome is
            accounted for) — it doesn't grow/shrink with results, and the
-           results region scrolls inside it. Desktop: centered dialog sized
-           by content. --%>
-      <div class="gs-sheet absolute inset-x-0 bottom-0 h-[85dvh] overflow-hidden border-t-[3px] border-neutral bg-base-100 p-3 sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-[12vh] sm:h-auto sm:w-[min(92vw,620px)] sm:-translate-x-1/2 sm:overflow-visible sm:border-2 sm:shadow-comic-lg">
+           results region scrolls inside it. max-h-full matters when the
+           on-screen keyboard is up: the hook shrinks the overlay to the
+           visual viewport, and the sheet must not poke above it. Desktop:
+           centered dialog sized by content. --%>
+      <div class="gs-sheet absolute inset-x-0 bottom-0 h-[85dvh] max-h-full overflow-hidden border-t-[3px] border-neutral bg-base-100 p-3 sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-[12vh] sm:h-auto sm:max-h-none sm:w-[min(92vw,620px)] sm:-translate-x-1/2 sm:overflow-visible sm:border-2 sm:shadow-comic-lg">
         <form
           id="global-search-form"
           phx-change="search"
@@ -67,7 +69,7 @@ defmodule SanctumWeb.GlobalSearchComponent do
             placeholder_short="Search…"
             help_path={~p"/search-help"}
             debounce={350}
-            panel_class="mt-3 hidden max-h-[calc(85dvh-6rem)] overflow-y-auto overscroll-contain border-t-2 border-line sm:max-h-[60vh]"
+            panel_class="mt-3 hidden max-h-[calc(min(85dvh,var(--gs-vh,100dvh))-6rem)] overflow-y-auto overscroll-contain border-t-2 border-line sm:max-h-[60vh]"
           >
             <:results>
               <%!-- Navigable rows carry server-rendered ids (for


### PR DESCRIPTION
## Problem

On mobile, opening the global search sheet and getting the on-screen keyboard pushed the sheet up so the input landed off the top of the screen (scrollable back into view, but broken UX).

Root cause: the mobile keyboard doesn't resize the layout viewport — it shrinks and scrolls the **visual viewport**, while `position: fixed` elements (the overlay) stay glued to the layout viewport. So the whole dialog visually slides up with the page.

## Fix

Pin the dialog to the visual viewport while it's open:

- **`global-search.js`**: new `syncViewport()` listens to `visualViewport` `resize`/`scroll` (attached on open, detached on close). When the visual viewport shifts/shrinks, it offsets the overlay by `visualViewport.offsetTop`, caps its height to `visualViewport.height`, and publishes the height as a `--gs-vh` CSS variable. Re-asserted in `updated()` (LiveView patches strip client-set inline styles); everything resets when the keyboard or overlay closes. Input now focuses with `preventScroll: true`.
- **`global_search_component.ex`**: the sheet gets `max-h-full` so it can't poke above the shortened overlay (`sm:max-h-none` keeps desktop unchanged), and the results panel max-height becomes `calc(min(85dvh, var(--gs-vh, 100dvh)) - 6rem)` so results stay scrollable above the keyboard instead of clipped behind it.

## Testing

Verified via playwright at 390×844 with a stubbed `visualViewport` (offsetTop 350, height 460):

- sheet spans exactly the visible region with the input pinned at its top, above the keyboard
- results panel shrinks (max-height 364px) and its bottom stays above the keyboard
- pinning survives LiveView result patches while typing
- styles reset cleanly on keyboard close, backdrop close, and Escape
- desktop unaffected (pinning only activates when the visual viewport actually shifts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)