### PR TITLE
feat(cards): prev/next nav replaces the history entry

### DIFF
--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -89,7 +89,7 @@ defmodule SanctumWeb.CoreComponents do
       <.button navigate={~p"/"}>Home</.button>
   """
   attr :rest, :global,
-    include: ~w(href navigate patch method download name value disabled type target rel)
+    include: ~w(href navigate patch replace method download name value disabled type target rel)
 
   attr :class, :string, default: ""
   attr :variant, :string, values: ~w(primary ghost icon)

--- a/lib/sanctum_web/live/card_live/detail.ex
+++ b/lib/sanctum_web/live/card_live/detail.ex
@@ -33,6 +33,7 @@ defmodule SanctumWeb.CardLive.Detail do
               <.button
                 :if={@prev}
                 navigate={~p"/cards/#{@prev.id}"}
+                replace
                 data-card-nav="prev"
                 aria-label="Previous card"
                 title={"#{card_name(@prev)} (←)"}
@@ -45,6 +46,7 @@ defmodule SanctumWeb.CardLive.Detail do
               <.button
                 :if={@next}
                 navigate={~p"/cards/#{@next.id}"}
+                replace
                 data-card-nav="next"
                 aria-label="Next card"
                 title={"#{card_name(@next)} (→)"}


### PR DESCRIPTION
## Summary

Follow-up to #276 (this change was amended onto that branch just as it merged, so it never landed). The prev/next nav links on the card detail page now navigate with `replace`, so arrowing through cards doesn't pile up history entries — Back returns to wherever the reader entered from (e.g. the card pool). The keyboard hook clicks these same links, so arrow-key navigation inherits the behavior. `.button` now passes the `replace` attribute through to links (it previously wasn't in the global include list and was silently dropped).

## Testing

- `mix compile --warnings-as-errors` passes.
- Verified in the browser (playwright-cli against localhost:4150): `history.length` stays constant while arrowing through multiple cards, and Back returns directly to the card pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)