### PR TITLE
fix(ui): stack header actions above title on mobile

### DIFF
--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -461,8 +461,10 @@ defmodule SanctumWeb.CoreComponents do
   def header(assigns) do
     ~H"""
     <header class="mb-6 border-b-[3px] border-neutral pb-4">
-      <div class={[@actions != [] && "flex items-end justify-between gap-6"]}>
-        <div class="min-w-0">
+      <div class={[
+        @actions != [] && "flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6"
+      ]}>
+        <div class={["min-w-0", @actions != [] && "order-2 sm:order-1"]}>
           <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-[42px]">
             {render_slot(@inner_block)}
           </h1>
@@ -470,7 +472,10 @@ defmodule SanctumWeb.CoreComponents do
             {render_slot(@subtitle)}
           </p>
         </div>
-        <div :if={@actions != []} class="flex flex-none items-center gap-2.5">
+        <div
+          :if={@actions != []}
+          class="order-1 flex flex-none items-center justify-end gap-2.5 sm:order-2"
+        >
           {render_slot(@actions)}
         </div>
       </div>

--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -463,15 +463,12 @@ defmodule SanctumWeb.CoreComponents do
       <div class={[
         @actions != [] && "flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6"
       ]}>
-        <div class={["min-w-0", @actions != [] && "order-2 sm:order-1"]}>
+        <div class="min-w-0">
           <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-[42px]">
             {render_slot(@inner_block)}
           </h1>
         </div>
-        <div
-          :if={@actions != []}
-          class="order-1 flex flex-none items-center justify-end gap-2.5 sm:order-2"
-        >
+        <div :if={@actions != []} class="flex flex-none items-center justify-end gap-2.5">
           {render_slot(@actions)}
         </div>
       </div>

--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -455,7 +455,6 @@ defmodule SanctumWeb.CoreComponents do
   Renders a header with title.
   """
   slot :inner_block, required: true
-  slot :subtitle
   slot :actions
 
   def header(assigns) do
@@ -468,9 +467,6 @@ defmodule SanctumWeb.CoreComponents do
           <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-[42px]">
             {render_slot(@inner_block)}
           </h1>
-          <p :if={@subtitle != []} class="mt-2 font-barlow text-[15px] text-base-content/60">
-            {render_slot(@subtitle)}
-          </p>
         </div>
         <div
           :if={@actions != []}

--- a/lib/sanctum_web/live/admin_live/index.ex
+++ b/lib/sanctum_web/live/admin_live/index.ex
@@ -16,7 +16,6 @@ defmodule SanctumWeb.AdminLive.Index do
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:admin}>
       <.header>
         Admin
-        <:subtitle>System health and management surfaces.</:subtitle>
       </.header>
 
       <section class="mt-6">

--- a/lib/sanctum_web/live/browse_live/index.ex
+++ b/lib/sanctum_web/live/browse_live/index.ex
@@ -137,9 +137,6 @@ defmodule SanctumWeb.BrowseLive.Index do
       <div id="scroll-restore" phx-hook="ScrollRestore"></div>
       <.header>
         Browse
-        <:subtitle>
-          Every product in the game, organized by release wave — campaign expansions, hero packs, and scenario packs. Pick a product to see everything inside it.
-        </:subtitle>
       </.header>
 
       <!-- search: matches product names and the names of the card sets inside them -->

--- a/lib/sanctum_web/live/browse_live/show.ex
+++ b/lib/sanctum_web/live/browse_live/show.ex
@@ -213,6 +213,12 @@ defmodule SanctumWeb.BrowseLive.Show do
           {@pack.name || @pack.code}
 
           <:actions :if={@current_user}>
+            <span
+              :if={@owned_ids}
+              class="font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.08em] text-primary"
+            >
+              {MapSet.size(@owned_ids)} / {@total_cards} owned
+            </span>
             <.collection_toggle owned={@pack_owned} event="toggle_pack_owned" id={@pack.id} />
           </:actions>
         </.header>

--- a/lib/sanctum_web/live/browse_live/show.ex
+++ b/lib/sanctum_web/live/browse_live/show.ex
@@ -211,18 +211,6 @@ defmodule SanctumWeb.BrowseLive.Show do
           </.link>
           <span class="text-base-content/30">/</span>
           {@pack.name || @pack.code}
-          <:subtitle>
-            {Catalog.ProductType.label(@pack.product_type)}
-            <span :if={@pack.wave}>
-              · {@pack.wave.name}
-            </span><span :if={@pack.released_on}>
-              · {@pack.released_on.year}
-            </span>
-            · {@pack.card_total || 0} cards
-            <span :if={@owned_ids} class="text-primary">
-              · {MapSet.size(@owned_ids)} / {@total_cards} owned
-            </span>
-          </:subtitle>
 
           <:actions :if={@current_user}>
             <.collection_toggle owned={@pack_owned} event="toggle_pack_owned" id={@pack.id} />

--- a/lib/sanctum_web/live/card_live/detail.ex
+++ b/lib/sanctum_web/live/card_live/detail.ex
@@ -26,14 +26,6 @@ defmodule SanctumWeb.CardLive.Detail do
       <div :if={@card != nil}>
         <.header>
           {@title}
-          <:subtitle>
-            <span class="font-ibm-mono text-[12px] uppercase tracking-[0.16em]">
-              {@card.base_code}
-            </span>
-            <span :if={@card.pack}> · {@card.pack}</span>
-            · {length(@sides)} side{if length(@sides) != 1, do: "s"}
-            <span :if={@card.unique} class="text-base-content/45">· unique</span>
-          </:subtitle>
 
           <:actions>
             <.back_button fallback={~p"/cards"} />

--- a/lib/sanctum_web/live/card_live/form.ex
+++ b/lib/sanctum_web/live/card_live/form.ex
@@ -7,7 +7,6 @@ defmodule SanctumWeb.CardLive.Form do
     <Layouts.app current_user={@current_user} flash={@flash}>
       <.header>
         {@page_title}
-        <:subtitle>Use this form to manage card records in your database.</:subtitle>
       </.header>
 
       <.form for={@card_form} id="card-form" phx-change="validate" phx-submit="save">

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -24,9 +24,6 @@ defmodule SanctumWeb.CardLive.Pool do
       <div id="scroll-restore" phx-hook="ScrollRestore" data-offset={@offset}></div>
       <.header>
         Card Pool
-        <:subtitle>
-          Every card in the game — player and encounter — with full text and stats. Filter by aspect or type to find what you need.
-        </:subtitle>
       </.header>
 
       <!-- controls -->

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -13,13 +13,6 @@ defmodule SanctumWeb.CardLive.Show do
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:cards}>
       <.header>
         {@title}
-        <:subtitle>
-          <span class="font-ibm-mono text-[12px] uppercase tracking-[0.16em]">
-            {@card.base_code}
-          </span>
-          · {length(@card.card_sides)} side{if length(@card.card_sides) != 1, do: "s"}
-          <span :if={@card.is_multi_sided} class="text-base-content/45">· multi-sided</span>
-        </:subtitle>
 
         <:actions>
           <.back_button fallback={~p"/admin/cards"} />

--- a/lib/sanctum_web/live/card_live/sync.ex
+++ b/lib/sanctum_web/live/card_live/sync.ex
@@ -9,9 +9,6 @@ defmodule SanctumWeb.CardLive.Sync do
     <Layouts.admin flash={@flash}>
       <.header>
         Card Sync
-        <:subtitle>
-          Pulls the card catalog from MarvelCDB and mirrors card scans into the public bucket.
-        </:subtitle>
         <:actions>
           <.back_button fallback={~p"/admin/cards"} />
         </:actions>

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -637,7 +637,6 @@ defmodule SanctumWeb.DeckLive.Build do
       <.haptics />
       <.header>
         {@deck.title}
-        <:subtitle>{@deck.hero.display_name} · building</:subtitle>
         <:actions>
           <div :if={!@confirm_delete?} class="flex items-center gap-2.5">
             <.button phx-click="confirm_delete" class="!text-error">

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -28,9 +28,6 @@ defmodule SanctumWeb.DeckLive.Index do
       <div id="scroll-restore" phx-hook="ScrollRestore" data-offset={@offset}></div>
       <.header>
         Browse Decks
-        <:subtitle>
-          Every deck in the vault. Filter by hero or aspect, then open one for the full list.
-        </:subtitle>
         <:actions>
           <.button :if={@current_user} variant="primary" navigate={~p"/decks/new"}>
             <.icon name="hero-plus" /> New Deck

--- a/lib/sanctum_web/live/deck_live/new.ex
+++ b/lib/sanctum_web/live/deck_live/new.ex
@@ -123,9 +123,6 @@ defmodule SanctumWeb.DeckLive.New do
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:decks}>
       <.header>
         New Deck
-        <:subtitle>
-          Pick a hero to start building. The hero's signature cards come locked in.
-        </:subtitle>
       </.header>
 
       <form id="hero-filter" phx-change="filter" class="mb-4" onsubmit="return false">

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -23,36 +23,30 @@ defmodule SanctumWeb.DeckLive.Show do
       </div>
 
       <div :if={@deck != nil}>
-        <header class="mb-6 border-b-[3px] border-neutral pb-4">
-          <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6">
-            <div class="order-2 min-w-0 sm:order-1">
-              <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-[42px]">
-                {@deck.title}
-              </h1>
-              <p class="mt-2 font-barlow text-[15px] text-base-content/60">
-                {@cover.hero_name}<span :if={@cover.author}> · by {@cover.author}</span>
-              </p>
-            </div>
-            <div class="order-1 flex flex-none items-center gap-2.5 sm:order-2">
-              <.button
-                :if={owner?(@deck, @current_user)}
-                variant="primary"
-                navigate={~p"/decks/#{@deck.id}/build"}
-              >
-                <.icon name="hero-pencil-square" /> Edit Deck
-              </.button>
-              <.button
-                :if={mcdb_url(@deck)}
-                href={mcdb_url(@deck)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <.icon name="hero-arrow-top-right-on-square" /> MarvelCDB
-              </.button>
-              <.back_button fallback={~p"/decks"} />
-            </div>
-          </div>
-        </header>
+        <.header>
+          {@deck.title}
+          <:subtitle>
+            {@cover.hero_name}<span :if={@cover.author}> · by {@cover.author}</span>
+          </:subtitle>
+          <:actions>
+            <.button
+              :if={owner?(@deck, @current_user)}
+              variant="primary"
+              navigate={~p"/decks/#{@deck.id}/build"}
+            >
+              <.icon name="hero-pencil-square" /> Edit Deck
+            </.button>
+            <.button
+              :if={mcdb_url(@deck)}
+              href={mcdb_url(@deck)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <.icon name="hero-arrow-top-right-on-square" /> MarvelCDB
+            </.button>
+            <.back_button fallback={~p"/decks"} />
+          </:actions>
+        </.header>
 
         <div class="space-y-5">
           <!-- cover -->

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -25,9 +25,6 @@ defmodule SanctumWeb.DeckLive.Show do
       <div :if={@deck != nil}>
         <.header>
           {@deck.title}
-          <:subtitle>
-            {@cover.hero_name}<span :if={@cover.author}> · by {@cover.author}</span>
-          </:subtitle>
           <:actions>
             <.button
               :if={owner?(@deck, @current_user)}

--- a/lib/sanctum_web/live/guess_live/play.ex
+++ b/lib/sanctum_web/live/guess_live/play.ex
@@ -17,10 +17,6 @@ defmodule SanctumWeb.GuessLive.Play do
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:guess}>
       <.header>
         Flavor Town
-        <:subtitle>
-          Read the flavor text and name the card. Inspired by the <em>Stunned &amp; Confused</em>
-          podcast — every wrong guess earns you a hint that narrows it down.
-        </:subtitle>
       </.header>
 
       <.panel :if={@status == :empty} class="px-6 py-12 text-center">

--- a/lib/sanctum_web/live/search_help_live.ex
+++ b/lib/sanctum_web/live/search_help_live.ex
@@ -35,11 +35,6 @@ defmodule SanctumWeb.SearchHelpLive do
     <Layouts.app current_user={@current_user} flash={@flash}>
       <.header>
         Search Syntax
-        <:subtitle>
-          The card pool and deck browser share a query language: type plain words to
-          search names, or combine field filters for precise questions. Everything is
-          case-insensitive, and partial or imperfect queries still return results.
-        </:subtitle>
       </.header>
 
       <div class="max-w-4xl space-y-8">

--- a/lib/sanctum_web/live/stats_live/index.ex
+++ b/lib/sanctum_web/live/stats_live/index.ex
@@ -45,9 +45,6 @@ defmodule SanctumWeb.StatsLive.Index do
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:stats}>
       <.header>
         Vault Stats
-        <:subtitle>
-          The deck vault by the numbers — growth over time, hero popularity, and aspect splits.
-        </:subtitle>
       </.header>
 
       <div :if={@stats == nil} class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">

--- a/test/sanctum_web/live/card_live/detail_test.exs
+++ b/test/sanctum_web/live/card_live/detail_test.exs
@@ -55,7 +55,6 @@ defmodule SanctumWeb.CardLive.DetailTest do
     assert html =~ "Spider-sense tingling."
     assert html =~ "Scientist supreme of Queens."
     assert html =~ "60001"
-    assert html =~ "2 sides"
   end
 
   test "shows pack metadata in the card file panel", %{conn: conn} do


### PR DESCRIPTION
## Summary

The shared `<.header>` component rendered its title and `:actions` slot inline at all viewport widths, which scrunched long titles on phones (e.g. "Browse Decks" next to the New Deck button).

- Below the `sm` breakpoint, the header now stacks: full-width title first, with the actions row right-aligned **below** it; at `sm+` the previous inline layout (title left, actions right, `items-end justify-between`) is unchanged.
- `deck_live/show.ex` had hand-rolled a duplicate of the header markup specifically to get a stacked mobile layout; it now uses the shared component.
- **Removes the `:subtitle` slot entirely** — none of the header subtitles earned their space. Stripped from the component and all call sites. (The two homebrew pages only exist on `feat/homebrew-foundation`, so their removals landed there as a companion commit on #266 — every merge order compiles.)

Affects the 8 call sites that pass `:actions`: deck index/build, browse show, homebrew index, and the card index/show/sync/detail admin pages.

## Testing

- Verified with playwright at 375×812 (deck detail page: full-width title with the actions row under it; decks index without subtitle) and 1280px (desktop layout unchanged).
- `mix compile --force --warnings-as-errors` clean, formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)