### PR TITLE
fix(decks): move sort options into the filter sheet body

### DIFF
--- a/lib/sanctum_web/components/filter_sheet.ex
+++ b/lib/sanctum_web/components/filter_sheet.ex
@@ -75,7 +75,9 @@ defmodule SanctumWeb.Components.FilterSheet do
   attr :on_clear, :string, default: "clear"
   attr :hide, :list, default: [], doc: "field names to omit (e.g. owned/mine when signed out)"
 
-  slot :footer_extra, doc: "extra controls in the footer form (e.g. the deck browser's sort)"
+  slot :body_extra,
+    doc:
+      "extra controls rendered as the first section of the sheet body (e.g. the deck browser's sort)"
 
   def filter_sheet(assigns) do
     assigns =
@@ -139,6 +141,12 @@ defmodule SanctumWeb.Components.FilterSheet do
       <form id={@id <> "-form"} phx-change={@on_change} class="flex min-h-0 flex-1 flex-col">
         <div class="min-h-0 flex-1 overflow-y-auto px-4 py-3 sm:px-5">
           <section
+            :if={@body_extra != []}
+            class="mb-6 border-t border-line/70 pt-4 first:border-t-0 first:pt-1"
+          >
+            {render_slot(@body_extra)}
+          </section>
+          <section
             :for={{group, controls} <- @groups}
             class="mb-6 border-t border-line/70 pt-4 first:border-t-0 first:pt-1 last:mb-2"
           >
@@ -162,7 +170,6 @@ defmodule SanctumWeb.Components.FilterSheet do
 
         <footer class="flex flex-none items-center gap-3 border-t-2 border-line bg-base-100 px-4 py-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] sm:px-5">
           <.button type="button" phx-click={@on_clear}>Clear all</.button>
-          {render_slot(@footer_extra)}
           <.button type="button" variant="primary" phx-click={@on_toggle} class="ml-auto">
             {(@count && "Show #{@count} results") || "Show results"}
           </.button>

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -79,15 +79,11 @@ defmodule SanctumWeb.DeckLive.Index do
         count={@count}
         hide={(@current_user && []) || ["mine"]}
       >
-        <:footer_extra>
-          <div
-            class="flex items-center gap-1.5"
-            role="radiogroup"
-            aria-label="Sort decks"
-          >
-            <span class="font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.07em] text-base-content/70">
-              Sort
-            </span>
+        <:body_extra>
+          <h3 class="mb-2.5 font-anton text-[13px] uppercase tracking-[0.08em] text-base-content/45">
+            Sort
+          </h3>
+          <div class="flex flex-wrap gap-1.5" role="radiogroup" aria-label="Sort decks">
             <.chip
               :for={{key, label} <- @sort_options}
               type="radio"
@@ -98,7 +94,7 @@ defmodule SanctumWeb.DeckLive.Index do
               {label}
             </.chip>
           </div>
-        </:footer_extra>
+        </:body_extra>
       </.filter_sheet>
 
       <!-- first-load skeletons: shown until the async load delivers a count -->


### PR DESCRIPTION
## Problem

On mobile, the deck browser's sort radios rendered in the filter sheet's footer bar alongside "Clear all" and "Show N results". The row overflowed horizontally and pushed the primary "Show results" button off screen.

## Change

- `FilterSheet`: the `footer_extra` slot is now `body_extra`, rendered as the first section inside the sheet's scroll region and styled like the registry-driven filter groups. The footer holds only "Clear all" + "Show N results". Since the whole sheet is a single form, controls in the body submit exactly as they did from the footer.
- `DeckLive.Index`: sort radios moved into the new slot with a group-style "Sort" heading matching Hero/Aspect/Source.

The card pool and deck build pages don't use the slot, so they're unaffected.

## Verification

Exercised in the browser at 390×844: the sheet opens with Sort as the first section, the footer shows both buttons fully on screen, and selecting "Unique" patches the URL to `?sort=unique` as before. The desktop (sm+) dialog renders the same section correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)