### PR TITLE
refactor(ui): move font sizes onto the Tailwind type-scale tokens

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -619,7 +619,7 @@ textarea::placeholder {
 
 .deck-writeup {
   font-family: 'Barlow', sans-serif;
-  font-size: 15px;
+  font-size: var(--text-base);
   line-height: 1.7;
   color: color-mix(in srgb, var(--color-base-content) 85%, transparent);
 }
@@ -652,13 +652,13 @@ textarea::placeholder {
   color: var(--color-base-content);
   margin: 1.75rem 0 0.75rem;
 }
-.deck-writeup h1 { font-size: 1.7rem; }
-.deck-writeup h2 { font-size: 1.45rem; }
+.deck-writeup h1 { font-size: var(--text-3xl); }
+.deck-writeup h2 { font-size: var(--text-2xl); }
 .deck-writeup h3,
-.deck-writeup center { font-size: 1.25rem; }
+.deck-writeup center { font-size: var(--text-xl); }
 .deck-writeup h4,
 .deck-writeup h5,
-.deck-writeup h6 { font-size: 1.1rem; }
+.deck-writeup h6 { font-size: var(--text-lg); }
 
 .deck-writeup a {
   color: var(--color-primary);
@@ -718,7 +718,7 @@ textarea::placeholder {
 
 .deck-writeup code {
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.85em;
+  font-size: var(--text-sm);
   background: var(--color-base-300);
   padding: 0.1em 0.35em;
   border: 1px solid var(--color-line);
@@ -755,7 +755,7 @@ textarea::placeholder {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  font-size: 0.8rem;
+  font-size: var(--text-xs);
 }
 .deck-writeup tbody td:first-child {
   font-weight: 600;
@@ -804,7 +804,7 @@ textarea::placeholder {
   padding: 0.45rem 0.8rem;
   cursor: pointer;
   font-family: var(--font-barlow, 'Barlow Condensed', sans-serif);
-  font-size: 0.9rem;
+  font-size: var(--text-sm);
   border-bottom: 1px solid var(--color-line);
 }
 .qi-option:last-child {
@@ -829,7 +829,7 @@ textarea::placeholder {
 }
 .qi-option-detail {
   color: color-mix(in srgb, var(--color-base-content) 50%, transparent);
-  font-size: 0.8rem;
+  font-size: var(--text-xs);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -853,7 +853,7 @@ textarea::placeholder {
 .mention-glyph {
   width: 2rem;
   flex: none;
-  font-size: 1.3rem;
+  font-size: var(--text-xl);
   line-height: 1;
   text-align: center;
 }
@@ -911,7 +911,7 @@ a.qi-option {
   width: 100%;
   border-collapse: collapse;
   font-family: 'Barlow', sans-serif;
-  font-size: 14px;
+  font-size: var(--text-sm);
 }
 .qh-table th,
 .qh-table td {
@@ -929,7 +929,7 @@ a.qi-option {
   font-weight: 400;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: color-mix(in srgb, var(--color-base-content) 70%, transparent);
 }
 .qh-table tbody td {

--- a/lib/sanctum_web/auth_overrides.ex
+++ b/lib/sanctum_web/auth_overrides.ex
@@ -27,7 +27,7 @@ defmodule SanctumWeb.AuthOverrides do
 
   # Comic button primitives (mirrors CoreComponents.button/1 variants).
   @button_base "w-full inline-flex min-h-[44px] items-center justify-center gap-2 cursor-pointer " <>
-                 "px-4 py-2.5 font-barlow-condensed font-extrabold uppercase tracking-[0.08em] text-[13px] " <>
+                 "px-4 py-2.5 font-barlow-condensed font-extrabold uppercase tracking-[0.08em] text-sm " <>
                  "transition-all active:translate-x-px active:translate-y-px disabled:opacity-40 disabled:pointer-events-none"
   @button_primary @button_base <>
                     " bg-primary text-primary-content border-2 border-transparent shadow-comic-sm hover:shadow-comic"
@@ -35,8 +35,8 @@ defmodule SanctumWeb.AuthOverrides do
                   " bg-base-300 text-base-content border-2 border-neutral shadow-comic-sm hover:text-white"
 
   # Form primitives (mirrors CoreComponents.input/1).
-  @heading_class "font-anton text-[24px] uppercase tracking-[0.03em] leading-none text-base-content mt-2 mb-5"
-  @field_label_class "block font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/60 mb-1.5"
+  @heading_class "font-anton text-2xl uppercase tracking-[0.03em] leading-none text-base-content mt-2 mb-5"
+  @field_label_class "block font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/60 mb-1.5"
   @input_base "appearance-none block w-full bg-black border-[2.5px] text-base-content font-barlow " <>
                 "px-3.5 py-2.5 text-sm outline-none placeholder:text-base-content/40"
   @input_class @input_base <> " border-line focus:border-primary"
@@ -113,7 +113,7 @@ defmodule SanctumWeb.AuthOverrides do
     set :dark_image_url, nil
     set :href_url, "/"
     set :text, "SANCTUM"
-    set :text_class, "font-bangers text-[40px] leading-none tracking-wide text-primary"
+    set :text_class, "font-bangers text-4xl leading-none tracking-wide text-primary"
   end
 
   override Components.HorizontalRule do
@@ -121,7 +121,7 @@ defmodule SanctumWeb.AuthOverrides do
     set :hr_inner_class, "w-full border-t-2 border-neutral"
 
     set :text_inner_class,
-        "px-3 bg-base-200 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50"
+        "px-3 bg-base-200 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50"
   end
 
   override Components.MagicLink do
@@ -135,7 +135,7 @@ defmodule SanctumWeb.AuthOverrides do
     set :checkbox_class, "checkbox checkbox-sm"
 
     set :checkbox_label_class,
-        "font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/70"
+        "font-barlow-condensed text-sm font-bold uppercase tracking-[0.06em] text-base-content/70"
   end
 
   override Components.Password do
@@ -143,7 +143,7 @@ defmodule SanctumWeb.AuthOverrides do
     set :interstitial_class, "flex flex-row justify-between content-between mt-3"
 
     set :toggler_class,
-        "flex-none px-2 first:pl-0 last:pr-0 font-barlow-condensed text-[13px] font-bold " <>
+        "flex-none px-2 first:pl-0 last:pr-0 font-barlow-condensed text-sm font-bold " <>
           "uppercase tracking-[0.06em] text-primary hover:underline underline-offset-4"
   end
 
@@ -170,7 +170,7 @@ defmodule SanctumWeb.AuthOverrides do
     set :checkbox_class, "checkbox checkbox-sm"
 
     set :checkbox_label_class,
-        "font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/70"
+        "font-barlow-condensed text-sm font-bold uppercase tracking-[0.06em] text-base-content/70"
   end
 
   override Components.OAuth2 do

--- a/lib/sanctum_web/auth_sign_in_live.ex
+++ b/lib/sanctum_web/auth_sign_in_live.ex
@@ -82,7 +82,7 @@ defmodule SanctumWeb.AuthSignInLive do
       <Layouts.flash_group flash={@flash} />
       <div class={AuthOverrides.panel_class()}>
         <div class="w-full pb-6 mb-6 border-b-2 border-neutral text-center">
-          <.link navigate="/" class="font-bangers text-[40px] leading-none tracking-wide text-primary">
+          <.link navigate="/" class="font-bangers text-4xl leading-none tracking-wide text-primary">
             SANCTUM
           </.link>
         </div>
@@ -127,7 +127,7 @@ defmodule SanctumWeb.AuthSignInLive do
           <div class="relative my-5">
             <div class="w-full border-t-2 border-neutral"></div>
             <div class="absolute inset-0 flex items-center justify-center -top-2">
-              <span class="px-3 bg-base-200 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+              <span class="px-3 bg-base-200 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
                 or
               </span>
             </div>
@@ -213,7 +213,7 @@ defmodule SanctumWeb.AuthSignInLive do
     ~H"""
     <.link
       navigate={@navigate}
-      class="flex-none px-2 first:pl-0 last:pr-0 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-primary hover:underline underline-offset-4"
+      class="flex-none px-2 first:pl-0 last:pr-0 font-barlow-condensed text-sm font-bold uppercase tracking-[0.06em] text-primary hover:underline underline-offset-4"
     >
       {render_slot(@inner_block)}
     </.link>

--- a/lib/sanctum_web/components/card_side_tile.ex
+++ b/lib/sanctum_web/components/card_side_tile.ex
@@ -60,7 +60,7 @@ defmodule SanctumWeb.Components.CardSideTile do
       </.maybe_link>
 
       <div class="flex min-w-0 flex-1 flex-col">
-        <div class="h-12 flex items-start gap-3">
+        <div class="min-h-12 flex items-start gap-3">
           <div
             :if={@side.show_cost}
             class="flex flex-none items-center justify-center rounded-full font-elektra-med text-4xl/normal"
@@ -70,7 +70,7 @@ defmodule SanctumWeb.Components.CardSideTile do
           <div class="min-w-0 flex-1">
             <div class="flex items-center justify-between gap-2">
               <div class={[
-                "font-ibm-mono text-[9px] uppercase tracking-[0.2em]",
+                "font-ibm-mono text-xs uppercase tracking-[0.2em]",
                 @side.aspect_text_class
               ]}>
                 {@side.type_name} · {@side.aspect_name}
@@ -78,7 +78,7 @@ defmodule SanctumWeb.Components.CardSideTile do
               <.owned_badge :if={@side.owned == true} />
             </div>
             <div class="mt-[3px] flex items-baseline gap-2">
-              <div class="min-w-0 flex-1 font-anton text-[22px] uppercase leading-[0.94]">
+              <div class="min-w-0 flex-1 font-anton text-2xl uppercase leading-[0.94]">
                 <.link :if={@navigate} navigate={@navigate} class="hover:text-primary">
                   {@side.name}
                 </.link>
@@ -86,7 +86,7 @@ defmodule SanctumWeb.Components.CardSideTile do
               </div>
               <div
                 :if={@side.stage_label}
-                class="flex-none font-elektra-med text-[18px] leading-none text-white"
+                class="flex-none font-elektra-med text-lg leading-none text-white"
               >
                 {@side.stage_label}
               </div>
@@ -137,7 +137,7 @@ defmodule SanctumWeb.Components.CardSideTile do
 
         <div
           :if={@side.is_scheme and (@side.start_threat || @side.escalation_threat)}
-          class="mb-1 w-full"
+          class="mt-2 mb-1 w-full"
         >
           <div class="inline-flex -skew-x-[9deg] border-2 border-white bg-base-100 shadow-comic-sm">
             <.scheme_cell value={@side.start_threat} per_player={@side.start_threat_pp} />
@@ -169,14 +169,14 @@ defmodule SanctumWeb.Components.CardSideTile do
           {@side.traits}
         </div>
 
-        <div class="font-barlow text-[13.5px] leading-[1.5] text-base-content/85">
+        <div class="font-barlow text-base-content/85">
           {Sanctum.CardText.to_html(@side.text)}
         </div>
 
         <div
           :if={@side.flavor}
           class={[
-            "text-center font-barlow italic text-xs text-base-content/65",
+            "text-center font-barlow italic text-sm text-base-content/65",
             (@lg? && "my-3.5") || "my-2"
           ]}
         >

--- a/lib/sanctum_web/components/collection.ex
+++ b/lib/sanctum_web/components/collection.ex
@@ -70,7 +70,7 @@ defmodule SanctumWeb.Components.Collection do
       <.icon name={(@owned && "hero-check") || "hero-plus"} class="size-3.5 flex-none" />
       <span
         :if={!@compact}
-        class="font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.07em]"
+        class="font-barlow-condensed text-xs font-bold uppercase tracking-[0.07em]"
       >
         {(@owned && "In Collection") || "Add to Collection"}
       </span>

--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -97,7 +97,7 @@ defmodule SanctumWeb.CoreComponents do
 
   def button(%{rest: rest} = assigns) do
     base =
-      "inline-flex min-h-[44px] items-center justify-center gap-2 cursor-pointer font-barlow-condensed font-extrabold uppercase tracking-[0.08em] text-[13px] transition-all active:translate-x-px active:translate-y-px disabled:opacity-40 disabled:pointer-events-none sm:min-h-0"
+      "inline-flex min-h-[44px] items-center justify-center gap-2 cursor-pointer font-barlow-condensed font-extrabold uppercase tracking-[0.08em] text-sm transition-all active:translate-x-px active:translate-y-px disabled:opacity-40 disabled:pointer-events-none sm:min-h-0"
 
     variants = %{
       "primary" =>
@@ -201,7 +201,7 @@ defmodule SanctumWeb.CoreComponents do
     <button
       class={[
         "inline-flex min-h-[44px] items-center gap-1.5 cursor-pointer border-2 px-3.5 py-1.5 sm:min-h-0 sm:px-3",
-        "font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.07em] transition-colors sm:text-[12px]",
+        "font-barlow-condensed text-sm font-bold uppercase tracking-[0.07em] transition-colors sm:text-xs",
         (@active && "border-transparent bg-primary text-primary-content") ||
           "border-neutral bg-base-300 text-base-content hover:text-white",
         @class
@@ -252,11 +252,11 @@ defmodule SanctumWeb.CoreComponents do
       <div class="flex items-baseline gap-1">
         <span class={[
           "font-anton leading-none text-primary",
-          (@size == "lg" && "text-[30px]") || "text-[22px]"
+          (@size == "lg" && "text-3xl") || "text-2xl"
         ]}>
           {@percentile}
         </span>
-        <span class="font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em] text-base-content/40">
+        <span class="font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em] text-base-content/40">
           /100
         </span>
       </div>
@@ -266,7 +266,7 @@ defmodule SanctumWeb.CoreComponents do
       ]}>
         <div class="h-full bg-primary" style={"width:#{@percentile}%"}></div>
       </div>
-      <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+      <div class="mt-1 font-barlow-condensed text-xs font-bold uppercase tracking-[0.1em] text-base-content/50">
         Uniqueness
       </div>
     </div>
@@ -367,7 +367,7 @@ defmodule SanctumWeb.CoreComponents do
     <div class="flex flex-col gap-1.5">
       <span
         :if={@label}
-        class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/60"
+        class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/60"
       >
         {@label}
       </span>
@@ -395,7 +395,7 @@ defmodule SanctumWeb.CoreComponents do
     <div class="flex flex-col gap-1.5">
       <span
         :if={@label}
-        class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/60"
+        class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/60"
       >
         {@label}
       </span>
@@ -420,7 +420,7 @@ defmodule SanctumWeb.CoreComponents do
     <div class="flex flex-col gap-1.5">
       <span
         :if={@label}
-        class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/60"
+        class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/60"
       >
         {@label}
       </span>
@@ -464,7 +464,7 @@ defmodule SanctumWeb.CoreComponents do
         @actions != [] && "flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-6"
       ]}>
         <div class="min-w-0">
-          <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-[42px]">
+          <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-4xl">
             {render_slot(@inner_block)}
           </h1>
         </div>

--- a/lib/sanctum_web/components/deck_builder.ex
+++ b/lib/sanctum_web/components/deck_builder.ex
@@ -33,8 +33,8 @@ defmodule SanctumWeb.Components.DeckBuilder do
         icon_class: (assigns.size == "md" && "size-5 sm:size-4") || "size-4 sm:size-3.5",
         add_icon_class: (assigns.size == "md" && "size-6 sm:size-5") || "size-5 sm:size-4",
         count_class:
-          (assigns.size == "md" && "min-w-7 text-[15px] sm:min-w-6 sm:text-[13px]") ||
-            "min-w-6 text-[13px] sm:min-w-5 sm:text-[12px]"
+          (assigns.size == "md" && "min-w-7 text-base sm:min-w-6 sm:text-sm") ||
+            "min-w-6 text-sm sm:min-w-5 sm:text-xs"
       )
 
     ~H"""

--- a/lib/sanctum_web/components/deck_cards.ex
+++ b/lib/sanctum_web/components/deck_cards.ex
@@ -177,7 +177,7 @@ defmodule SanctumWeb.Components.DeckCards do
 
   def row_cost(assigns) do
     ~H"""
-    <span class="w-5 flex-none text-center font-elektra-med text-[16px] leading-none text-base-content/90">
+    <span class="w-5 flex-none text-center font-elektra-med text-base leading-none text-base-content/90">
       {@cost}
     </span>
     """

--- a/lib/sanctum_web/components/filter_sheet.ex
+++ b/lib/sanctum_web/components/filter_sheet.ex
@@ -49,7 +49,7 @@ defmodule SanctumWeb.Components.FilterSheet do
       <.icon name="hero-funnel" class="size-4" /> Filters
       <span
         :if={@count > 0}
-        class="grid min-w-5 place-items-center bg-primary px-1 font-anton text-[12px] leading-5 text-primary-content"
+        class="grid min-w-5 place-items-center bg-primary px-1 font-anton text-xs leading-5 text-primary-content"
       >
         {@count}
       </span>
@@ -123,7 +123,7 @@ defmodule SanctumWeb.Components.FilterSheet do
       </button>
 
       <header class="hidden flex-none items-center justify-between border-b-2 border-line px-5 py-3 sm:flex">
-        <h2 class="font-bangers text-[22px] tracking-[0.02em] text-primary">Filters</h2>
+        <h2 class="font-bangers text-2xl tracking-[0.02em] text-primary">Filters</h2>
         <button
           type="button"
           phx-click={@on_toggle}
@@ -150,7 +150,7 @@ defmodule SanctumWeb.Components.FilterSheet do
             :for={{group, controls} <- @groups}
             class="mb-6 border-t border-line/70 pt-4 first:border-t-0 first:pt-1 last:mb-2"
           >
-            <h3 class="mb-2.5 font-anton text-[13px] uppercase tracking-[0.08em] text-base-content/45">
+            <h3 class="mb-2.5 font-anton text-sm uppercase tracking-[0.08em] text-base-content/45">
               {group}
             </h3>
             <div class={group_layout(controls)}>
@@ -160,10 +160,10 @@ defmodule SanctumWeb.Components.FilterSheet do
 
           <div
             :if={@sync.residual != ""}
-            class="mb-2 border border-dashed border-line px-3 py-2 font-barlow text-[13px] text-base-content/55"
+            class="mb-2 border border-dashed border-line px-3 py-2 font-barlow text-sm text-base-content/55"
           >
             Also filtering:
-            <span class="font-ibm-mono text-[12.5px] text-base-content/80">{@sync.residual}</span>
+            <span class="font-ibm-mono text-sm text-base-content/80">{@sync.residual}</span>
             — edit in the search bar.
           </div>
         </div>
@@ -259,7 +259,7 @@ defmodule SanctumWeb.Components.FilterSheet do
         autocomplete="off"
         spellcheck="false"
         phx-debounce="300"
-        class="min-w-0 border-2 border-line bg-black px-2.5 py-1.5 font-barlow text-[14px] text-base-content outline-none placeholder:text-base-content/35 focus:border-primary"
+        class="min-w-0 border-2 border-line bg-black px-2.5 py-1.5 font-barlow text-sm text-base-content outline-none placeholder:text-base-content/35 focus:border-primary"
       />
     </label>
     <datalist id={@list_id}>
@@ -293,7 +293,7 @@ defmodule SanctumWeb.Components.FilterSheet do
         value={@current.value}
         phx-debounce="300"
         aria-label={@control.label}
-        class="w-14 border-2 border-line bg-black px-2 py-1.5 text-center font-barlow text-[14px] text-base-content outline-none focus:border-primary"
+        class="w-14 border-2 border-line bg-black px-2 py-1.5 text-center font-barlow text-sm text-base-content outline-none focus:border-primary"
       />
     </div>
     """
@@ -315,7 +315,7 @@ defmodule SanctumWeb.Components.FilterSheet do
     ~H"""
     <label class={[
       "inline-flex min-h-[40px] cursor-pointer items-center gap-1.5 border-2 px-3.5 py-1.5 sm:min-h-0 sm:px-3",
-      "font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.07em] transition-colors sm:text-[12px]",
+      "font-barlow-condensed text-sm font-bold uppercase tracking-[0.07em] transition-colors sm:text-xs",
       (@checked && "border-transparent bg-primary text-primary-content") ||
         "border-neutral bg-base-300 text-base-content hover:text-white"
     ]}>
@@ -356,10 +356,9 @@ defmodule SanctumWeb.Components.FilterSheet do
   defp op_symbol(op), do: Map.fetch!(@op_symbols, op)
 
   defp control_label_classes,
-    do:
-      "font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.07em] text-base-content/70"
+    do: "font-barlow-condensed text-sm font-bold uppercase tracking-[0.07em] text-base-content/70"
 
   defp select_classes,
     do:
-      "cursor-pointer border-2 border-line bg-black px-2 py-1.5 font-barlow text-[14px] text-base-content outline-none focus:border-primary"
+      "cursor-pointer border-2 border-line bg-black px-2 py-1.5 font-barlow text-sm text-base-content outline-none focus:border-primary"
 end

--- a/lib/sanctum_web/components/layouts.ex
+++ b/lib/sanctum_web/components/layouts.ex
@@ -58,12 +58,12 @@ defmodule SanctumWeb.Layouts do
         <span class="font-bangers text-lg leading-none tracking-wide text-primary">
           Update your profile!
         </span>
-        <span class="font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.08em] text-base-content/60">
+        <span class="font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-base-content/60">
           Pick a username to get credit on your decks
         </span>
         <.link
           navigate={~p"/profile"}
-          class="ml-auto border-2 border-neutral bg-primary px-3 py-1 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.1em] text-primary-content shadow-comic-sm"
+          class="ml-auto border-2 border-neutral bg-primary px-3 py-1 font-barlow-condensed text-sm font-bold uppercase tracking-[0.1em] text-primary-content shadow-comic-sm"
         >
           Go to profile
         </.link>
@@ -101,7 +101,7 @@ defmodule SanctumWeb.Layouts do
         <!-- slim top bar (mobile only) -->
         <header class="sticky top-0 z-30 border-b-[3px] border-neutral bg-base-100/90 backdrop-blur lg:hidden">
           <div class="flex items-center justify-between gap-3 px-4 py-3.5">
-            <a href="/" class="font-bangers text-[28px] leading-none tracking-wide text-primary">
+            <a href="/" class="font-bangers text-3xl leading-none tracking-wide text-primary">
               SANCTUM
             </a>
             <div class="flex items-center gap-2">
@@ -146,7 +146,7 @@ defmodule SanctumWeb.Layouts do
           <div class="flex items-center justify-between border-b-2 border-neutral pb-4 lg:pb-3">
             <a
               href="/"
-              class="font-bangers text-[28px] leading-none tracking-wide text-primary lg:text-[24px]"
+              class="font-bangers text-3xl leading-none tracking-wide text-primary lg:text-2xl"
             >
               SANCTUM
             </a>
@@ -162,12 +162,12 @@ defmodule SanctumWeb.Layouts do
             <button
               type="button"
               phx-click={open_search()}
-              class="hidden cursor-pointer items-center justify-between border-2 border-transparent px-3 py-2 font-barlow-condensed text-[15px] font-bold uppercase tracking-[0.1em] text-base-content/55 transition-colors hover:text-white lg:flex lg:px-2.5 lg:py-1.5 lg:text-[13px]"
+              class="hidden cursor-pointer items-center justify-between border-2 border-transparent px-3 py-2 font-barlow-condensed text-base font-bold uppercase tracking-[0.1em] text-base-content/55 transition-colors hover:text-white lg:flex lg:px-2.5 lg:py-1.5 lg:text-sm"
             >
               <span class="flex items-center gap-2">
                 <.icon name="hero-magnifying-glass" class="size-3.5" /> Search
               </span>
-              <kbd class="border border-base-content/20 px-1 font-ibm-mono text-[10px] normal-case tracking-normal text-base-content/35">
+              <kbd class="border border-base-content/20 px-1 font-ibm-mono text-xs normal-case tracking-normal text-base-content/35">
                 ⌘K
               </kbd>
             </button>
@@ -264,7 +264,7 @@ defmodule SanctumWeb.Layouts do
     ~H"""
     <.link
       class={[
-        "border-2 px-3 py-2 font-barlow-condensed text-[15px] font-bold uppercase tracking-[0.1em] transition-colors lg:px-2.5 lg:py-1.5 lg:text-[13px]",
+        "border-2 px-3 py-2 font-barlow-condensed text-base font-bold uppercase tracking-[0.1em] transition-colors lg:px-2.5 lg:py-1.5 lg:text-sm",
         (@active && "-rotate-1 border-neutral bg-base-300 bg-halftone text-primary shadow-comic-sm") ||
           "border-transparent text-base-content/55 hover:text-white"
       ]}
@@ -305,14 +305,14 @@ defmodule SanctumWeb.Layouts do
           </p>
         </div>
 
-        <p class="mt-6 max-w-3xl font-barlow-condensed text-[13px] leading-relaxed text-base-content/40">
+        <p class="mt-6 max-w-3xl font-barlow-condensed text-sm leading-relaxed text-base-content/40">
           Sanctum is an unofficial, fan-made project. The information presented on this site about
           Marvel Champions: The Card Game, both literal and graphical, is copyrighted by Fantasy
           Flight Games and/or Marvel. This website is not produced, endorsed, supported, or
           affiliated with Fantasy Flight Games or Marvel.
         </p>
 
-        <p class="mt-4 font-ibm-mono text-[11px] uppercase tracking-[0.18em] text-base-content/30">
+        <p class="mt-4 font-ibm-mono text-xs uppercase tracking-[0.18em] text-base-content/30">
           © {Date.utc_today().year} Sanctum · Go play some Champs
         </p>
       </div>

--- a/lib/sanctum_web/components/query_input.ex
+++ b/lib/sanctum_web/components/query_input.ex
@@ -67,7 +67,7 @@ defmodule SanctumWeb.Components.QueryInput do
     ~H"""
     <div class="relative min-w-[260px] flex-1">
       <div id={@id} phx-hook={@hook} data-fields={Jason.encode!(@field_names)}>
-        <span class="pointer-events-none absolute left-3.5 top-[21px] z-20 -translate-y-1/2 text-[17px] text-base-content/40">
+        <span class="pointer-events-none absolute left-3.5 top-[21px] z-20 -translate-y-1/2 text-lg text-base-content/40">
           ⌕
         </span>
         <div class="relative border-[2.5px] border-line bg-black focus-within:border-primary">
@@ -75,7 +75,7 @@ defmodule SanctumWeb.Components.QueryInput do
             id={@id <> "-mirror"}
             phx-update="ignore"
             aria-hidden="true"
-            class="qi-mirror pointer-events-none absolute inset-0 overflow-hidden whitespace-pre py-2.5 pl-[38px] pr-9 font-barlow text-base text-base-content sm:text-[15px]"
+            class="qi-mirror pointer-events-none absolute inset-0 overflow-hidden whitespace-pre py-2.5 pl-[38px] pr-9 font-barlow text-base text-base-content"
           >
           </div>
           <input
@@ -94,14 +94,14 @@ defmodule SanctumWeb.Components.QueryInput do
             aria-expanded="false"
             aria-autocomplete="list"
             aria-controls={@id <> "-listbox"}
-            class="relative z-10 w-full bg-transparent py-2.5 pl-[38px] pr-9 font-barlow text-base text-transparent caret-primary outline-none placeholder:text-base-content/35 sm:text-[15px]"
+            class="relative z-10 w-full bg-transparent py-2.5 pl-[38px] pr-9 font-barlow text-base text-transparent caret-primary outline-none placeholder:text-base-content/35"
           />
           <.link
             :if={@help_path}
             navigate={@help_path}
             title="Search syntax help"
             aria-label="Search syntax help"
-            class="absolute right-2.5 top-1/2 z-20 grid size-[18px] -translate-y-1/2 place-items-center rounded-full border border-base-content/30 font-barlow text-[11px] font-bold text-base-content/45 hover:border-primary hover:text-primary"
+            class="absolute right-2.5 top-1/2 z-20 grid size-[18px] -translate-y-1/2 place-items-center rounded-full border border-base-content/30 font-barlow text-xs font-bold text-base-content/45 hover:border-primary hover:text-primary"
           >
             ?
           </.link>
@@ -133,7 +133,7 @@ defmodule SanctumWeb.Components.QueryInput do
       </div>
       <div
         :if={@diagnostics != []}
-        class="pointer-events-none absolute left-0 top-full z-20 mt-1 border border-line bg-base-100/95 px-2 py-0.5 font-barlow text-[12.5px] leading-tight text-primary/90"
+        class="pointer-events-none absolute left-0 top-full z-20 mt-1 border border-line bg-base-100/95 px-2 py-0.5 font-barlow text-sm leading-tight text-primary/90"
       >
         {format_diagnostic(hd(@diagnostics))}
       </div>

--- a/lib/sanctum_web/live/admin_live/index.ex
+++ b/lib/sanctum_web/live/admin_live/index.ex
@@ -62,7 +62,7 @@ defmodule SanctumWeb.AdminLive.Index do
           <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
             <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
               <span class={[
-                "inline-flex items-center border-2 px-3 py-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em]",
+                "inline-flex items-center border-2 px-3 py-1 font-ibm-mono text-xs uppercase tracking-[0.15em]",
                 deck_status_class(@deck_sync.status)
               ]}>
                 {deck_status_label(@deck_sync.status)}
@@ -78,7 +78,7 @@ defmodule SanctumWeb.AdminLive.Index do
               type="button"
               phx-click="sync_decks"
               disabled={@deck_sync.status == :running}
-              class="inline-flex -rotate-1 items-center gap-2 border-2 border-neutral bg-base-300 bg-halftone px-3 py-2 font-barlow-condensed text-[15px] font-bold uppercase tracking-[0.1em] text-primary shadow-comic-sm transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-50 lg:px-2.5 lg:py-1.5 lg:text-[13px]"
+              class="inline-flex -rotate-1 items-center gap-2 border-2 border-neutral bg-base-300 bg-halftone px-3 py-2 font-barlow-condensed text-base font-bold uppercase tracking-[0.1em] text-primary shadow-comic-sm transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-50 lg:px-2.5 lg:py-1.5 lg:text-sm"
             >
               <.icon name="hero-arrow-path" class="size-4" />
               {if @deck_sync.status == :running, do: "Syncing…", else: "Sync now"}
@@ -119,7 +119,7 @@ defmodule SanctumWeb.AdminLive.Index do
           </div>
 
           <div :if={@deck_sync.failures != []}>
-            <h3 class="mb-2 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-error">
+            <h3 class="mb-2 font-ibm-mono text-xs uppercase tracking-[0.15em] text-error">
               Recent failures ({length(@deck_sync.failures)})
             </h3>
             <ul class="space-y-1 font-ibm-mono text-xs text-base-content/70">
@@ -237,7 +237,7 @@ defmodule SanctumWeb.AdminLive.Index do
       ]}>
         {@value}
       </div>
-      <div class="mt-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+      <div class="mt-1 font-ibm-mono text-xs uppercase tracking-[0.15em] text-base-content/55">
         {@label}
       </div>
     </div>
@@ -253,7 +253,7 @@ defmodule SanctumWeb.AdminLive.Index do
       <div class="truncate font-barlow-condensed text-xl font-bold leading-none text-primary">
         {@value}
       </div>
-      <div class="mt-1 font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+      <div class="mt-1 font-ibm-mono text-xs uppercase tracking-[0.15em] text-base-content/55">
         {@label}
       </div>
     </div>

--- a/lib/sanctum_web/live/browse_live/index.ex
+++ b/lib/sanctum_web/live/browse_live/index.ex
@@ -151,7 +151,7 @@ defmodule SanctumWeb.BrowseLive.Index do
           placeholder="Search products and sets — try “spider”, “kang”, or “bomb scare”"
           phx-hook="ResponsivePlaceholder"
           data-placeholder-short="Search products and sets — try “kang”"
-          class="min-h-[44px] w-full border-[2.5px] border-line bg-black px-3 py-2 font-barlow-condensed text-base font-bold uppercase tracking-[0.04em] text-base-content outline-none placeholder:normal-case placeholder:font-normal placeholder:text-base-content/40 focus:border-primary sm:min-h-0 sm:text-[14px]"
+          class="min-h-[44px] w-full border-[2.5px] border-line bg-black px-3 py-2 font-barlow-condensed text-base font-bold uppercase tracking-[0.04em] text-base-content outline-none placeholder:normal-case placeholder:font-normal placeholder:text-base-content/40 focus:border-primary sm:min-h-0 sm:text-sm"
         />
       </form>
 
@@ -176,7 +176,7 @@ defmodule SanctumWeb.BrowseLive.Index do
         </section>
 
         <section :if={@filtered_other != []}>
-          <h2 class="mb-3.5 font-anton text-[22px] uppercase tracking-[0.03em]">Other</h2>
+          <h2 class="mb-3.5 font-anton text-2xl uppercase tracking-[0.03em]">Other</h2>
           <.pack_grid packs={@filtered_other} covers={@covers} owned_pack_ids={@owned_pack_ids} />
         </section>
 
@@ -201,7 +201,7 @@ defmodule SanctumWeb.BrowseLive.Index do
 
     ~H"""
     <div class="mb-3.5 flex flex-wrap items-baseline gap-x-3 gap-y-1 border-b-2 border-neutral pb-2">
-      <h2 class="font-anton text-[26px] uppercase leading-none tracking-[0.03em] text-primary">
+      <h2 class="font-anton text-2xl uppercase leading-none tracking-[0.03em] text-primary">
         {@wave.name}
       </h2>
       <span :if={@campaign} class="font-barlow-condensed text-lg uppercase text-base-content/55">
@@ -232,7 +232,7 @@ defmodule SanctumWeb.BrowseLive.Index do
             class="h-full w-full object-cover object-top opacity-90 transition group-hover:opacity-100"
           />
           <div :if={!@covers[pack.id]} class="h-full w-full bg-hatch"></div>
-          <span class="absolute left-1.5 top-1.5 border border-neutral bg-base-100/90 px-1.5 py-0.5 font-ibm-mono text-[10px] uppercase tracking-wide text-base-content/70">
+          <span class="absolute left-1.5 top-1.5 border border-neutral bg-base-100/90 px-1.5 py-0.5 font-ibm-mono text-xs uppercase tracking-wide text-base-content/70">
             {type_label(pack.product_type)}
           </span>
           <.owned_badge
@@ -242,10 +242,10 @@ defmodule SanctumWeb.BrowseLive.Index do
           />
         </div>
         <div class="flex flex-1 flex-col gap-1 p-2.5">
-          <span class="font-anton text-[15px] uppercase leading-tight tracking-[0.02em] group-hover:text-primary">
+          <span class="font-anton text-base uppercase leading-tight tracking-[0.02em] group-hover:text-primary">
             {pack.name}
           </span>
-          <span class="mt-auto font-ibm-mono text-[11px] text-base-content/45">
+          <span class="mt-auto font-ibm-mono text-xs text-base-content/45">
             {pack.card_total || 0} cards<span :if={pack.released_on}> · {pack.released_on.year}</span>
           </span>
         </div>

--- a/lib/sanctum_web/live/browse_live/show.ex
+++ b/lib/sanctum_web/live/browse_live/show.ex
@@ -215,7 +215,7 @@ defmodule SanctumWeb.BrowseLive.Show do
           <:actions :if={@current_user}>
             <span
               :if={@owned_ids}
-              class="font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.08em] text-primary"
+              class="font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-primary"
             >
               {MapSet.size(@owned_ids)} / {@total_cards} owned
             </span>
@@ -289,7 +289,7 @@ defmodule SanctumWeb.BrowseLive.Show do
     ~H"""
     <section :if={@groups != []}>
       <h2 class={[
-        "font-anton text-[22px] uppercase tracking-[0.03em] text-primary",
+        "font-anton text-2xl uppercase tracking-[0.03em] text-primary",
         (@description && "mb-1") || "mb-4"
       ]}>
         {@title}
@@ -327,15 +327,15 @@ defmodule SanctumWeb.BrowseLive.Show do
       <div class="mb-3.5 flex flex-wrap items-baseline gap-x-3 border-b-2 border-neutral pb-2">
         <h2 class={[
           "font-anton uppercase leading-none tracking-[0.03em]",
-          @level == :top && "text-[22px] text-primary",
-          @level == :sub && "text-[17px] text-base-content/85"
+          @level == :top && "text-2xl text-primary",
+          @level == :sub && "text-lg text-base-content/85"
         ]}>
           {@title}
         </h2>
         <span :if={@subtitle} class="font-barlow-condensed text-base uppercase text-base-content/45">
           {@subtitle}
         </span>
-        <span class="ml-auto font-ibm-mono text-[11px] text-base-content/40">
+        <span class="ml-auto font-ibm-mono text-xs text-base-content/40">
           {Enum.sum_by(@cards, & &1.quantity)} cards
         </span>
       </div>

--- a/lib/sanctum_web/live/card_live/detail.ex
+++ b/lib/sanctum_web/live/card_live/detail.ex
@@ -104,18 +104,18 @@ defmodule SanctumWeb.CardLive.Detail do
 
             <!-- metadata side panel -->
             <.panel class="p-4">
-              <div class="mb-3 border-b-2 border-neutral pb-2 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+              <div class="mb-3 border-b-2 border-neutral pb-2 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
                 Card File
               </div>
 
               <div class="flex flex-col gap-3">
                 <div :if={@pack}>
-                  <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+                  <div class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/45">
                     Pack
                   </div>
                   <.link
                     navigate={~p"/browse/#{@pack.code}"}
-                    class="mt-0.5 block font-barlow-condensed text-[15px] font-semibold hover:text-primary"
+                    class="mt-0.5 block font-barlow-condensed text-base font-semibold hover:text-primary"
                   >
                     {@pack.name || @pack.code}
                   </.link>
@@ -149,7 +149,7 @@ defmodule SanctumWeb.CardLive.Detail do
 
                 <div :if={@current_user}>
                   <div class="mb-1.5 flex items-center justify-between">
-                    <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+                    <div class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/45">
                       Collection
                     </div>
                     <.owned_badge :if={@owned} />
@@ -167,7 +167,7 @@ defmodule SanctumWeb.CardLive.Detail do
                       :if={@pack}
                       phx-click="toggle_pack_owned"
                       phx-value-id={@pack.id}
-                      class="cursor-pointer text-left font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.06em] text-base-content/50 hover:text-primary"
+                      class="cursor-pointer text-left font-barlow-condensed text-xs font-bold uppercase tracking-[0.06em] text-base-content/50 hover:text-primary"
                     >
                       {if @pack_owned,
                         do: "✓ #{@pack.name || @pack.code} in collection — remove",
@@ -182,7 +182,7 @@ defmodule SanctumWeb.CardLive.Detail do
                   href={"https://marvelcdb.com/card/#{@card.code}"}
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="flex items-center gap-1.5 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/60 hover:text-primary"
+                  class="flex items-center gap-1.5 font-barlow-condensed text-sm font-bold uppercase tracking-[0.06em] text-base-content/60 hover:text-primary"
                 >
                   <.icon name="hero-arrow-top-right-on-square" class="size-3.5" /> View on MarvelCDB
                 </a>
@@ -192,7 +192,7 @@ defmodule SanctumWeb.CardLive.Detail do
 
           <!-- alternate printings -->
           <.panel :if={@alts != []} class="p-4">
-            <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+            <div class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
               Alternate Printings ({length(@alts)})
             </div>
             <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
@@ -209,12 +209,12 @@ defmodule SanctumWeb.CardLive.Detail do
                     :if={!alt.image_url}
                     class="bg-card-hatch flex h-full w-full items-center justify-center"
                   >
-                    <span class="whitespace-nowrap font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-white/[0.32]">
+                    <span class="whitespace-nowrap font-ibm-mono text-xs uppercase tracking-[0.2em] text-white/[0.32]">
                       no scan
                     </span>
                   </div>
                 </div>
-                <figcaption class="font-ibm-mono text-[10px] uppercase tracking-[0.16em] text-base-content/50">
+                <figcaption class="font-ibm-mono text-xs uppercase tracking-[0.16em] text-base-content/50">
                   {alt.code}<span :if={alt.pack}> · {alt.pack}</span>
                 </figcaption>
               </figure>
@@ -232,10 +232,10 @@ defmodule SanctumWeb.CardLive.Detail do
   defp meta(assigns) do
     ~H"""
     <div :if={@value not in [nil, ""]}>
-      <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+      <div class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/45">
         {@label}
       </div>
-      <div class="mt-0.5 font-barlow-condensed text-[15px] font-semibold">{@value}</div>
+      <div class="mt-0.5 font-barlow-condensed text-base font-semibold">{@value}</div>
     </div>
     """
   end

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -46,7 +46,7 @@ defmodule SanctumWeb.CardLive.Pool do
             class="w-full min-h-[46px] flex-none sm:w-auto sm:min-h-[46px]"
           />
         </div>
-        <div class="mt-2 flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
+        <div class="mt-2 flex items-center gap-2 whitespace-nowrap font-anton text-base uppercase tracking-[0.05em]">
           <.icon
             :if={@loading?}
             name="hero-arrow-path"
@@ -99,8 +99,8 @@ defmodule SanctumWeb.CardLive.Pool do
         :if={@count == 0}
         class="mt-2 border-dashed !border-[#2a2a30] px-6 py-12 text-center !shadow-none"
       >
-        <div class="font-bangers text-[30px] tracking-[0.02em] text-primary">No cards found</div>
-        <div class="mt-1.5 font-barlow text-[14px] text-base-content/55">
+        <div class="font-bangers text-3xl tracking-[0.02em] text-primary">No cards found</div>
+        <div class="mt-1.5 font-barlow text-sm text-base-content/55">
           Try a different search or clear your filters.
         </div>
         <.button variant="primary" phx-click="clear" class="mt-4">Clear filters</.button>

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -25,7 +25,7 @@ defmodule SanctumWeb.CardLive.Show do
       <div class="space-y-5">
         <!-- card-level info -->
         <.panel class="p-4">
-          <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+          <div class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
             Card Info
           </div>
           <div class="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
@@ -72,13 +72,13 @@ defmodule SanctumWeb.CardLive.Show do
             </div>
 
             <div class={[
-              "mt-2 font-ibm-mono text-[10px] uppercase tracking-[0.2em]",
+              "mt-2 font-ibm-mono text-xs uppercase tracking-[0.2em]",
               side.aspect_text_class
             ]}>
               {side.type_name}<span :if={side.aspect_name}> · {side.aspect_name}</span>
             </div>
-            <h2 class="mt-1 font-anton text-[30px] uppercase leading-[0.92]">{side.name}</h2>
-            <div :if={side.subname} class="font-barlow text-[14px] italic text-base-content/55">
+            <h2 class="mt-1 font-anton text-3xl uppercase leading-[0.92]">{side.name}</h2>
+            <div :if={side.subname} class="font-barlow text-sm italic text-base-content/55">
               {side.subname}
             </div>
 
@@ -86,7 +86,7 @@ defmodule SanctumWeb.CardLive.Show do
             <div :if={side.pips != []} class="mt-3 flex items-center gap-1.5">
               <span
                 :for={{color_class, glyph} <- side.pips}
-                class={["font-champions text-[18px] leading-none", color_class]}
+                class={["font-champions text-lg leading-none", color_class]}
               >
                 {glyph}
               </span>
@@ -94,14 +94,14 @@ defmodule SanctumWeb.CardLive.Show do
 
             <div
               :if={side.traits != ""}
-              class="mt-3 font-barlow-condensed text-[12px] font-semibold uppercase tracking-[0.02em] text-base-content/55"
+              class="mt-3 font-barlow-condensed text-xs font-semibold uppercase tracking-[0.02em] text-base-content/55"
             >
               {side.traits}
             </div>
 
             <div class="my-3 h-px bg-neutral"></div>
 
-            <div :if={side.text} class="font-barlow text-[14px] leading-[1.55] text-base-content/85">
+            <div :if={side.text} class="font-barlow text-sm leading-[1.55] text-base-content/85">
               {Sanctum.CardText.to_html(side.text)}
             </div>
 
@@ -124,7 +124,7 @@ defmodule SanctumWeb.CardLive.Show do
 
         <!-- alternate printings -->
         <.panel :if={@alts != []} class="p-4">
-          <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+          <div class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
             Alternate Printings ({length(@alts)})
           </div>
           <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
@@ -137,7 +137,7 @@ defmodule SanctumWeb.CardLive.Show do
                   class="h-full w-full object-cover"
                 />
               </div>
-              <figcaption class="font-ibm-mono text-[10px] uppercase tracking-[0.16em] text-base-content/50">
+              <figcaption class="font-ibm-mono text-xs uppercase tracking-[0.16em] text-base-content/50">
                 {alt.code}<span :if={alt.pack}> · {alt.pack}</span>
               </figcaption>
             </figure>
@@ -154,10 +154,10 @@ defmodule SanctumWeb.CardLive.Show do
   defp meta(assigns) do
     ~H"""
     <div :if={present?(@value)}>
-      <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+      <div class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/45">
         {@label}
       </div>
-      <div class="mt-0.5 font-barlow-condensed text-[15px] font-semibold">{@value}</div>
+      <div class="mt-0.5 font-barlow-condensed text-base font-semibold">{@value}</div>
     </div>
     """
   end
@@ -172,8 +172,8 @@ defmodule SanctumWeb.CardLive.Show do
       class="border-2 border-neutral bg-base-100 px-0.5 py-1.5 text-center"
       style={"border-top:3px solid #{@color};"}
     >
-      <div class="font-anton text-[20px] leading-[0.9]">{@value}</div>
-      <div class="mt-[3px] text-[8px] font-extrabold uppercase tracking-[0.12em] text-base-content/50">
+      <div class="font-anton text-xl leading-[0.9]">{@value}</div>
+      <div class="mt-[3px] text-xs font-extrabold uppercase tracking-[0.12em] text-base-content/50">
         {@label}
       </div>
     </div>
@@ -189,7 +189,7 @@ defmodule SanctumWeb.CardLive.Show do
 
     ~H"""
     <span class={[
-      "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
+      "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em]",
       (@badge_classes && [@badge_classes.text, @badge_classes.border]) ||
         "border-neutral text-base-content/80"
     ]}>
@@ -215,7 +215,7 @@ defmodule SanctumWeb.CardLive.Show do
         type="button"
         phx-click="start_replace"
         phx-value-side={@side.id}
-        class="flex w-full items-center justify-center gap-1.5 border-2 border-neutral bg-black px-2 py-1.5 font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.08em] text-base-content/70 hover:text-primary"
+        class="flex w-full items-center justify-center gap-1.5 border-2 border-neutral bg-black px-2 py-1.5 font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em] text-base-content/70 hover:text-primary"
       >
         <.icon name="hero-arrow-up-tray" class="size-3.5" /> Replace image
       </button>
@@ -227,14 +227,14 @@ defmodule SanctumWeb.CardLive.Show do
         phx-submit="save_image"
         class="flex flex-col gap-2 border-2 border-primary bg-black p-2"
       >
-        <.live_file_input upload={@upload} class="w-full text-[11px] text-base-content/70" />
+        <.live_file_input upload={@upload} class="w-full text-xs text-base-content/70" />
 
-        <p :for={err <- upload_errors(@upload)} class="font-ibm-mono text-[10px] text-error">
+        <p :for={err <- upload_errors(@upload)} class="font-ibm-mono text-xs text-error">
           {upload_error_to_string(err)}
         </p>
 
         <div :for={entry <- @upload.entries} class="flex flex-col gap-1">
-          <p :for={err <- upload_errors(@upload, entry)} class="font-ibm-mono text-[10px] text-error">
+          <p :for={err <- upload_errors(@upload, entry)} class="font-ibm-mono text-xs text-error">
             {upload_error_to_string(err)}
           </p>
         </div>
@@ -243,14 +243,14 @@ defmodule SanctumWeb.CardLive.Show do
           <button
             type="submit"
             disabled={@upload.entries == []}
-            class="flex-1 border-2 border-neutral bg-primary px-2 py-1 font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.08em] text-black disabled:opacity-40"
+            class="flex-1 border-2 border-neutral bg-primary px-2 py-1 font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em] text-black disabled:opacity-40"
           >
             Save
           </button>
           <button
             type="button"
             phx-click="cancel_replace"
-            class="border-2 border-neutral bg-black px-2 py-1 font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.08em] text-base-content/70 hover:text-primary"
+            class="border-2 border-neutral bg-black px-2 py-1 font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em] text-base-content/70 hover:text-primary"
           >
             Cancel
           </button>

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -648,7 +648,7 @@ defmodule SanctumWeb.DeckLive.Build do
           </div>
           <!-- two-step confirm, inline (no modal) -->
           <div :if={@confirm_delete?} class="flex items-center gap-2.5">
-            <span class="font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.08em] text-error">
+            <span class="font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-error">
               Really delete?
             </span>
             <.button phx-click="delete_deck" class="!text-error">
@@ -667,7 +667,7 @@ defmodule SanctumWeb.DeckLive.Build do
           phx-click="set_tab"
           phx-value-key={key}
           class={[
-            "-mb-[2px] cursor-pointer border-b-[3px] px-4 py-2.5 font-anton text-[14px] uppercase tracking-[0.06em] transition-colors",
+            "-mb-[2px] cursor-pointer border-b-[3px] px-4 py-2.5 font-anton text-sm uppercase tracking-[0.06em] transition-colors",
             (@tab == key && "border-primary text-primary") ||
               "border-transparent text-base-content/55 hover:text-base-content"
           ]}
@@ -706,7 +706,7 @@ defmodule SanctumWeb.DeckLive.Build do
                 class="w-full min-h-[46px] flex-none sm:w-auto sm:min-h-[46px]"
               />
             </div>
-            <div class="mt-2 flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
+            <div class="mt-2 flex items-center gap-2 whitespace-nowrap font-anton text-base uppercase tracking-[0.05em]">
               <.icon
                 :if={@loading?}
                 name="hero-arrow-path"
@@ -731,11 +731,11 @@ defmodule SanctumWeb.DeckLive.Build do
               type="button"
               data-haptic
               phx-click="add_staples"
-              class="inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 border-2 border-neutral bg-base-300 px-3.5 py-1.5 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.07em] text-base-content transition-colors hover:border-primary hover:text-primary sm:min-h-0 sm:px-3 sm:text-[12px]"
+              class="inline-flex min-h-[44px] cursor-pointer items-center gap-1.5 border-2 border-neutral bg-base-300 px-3.5 py-1.5 font-barlow-condensed text-sm font-bold uppercase tracking-[0.07em] text-base-content transition-colors hover:border-primary hover:text-primary sm:min-h-0 sm:px-3 sm:text-xs"
             >
               <.icon name="hero-bolt" class="size-3.5" /> Add Energy · Genius · Strength
             </button>
-            <span class="font-barlow-condensed text-[12px] uppercase tracking-[0.06em] text-base-content/45">
+            <span class="font-barlow-condensed text-xs uppercase tracking-[0.06em] text-base-content/45">
               {staples_status(@staples, @entries)}
             </span>
           </div>
@@ -783,10 +783,10 @@ defmodule SanctumWeb.DeckLive.Build do
             :if={@count == 0}
             class="mt-2 border-dashed !border-[#2a2a30] px-6 py-12 text-center !shadow-none"
           >
-            <div class="font-bangers text-[30px] tracking-[0.02em] text-primary">
+            <div class="font-bangers text-3xl tracking-[0.02em] text-primary">
               No cards found
             </div>
-            <div class="mt-1.5 font-barlow text-[14px] text-base-content/55">
+            <div class="mt-1.5 font-barlow text-sm text-base-content/55">
               Try a different search or clear your filters.
             </div>
             <.button variant="primary" phx-click="clear" class="mt-4">Clear filters</.button>
@@ -867,7 +867,7 @@ defmodule SanctumWeb.DeckLive.Build do
               name="description"
               phx-debounce="300"
               placeholder="Write up your deck — how it plays, key combos, mulligan advice… Markdown supported; type #cardname to link a card, $icon for symbols."
-              class="block min-h-[55vh] w-full border-[2.5px] border-line bg-black px-3.5 py-3 font-ibm-mono text-[13px] leading-relaxed text-base-content outline-none focus:border-primary"
+              class="block min-h-[55vh] w-full border-[2.5px] border-line bg-black px-3.5 py-3 font-ibm-mono text-sm leading-relaxed text-base-content outline-none focus:border-primary"
             >{@description_draft}</textarea>
             <div
               data-mention-listbox
@@ -895,7 +895,7 @@ defmodule SanctumWeb.DeckLive.Build do
               ></iframe>
             </div>
           </div>
-          <div :if={!@description_preview} class="font-barlow text-[14px] italic text-base-content/45">
+          <div :if={!@description_preview} class="font-barlow text-sm italic text-base-content/45">
             Nothing to preview yet.
           </div>
         </.panel>
@@ -977,7 +977,7 @@ defmodule SanctumWeb.DeckLive.Build do
           <div class="absolute inset-0 bg-black/60" phx-click="close_picker" aria-hidden="true"></div>
           <div class="absolute inset-x-0 bottom-0 max-h-[85dvh] overflow-hidden border-t-[3px] border-neutral bg-base-100 p-3 sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-[12vh] sm:w-[min(92vw,560px)] sm:-translate-x-1/2 sm:border-2 sm:shadow-comic-lg">
             <div class="mb-2.5 flex items-center justify-between gap-3">
-              <span class="font-anton text-[15px] uppercase tracking-[0.05em]">
+              <span class="font-anton text-base uppercase tracking-[0.05em]">
                 {(@picker == "card" && "Link a Card") || "Insert an Icon"}
               </span>
               <button
@@ -998,7 +998,7 @@ defmodule SanctumWeb.DeckLive.Build do
                 phx-debounce="150"
                 phx-mounted={JS.focus()}
                 autocomplete="off"
-                class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 font-barlow text-base text-base-content outline-none placeholder:text-base-content/35 focus:border-primary sm:text-[15px]"
+                class="w-full border-[2.5px] border-line bg-black px-3.5 py-2.5 font-barlow text-base text-base-content outline-none placeholder:text-base-content/35 focus:border-primary"
               />
             </form>
             <div class="mt-3 max-h-[calc(85dvh-9rem)] overflow-y-auto overscroll-contain pb-[max(env(safe-area-inset-bottom),0.5rem)] sm:max-h-[55vh] sm:pb-0">
@@ -1024,10 +1024,10 @@ defmodule SanctumWeb.DeckLive.Build do
                   >
                   </div>
                   <div class="min-w-0">
-                    <div class="truncate font-barlow-condensed text-[15px] font-semibold">
+                    <div class="truncate font-barlow-condensed text-base font-semibold">
                       {item.name}
                     </div>
-                    <div class="truncate font-barlow-condensed text-[13px] text-base-content/55">
+                    <div class="truncate font-barlow-condensed text-sm text-base-content/55">
                       {[item.subname, item.type] |> Enum.filter(& &1) |> Enum.join(" · ")}
                     </div>
                   </div>
@@ -1042,17 +1042,17 @@ defmodule SanctumWeb.DeckLive.Build do
                   phx-value-index={i}
                   class="flex min-h-[64px] cursor-pointer flex-col items-center justify-center gap-1.5 border-2 border-neutral bg-base-200 px-2 py-2 transition-colors hover:border-primary"
                 >
-                  <span class={["font-champions text-[22px] leading-none", icon.color]}>
+                  <span class={["font-champions text-2xl leading-none", icon.color]}>
                     {icon.glyph}
                   </span>
-                  <span class="font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.06em] text-base-content/70">
+                  <span class="font-barlow-condensed text-xs font-bold uppercase tracking-[0.06em] text-base-content/70">
                     {icon.label}
                   </span>
                 </button>
               </div>
               <div
                 :if={@picker_results == []}
-                class="px-2 py-6 text-center font-barlow text-[14px] italic text-base-content/45"
+                class="px-2 py-6 text-center font-barlow text-sm italic text-base-content/45"
               >
                 {(@picker == "card" && @picker_query == "" && "Search the card catalog…") ||
                   "No matches."}
@@ -1113,17 +1113,17 @@ defmodule SanctumWeb.DeckLive.Build do
           phx-click="toggle_panel"
           class="flex min-h-[48px] w-full cursor-pointer items-center justify-between gap-3"
         >
-          <span class="font-anton text-[19px] uppercase tracking-[0.05em]">
+          <span class="font-anton text-lg uppercase tracking-[0.05em]">
             <span class={deck_size_class(deck_size(@entries))}>{deck_size(@entries)}</span>
             <span class="text-base-content/45">/ 40–50 cards</span>
           </span>
           <span
             :if={@issues != []}
-            class="inline-flex items-center gap-1 font-barlow-condensed text-[15px] font-bold uppercase tracking-[0.07em] text-warning"
+            class="inline-flex items-center gap-1 font-barlow-condensed text-base font-bold uppercase tracking-[0.07em] text-warning"
           >
             <.icon name="hero-exclamation-triangle" class="size-4" /> {length(@issues)}
           </span>
-          <span class="inline-flex items-center gap-1.5 border-2 border-neutral bg-primary px-3.5 py-2 font-barlow-condensed text-[14px] font-bold uppercase tracking-[0.08em] text-primary-content shadow-comic-sm">
+          <span class="inline-flex items-center gap-1.5 border-2 border-neutral bg-primary px-3.5 py-2 font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-primary-content shadow-comic-sm">
             Deck <.icon name="hero-chevron-up" class="size-4" />
           </span>
         </button>
@@ -1158,17 +1158,17 @@ defmodule SanctumWeb.DeckLive.Build do
             value={@deck.title}
             phx-blur="rename"
             autocomplete="off"
-            class="min-h-[44px] w-full border-[2.5px] border-transparent bg-transparent px-1 font-anton text-[18px] uppercase tracking-[0.04em] text-base-content outline-none focus:border-line focus:bg-black sm:min-h-0"
+            class="min-h-[44px] w-full border-[2.5px] border-transparent bg-transparent px-1 font-anton text-lg uppercase tracking-[0.04em] text-base-content outline-none focus:border-line focus:bg-black sm:min-h-0"
           />
         </form>
         <div class="mt-1 flex items-center gap-2 px-1">
-          <span class="font-anton text-[14px] uppercase tracking-[0.05em]">
+          <span class="font-anton text-sm uppercase tracking-[0.05em]">
             <span class={deck_size_class(@size)}>{@size}</span>
             <span class="text-base-content/45">/ 40–50 cards</span>
           </span>
           <.link
             navigate={~p"/decks/#{@deck.id}"}
-            class="ml-auto font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.08em] text-base-content/60 hover:text-base-content"
+            class="ml-auto font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-base-content/60 hover:text-base-content"
           >
             View deck →
           </.link>
@@ -1194,14 +1194,14 @@ defmodule SanctumWeb.DeckLive.Build do
         :if={@issues != []}
         class="border-2 border-warning/40 bg-warning/5 px-3 py-2.5"
       >
-        <div class="mb-1.5 flex items-center gap-1.5 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.08em] text-warning">
+        <div class="mb-1.5 flex items-center gap-1.5 font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-warning">
           <.icon name="hero-exclamation-triangle" class="size-3.5" /> Deck issues (advisory)
         </div>
         <ul class="flex flex-col gap-1">
           <li
             :for={issue <- @issues}
             class={[
-              "font-barlow-condensed text-[13px]",
+              "font-barlow-condensed text-sm",
               (issue.severity == :error && "text-error/90") || "text-base-content/70"
             ]}
           >
@@ -1212,7 +1212,7 @@ defmodule SanctumWeb.DeckLive.Build do
 
       <!-- grouped card list (mirrors the deck page's "In This Deck") -->
       <div :for={g <- @groups}>
-        <div class="mb-2 font-anton text-[12px] uppercase tracking-[0.06em] text-primary">
+        <div class="mb-2 font-anton text-xs uppercase tracking-[0.06em] text-primary">
           {g.name} · {g.count}
         </div>
 
@@ -1265,12 +1265,12 @@ defmodule SanctumWeb.DeckLive.Build do
             <span :if={!row.hero?} class={["size-2.5 flex-none", row.aspect_bg]}></span>
             <.link
               navigate={~p"/cards/#{row.card_id}"}
-              class="min-w-0 truncate font-barlow-condensed text-[14px] font-semibold text-base-content/85 hover:text-base-content"
+              class="min-w-0 truncate font-barlow-condensed text-sm font-semibold text-base-content/85 hover:text-base-content"
             >
               {row.name}
             </.link>
             <span class="flex-1"></span>
-            <span class="flex-none font-ibm-mono text-[13px] text-base-content/50">
+            <span class="flex-none font-ibm-mono text-sm text-base-content/50">
               ×{row.qty}
             </span>
             <!-- pips column: always rendered so every row's icons share one
@@ -1278,7 +1278,7 @@ defmodule SanctumWeb.DeckLive.Build do
             <span class="flex w-8 flex-none items-center justify-end gap-1">
               <span
                 :for={{color_class, glyph} <- row.pips}
-                class={["font-champions text-[13px] leading-none", color_class]}
+                class={["font-champions text-sm leading-none", color_class]}
               >
                 {glyph}
               </span>
@@ -1322,7 +1322,7 @@ defmodule SanctumWeb.DeckLive.Build do
 
       <p
         :if={@groups == []}
-        class="font-barlow-condensed text-[14px] text-base-content/50"
+        class="font-barlow-condensed text-sm text-base-content/50"
       >
         No cards yet — tap + on a card to add it.
       </p>
@@ -1345,7 +1345,7 @@ defmodule SanctumWeb.DeckLive.Build do
       data-haptic
       title={@title}
       aria-label={@title}
-      class="flex h-11 min-w-11 cursor-pointer items-center justify-center px-2 font-barlow-condensed text-[14px] font-bold text-base-content/60 transition-colors hover:text-primary sm:h-7 sm:min-w-7 sm:px-1.5 sm:text-[13px]"
+      class="flex h-11 min-w-11 cursor-pointer items-center justify-center px-2 font-barlow-condensed text-sm font-bold text-base-content/60 transition-colors hover:text-primary sm:h-7 sm:min-w-7 sm:px-1.5"
     >
       {render_slot(@inner_block)}
     </button>

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -55,7 +55,7 @@ defmodule SanctumWeb.DeckLive.Index do
             class="w-full min-h-[46px] flex-none sm:w-auto sm:min-h-[46px]"
           />
         </div>
-        <div class="mt-2 flex items-center gap-2 whitespace-nowrap font-anton text-[15px] uppercase tracking-[0.05em]">
+        <div class="mt-2 flex items-center gap-2 whitespace-nowrap font-anton text-base uppercase tracking-[0.05em]">
           <.icon
             :if={@loading?}
             name="hero-arrow-path"
@@ -77,7 +77,7 @@ defmodule SanctumWeb.DeckLive.Index do
         hide={(@current_user && []) || ["mine"]}
       >
         <:body_extra>
-          <h3 class="mb-2.5 font-anton text-[13px] uppercase tracking-[0.08em] text-base-content/45">
+          <h3 class="mb-2.5 font-anton text-sm uppercase tracking-[0.08em] text-base-content/45">
             Sort
           </h3>
           <div class="flex flex-wrap gap-1.5" role="radiogroup" aria-label="Sort decks">
@@ -131,32 +131,32 @@ defmodule SanctumWeb.DeckLive.Index do
                 <span
                   :for={a <- deck.aspects}
                   class={[
-                    "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
+                    "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em]",
                     a.text,
                     a.border
                   ]}
                 >
                   {a.label}
                 </span>
-                <span class="border-2 border-neutral bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em] text-base-content/70">
+                <span class="border-2 border-neutral bg-black px-2 py-0.5 font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em] text-base-content/70">
                   {deck.source_label}
                 </span>
               </div>
 
-              <div class="mt-2 break-words font-anton text-[26px] uppercase leading-[0.95]">
+              <div class="mt-2 break-words font-anton text-2xl uppercase leading-[0.95]">
                 {deck.title}
               </div>
 
               <div
                 :if={deck.tagline}
-                class="mt-1.5 break-words font-barlow text-[14px] leading-[1.42] text-base-content/60"
+                class="mt-1.5 break-words font-barlow text-sm leading-[1.42] text-base-content/60"
               >
                 {deck.tagline}
               </div>
 
               <div :if={deck.author} class="mt-auto flex items-center gap-2 pt-3">
                 <.avatar name={deck.author} url={deck.author_avatar} />
-                <span class="font-barlow-condensed text-[13px] font-bold text-primary">
+                <span class="font-barlow-condensed text-sm font-bold text-primary">
                   {deck.author}
                 </span>
               </div>
@@ -165,12 +165,12 @@ defmodule SanctumWeb.DeckLive.Index do
             <div class="flex flex-none items-center gap-4 border-t-2 border-neutral pt-3 sm:w-[120px] sm:flex-col sm:items-start sm:justify-center sm:gap-2 sm:border-l-2 sm:border-t-0 sm:pl-4 sm:pt-0">
               <.uniqueness_meter percentile={deck.uniqueness} class="w-[110px] sm:w-full" />
               <div>
-                <div class="font-anton text-[26px] leading-none">{deck.total_card_count}</div>
-                <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                <div class="font-anton text-2xl leading-none">{deck.total_card_count}</div>
+                <div class="mt-1 font-barlow-condensed text-xs font-bold uppercase tracking-[0.1em] text-base-content/50">
                   Cards
                 </div>
               </div>
-              <div class="ml-auto font-ibm-mono text-[11px] leading-[1.5] text-base-content/40 sm:ml-0">
+              <div class="ml-auto font-ibm-mono text-xs leading-[1.5] text-base-content/40 sm:ml-0">
                 {deck.updated}
               </div>
             </div>
@@ -183,8 +183,8 @@ defmodule SanctumWeb.DeckLive.Index do
         :if={@count == 0}
         class="mt-2 border-dashed !border-[#2a2a30] px-6 py-12 text-center !shadow-none"
       >
-        <div class="font-bangers text-[30px] tracking-[0.02em] text-primary">No decks found</div>
-        <div class="mt-1.5 font-barlow text-[14px] text-base-content/55">
+        <div class="font-bangers text-3xl tracking-[0.02em] text-primary">No decks found</div>
+        <div class="mt-1.5 font-barlow text-sm text-base-content/55">
           Try a different search or clear your filters.
         </div>
         <.button variant="primary" phx-click="clear" class="mt-4">Clear filters</.button>

--- a/lib/sanctum_web/live/deck_live/new.ex
+++ b/lib/sanctum_web/live/deck_live/new.ex
@@ -169,13 +169,13 @@ defmodule SanctumWeb.DeckLive.New do
       >
         <div class="mx-auto flex max-w-3xl flex-col gap-3">
           <div class="flex items-center justify-between gap-3">
-            <span class="font-anton text-[15px] uppercase tracking-[0.05em]">
+            <span class="font-anton text-base uppercase tracking-[0.05em]">
               {@selected.name}
             </span>
             <button
               type="button"
               phx-click="clear_hero"
-              class="font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.08em] text-base-content/60 hover:text-base-content"
+              class="font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-base-content/60 hover:text-base-content"
             >
               Change hero
             </button>
@@ -200,7 +200,7 @@ defmodule SanctumWeb.DeckLive.New do
             >
               {label}
             </.filter_pill>
-            <span class="ml-1 font-barlow-condensed text-[12px] uppercase tracking-[0.06em] text-base-content/45">
+            <span class="ml-1 font-barlow-condensed text-xs uppercase tracking-[0.06em] text-base-content/45">
               none = basic deck
             </span>
           </div>

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -64,10 +64,10 @@ defmodule SanctumWeb.DeckLive.Show do
             </div>
 
             <div class="flex min-w-0 flex-1 flex-col">
-              <div class="font-ibm-mono text-[11px] uppercase tracking-[0.25em] text-primary">
+              <div class="font-ibm-mono text-xs uppercase tracking-[0.25em] text-primary">
                 {@cover.source_label} · {@cover.hero_name}
               </div>
-              <h1 class="mt-1.5 font-anton text-[34px] uppercase leading-[0.9] [text-wrap:balance] sm:text-[46px] sm:leading-[0.88]">
+              <h1 class="mt-1.5 font-anton text-4xl uppercase leading-[0.9] [text-wrap:balance] sm:text-5xl sm:leading-[0.88]">
                 {@deck.title}
               </h1>
 
@@ -75,7 +75,7 @@ defmodule SanctumWeb.DeckLive.Show do
                 <span
                   :for={a <- @cover.aspects}
                   class={[
-                    "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.08em]",
+                    "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em]",
                     a.text,
                     a.border
                   ]}
@@ -86,21 +86,21 @@ defmodule SanctumWeb.DeckLive.Show do
 
               <div class="mt-4 flex flex-wrap items-end gap-x-6 gap-y-3">
                 <div>
-                  <div class="font-anton text-[30px] leading-none">{@cover.total_cards}</div>
-                  <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                  <div class="font-anton text-3xl leading-none">{@cover.total_cards}</div>
+                  <div class="mt-1 font-barlow-condensed text-xs font-bold uppercase tracking-[0.1em] text-base-content/50">
                     Cards
                   </div>
                 </div>
                 <div>
-                  <div class="font-anton text-[30px] leading-none">{@cover.unique_cards}</div>
-                  <div class="mt-1 font-barlow-condensed text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/50">
+                  <div class="font-anton text-3xl leading-none">{@cover.unique_cards}</div>
+                  <div class="mt-1 font-barlow-condensed text-xs font-bold uppercase tracking-[0.1em] text-base-content/50">
                     Unique
                   </div>
                 </div>
                 <.uniqueness_meter percentile={@cover.uniqueness} size="lg" class="self-center" />
                 <div :if={@cover.author} class="flex items-center gap-2 self-center">
                   <.avatar name={@cover.author} url={@cover.author_avatar} size="md" />
-                  <span class="font-barlow-condensed text-[13px] font-bold text-primary">
+                  <span class="font-barlow-condensed text-sm font-bold text-primary">
                     {@cover.author}
                   </span>
                 </div>
@@ -118,7 +118,7 @@ defmodule SanctumWeb.DeckLive.Show do
             class="grid items-start gap-5 lg:grid-cols-[1.4fr_1fr]"
           >
             <.panel class="min-w-0 p-5">
-              <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+              <div class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
                 Deck Notes
               </div>
               <div :if={@writeup} class="space-y-4">
@@ -135,7 +135,7 @@ defmodule SanctumWeb.DeckLive.Show do
                   ></iframe>
                 </div>
               </div>
-              <div :if={!@writeup} class="font-barlow text-[14px] italic text-base-content/45">
+              <div :if={!@writeup} class="font-barlow text-sm italic text-base-content/45">
                 No writeup for this deck.
               </div>
             </.panel>
@@ -143,8 +143,8 @@ defmodule SanctumWeb.DeckLive.Show do
             <div class="min-w-0 space-y-5">
               <.panel class="p-4">
                 <div class="mb-3 flex items-center gap-2 border-b-2 border-neutral pb-2">
-                  <div class="font-anton text-[17px] uppercase tracking-[0.05em]">In This Deck</div>
-                  <div class="ml-auto font-ibm-mono text-[11px] text-base-content/45">
+                  <div class="font-anton text-lg uppercase tracking-[0.05em]">In This Deck</div>
+                  <div class="ml-auto font-ibm-mono text-xs text-base-content/45">
                     {@cover.total_cards} cards<span
                       :if={@owned_summary}
                       class="text-primary"
@@ -167,7 +167,7 @@ defmodule SanctumWeb.DeckLive.Show do
                 </div>
 
                 <div :for={g <- @groups} class="mb-4 last:mb-0">
-                  <div class="mb-2 font-anton text-[12px] uppercase tracking-[0.06em] text-primary">
+                  <div class="mb-2 font-anton text-xs uppercase tracking-[0.06em] text-primary">
                     {g.name} · {g.count}
                   </div>
                   <div
@@ -212,20 +212,20 @@ defmodule SanctumWeb.DeckLive.Show do
                         class="size-3 flex-none text-aspect-hero"
                       />
                       <span :if={c.aspect_key != :hero} class={["size-2.5 flex-none", c.aspect_bg]}></span>
-                      <span class="min-w-0 truncate font-barlow-condensed text-[14px] font-semibold text-base-content/85">
+                      <span class="min-w-0 truncate font-barlow-condensed text-sm font-semibold text-base-content/85">
                         {c.name}
                       </span>
                       <span :if={c.owned == false} title="Not in your collection" class="flex-none">
                         <.icon name="hero-x-mark" class="size-3 text-error" />
                       </span>
                       <span class="flex-1"></span>
-                      <span class="flex-none font-ibm-mono text-[13px] text-base-content/50">
+                      <span class="flex-none font-ibm-mono text-sm text-base-content/50">
                         ×{c.qty}
                       </span>
                       <span class="flex w-8 flex-none items-center justify-end gap-1">
                         <span
                           :for={{color_class, glyph} <- c.pips}
-                          class={["font-champions text-[14px] leading-none", color_class]}
+                          class={["font-champions text-sm leading-none", color_class]}
                         >
                           {glyph}
                         </span>
@@ -237,7 +237,7 @@ defmodule SanctumWeb.DeckLive.Show do
 
               <!-- similar decks -->
               <.panel :if={@similar != []} class="p-4">
-                <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+                <div class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
                   Similar Decks
                 </div>
                 <div class="space-y-2">
@@ -247,14 +247,14 @@ defmodule SanctumWeb.DeckLive.Show do
                     class="mc-tile flex items-center gap-3 border-2 border-neutral bg-black p-2.5 shadow-comic-sm"
                   >
                     <div class="min-w-0 flex-1">
-                      <div class="truncate font-anton text-[16px] uppercase leading-tight">
+                      <div class="truncate font-anton text-base uppercase leading-tight">
                         {s.title}
                       </div>
                       <div class="mt-1 flex flex-wrap gap-1">
                         <span
                           :for={a <- s.aspects}
                           class={[
-                            "border bg-base-200 px-1.5 font-barlow-condensed text-[10px] font-bold uppercase tracking-[0.06em]",
+                            "border bg-base-200 px-1.5 font-barlow-condensed text-xs font-bold uppercase tracking-[0.06em]",
                             a.text,
                             a.border
                           ]}
@@ -264,8 +264,8 @@ defmodule SanctumWeb.DeckLive.Show do
                       </div>
                     </div>
                     <div class="flex-none text-right">
-                      <div class="font-anton text-[20px] leading-none text-primary">{s.match}%</div>
-                      <div class="font-barlow-condensed text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/45">
+                      <div class="font-anton text-xl leading-none text-primary">{s.match}%</div>
+                      <div class="font-barlow-condensed text-xs font-bold uppercase tracking-[0.1em] text-base-content/45">
                         Match
                       </div>
                     </div>
@@ -275,20 +275,20 @@ defmodule SanctumWeb.DeckLive.Show do
 
               <!-- details -->
               <.panel class="p-4">
-                <div class="mb-3 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/50">
+                <div class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
                   Details
                 </div>
                 <div class="grid grid-cols-2 gap-x-6 gap-y-3">
                   <.meta label="Source" value={@cover.source_label} />
                   <div :if={mcdb_url(@deck)}>
-                    <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+                    <div class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/45">
                       MarvelCDB
                     </div>
                     <a
                       href={mcdb_url(@deck)}
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="mt-0.5 inline-flex items-center gap-1 font-barlow-condensed text-[15px] font-semibold text-primary hover:underline"
+                      class="mt-0.5 inline-flex items-center gap-1 font-barlow-condensed text-base font-semibold text-primary hover:underline"
                     >
                       {@deck.mcdb_type}/{@deck.mcdb_id}
                       <.icon name="hero-arrow-top-right-on-square" class="size-3" />
@@ -314,10 +314,10 @@ defmodule SanctumWeb.DeckLive.Show do
   defp meta(assigns) do
     ~H"""
     <div :if={@value not in [nil, ""]}>
-      <div class="font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+      <div class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/45">
         {@label}
       </div>
-      <div class="mt-0.5 font-barlow-condensed text-[15px] font-semibold">{@value}</div>
+      <div class="mt-0.5 font-barlow-condensed text-base font-semibold">{@value}</div>
     </div>
     """
   end

--- a/lib/sanctum_web/live/dev_live/stat_badges.ex
+++ b/lib/sanctum_web/live/dev_live/stat_badges.ex
@@ -91,7 +91,7 @@ defmodule SanctumWeb.DevLive.StatBadges do
               consequential={@consequential}
               star={@star}
             />
-            <span class="text-[11px] uppercase tracking-widest text-white/50 font-bold">{stat}</span>
+            <span class="text-xs uppercase tracking-widest text-white/50 font-bold">{stat}</span>
           </div>
         </div>
       </section>
@@ -119,17 +119,17 @@ defmodule SanctumWeb.DevLive.StatBadges do
         <div class="bg-base-200 bg-halftone flex flex-wrap items-center gap-8 rounded-xl p-8">
           <div class="flex flex-col items-center gap-2">
             <.health_badge value={@value} size={@size} />
-            <span class="text-[11px] uppercase tracking-widest text-white/50 font-bold">hp</span>
+            <span class="text-xs uppercase tracking-widest text-white/50 font-bold">hp</span>
           </div>
           <div class="flex flex-col items-center gap-2">
             <.health_badge value="12" size={@size} />
-            <span class="text-[11px] uppercase tracking-widest text-white/50 font-bold">
+            <span class="text-xs uppercase tracking-widest text-white/50 font-bold">
               two digits
             </span>
           </div>
           <div class="flex flex-col items-center gap-2">
             <.health_badge value={@value} size={@size} player />
-            <span class="text-[11px] uppercase tracking-widest text-white/50 font-bold">
+            <span class="text-xs uppercase tracking-widest text-white/50 font-bold">
               per player
             </span>
           </div>

--- a/lib/sanctum_web/live/global_search_component.ex
+++ b/lib/sanctum_web/live/global_search_component.ex
@@ -79,7 +79,7 @@ defmodule SanctumWeb.GlobalSearchComponent do
               <div :if={@groups != []} data-gs-content>
                 <div :for={group <- @groups}>
                   <div class="flex items-baseline justify-between border-b border-line bg-base-300/60 px-3 py-1">
-                    <span class="font-barlow-condensed text-[12px] font-bold uppercase tracking-[0.14em] text-base-content/60">
+                    <span class="font-barlow-condensed text-xs font-bold uppercase tracking-[0.14em] text-base-content/60">
                       {group.label}
                     </span>
                     <.link
@@ -87,7 +87,7 @@ defmodule SanctumWeb.GlobalSearchComponent do
                       navigate={group.more_url}
                       id={"gs-more-#{group.type}"}
                       data-gs-nav
-                      class="gs-more font-barlow-condensed text-[12px] uppercase tracking-wide text-primary/80 hover:text-primary"
+                      class="gs-more font-barlow-condensed text-xs uppercase tracking-wide text-primary/80 hover:text-primary"
                     >
                       all {String.downcase(group.label)} results →
                     </.link>
@@ -113,14 +113,14 @@ defmodule SanctumWeb.GlobalSearchComponent do
               <div
                 :if={@groups == [] and @loading?}
                 data-gs-content
-                class="px-3 py-2.5 font-barlow text-[13px] text-base-content/50"
+                class="px-3 py-2.5 font-barlow text-sm text-base-content/50"
               >
                 Searching…
               </div>
               <div
                 :if={@groups == [] and not @loading? and String.trim(@query) != ""}
                 data-gs-content
-                class="px-3 py-2.5 font-barlow text-[13px] text-base-content/50"
+                class="px-3 py-2.5 font-barlow text-sm text-base-content/50"
               >
                 <span :if={@diagnostics == []}>No matches for this search.</span>
                 <span :if={@diagnostics != []} class="text-primary/90">

--- a/lib/sanctum_web/live/profile_live/index.ex
+++ b/lib/sanctum_web/live/profile_live/index.ex
@@ -19,7 +19,7 @@ defmodule SanctumWeb.ProfileLive.Index do
     ~H"""
     <Layouts.app current_user={@current_user} flash={@flash} active_tab={:profile}>
       <div class="mx-auto max-w-xl">
-        <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-[42px]">
+        <h1 class="font-anton text-3xl uppercase leading-[0.9] tracking-[0.005em] md:text-4xl">
           Profile
         </h1>
 
@@ -32,7 +32,7 @@ defmodule SanctumWeb.ProfileLive.Index do
               size="lg"
             />
             <div class="min-w-0">
-              <div class="truncate font-bangers text-[26px] leading-none tracking-wide text-primary">
+              <div class="truncate font-bangers text-2xl leading-none tracking-wide text-primary">
                 {display_name(@current_user)}
               </div>
               <div class="mt-1.5 truncate font-ibm-mono text-xs text-base-content/50">
@@ -49,7 +49,7 @@ defmodule SanctumWeb.ProfileLive.Index do
               autocomplete="username"
               placeholder="e.g. web_head"
             />
-            <p class="mt-2 font-barlow-condensed text-[13px] text-base-content/50">
+            <p class="mt-2 font-barlow-condensed text-sm text-base-content/50">
               3–20 characters: letters, numbers, and underscores. Shown on your decks.
             </p>
             <.button variant="primary" type="submit" class="mt-4">
@@ -62,14 +62,14 @@ defmodule SanctumWeb.ProfileLive.Index do
              product in the catalog with a checkbox — the one-place manager. -->
         <.panel class="mt-6 p-5">
           <div class="flex items-baseline justify-between border-b-2 border-neutral pb-3">
-            <h2 class="font-anton text-[20px] uppercase tracking-[0.03em]">Collection</h2>
-            <span class="font-ibm-mono text-[11px] text-base-content/45">
+            <h2 class="font-anton text-xl uppercase tracking-[0.03em]">Collection</h2>
+            <span class="font-ibm-mono text-xs text-base-content/45">
               {@owned_card_count} cards owned
             </span>
           </div>
 
           <div :for={group <- @collection_groups} class="mt-4">
-            <div class="mb-1.5 font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/45">
+            <div class="mb-1.5 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/45">
               {group.label} · {group.owned_count} / {length(group.packs)}
             </div>
             <div class="divide-y divide-neutral/50">
@@ -85,12 +85,12 @@ defmodule SanctumWeb.ProfileLive.Index do
                   class="checkbox checkbox-sm"
                 />
                 <span class={[
-                  "min-w-0 flex-1 truncate font-barlow-condensed text-[15px] font-semibold",
+                  "min-w-0 flex-1 truncate font-barlow-condensed text-base font-semibold",
                   !MapSet.member?(@owned_pack_ids, pack.id) && "text-base-content/60"
                 ]}>
                   {pack.name || pack.code}
                 </span>
-                <span :if={pack.released_on} class="font-ibm-mono text-[11px] text-base-content/40">
+                <span :if={pack.released_on} class="font-ibm-mono text-xs text-base-content/40">
                   {pack.released_on.year}
                 </span>
                 <.link
@@ -106,7 +106,7 @@ defmodule SanctumWeb.ProfileLive.Index do
 
           <p
             :if={@override_counts != %{}}
-            class="mt-4 font-barlow-condensed text-[13px] text-base-content/50"
+            class="mt-4 font-barlow-condensed text-sm text-base-content/50"
           >
             <span :if={@override_counts[:owned]}>
               Plus {@override_counts[:owned]} individually added {(@override_counts[:owned] == 1 &&
@@ -119,7 +119,7 @@ defmodule SanctumWeb.ProfileLive.Index do
 
           <.link
             navigate={~p"/browse"}
-            class="mt-4 inline-flex items-center gap-1 font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.06em] text-base-content/60 hover:text-primary"
+            class="mt-4 inline-flex items-center gap-1 font-barlow-condensed text-sm font-bold uppercase tracking-[0.06em] text-base-content/60 hover:text-primary"
           >
             Fine-tune individual cards in Browse <.icon name="hero-arrow-right" class="size-3.5" />
           </.link>

--- a/lib/sanctum_web/live/search_help_live.ex
+++ b/lib/sanctum_web/live/search_help_live.ex
@@ -40,7 +40,7 @@ defmodule SanctumWeb.SearchHelpLive do
       <div class="max-w-4xl space-y-8">
         <section>
           <.section_title>Basics</.section_title>
-          <div class="space-y-2.5 font-barlow text-[15px] leading-relaxed text-base-content/85">
+          <div class="space-y-2.5 font-barlow text-base leading-relaxed text-base-content/85">
             <p>
               A bare word like <.q c="spider" /> searches card names and subtitles
               (deck titles and heroes on the deck browser). Use <.q c={~s("quotes")} />
@@ -99,7 +99,7 @@ defmodule SanctumWeb.SearchHelpLive do
 
         <section id="global">
           <.section_title>Global search</.section_title>
-          <div class="space-y-2.5 font-barlow text-[15px] leading-relaxed text-base-content/85">
+          <div class="space-y-2.5 font-barlow text-base leading-relaxed text-base-content/85">
             <p>
               The Search button (in the sidebar or the mobile header — or press <.q c="⌘K" />
               anywhere) opens a search palette that searches the whole
@@ -151,7 +151,7 @@ defmodule SanctumWeb.SearchHelpLive do
 
   defp section_title(assigns) do
     ~H"""
-    <h2 class="mb-2.5 font-anton text-[19px] uppercase tracking-[0.05em] text-primary">
+    <h2 class="mb-2.5 font-anton text-lg uppercase tracking-[0.05em] text-primary">
       {render_slot(@inner_block)}
     </h2>
     """
@@ -160,7 +160,7 @@ defmodule SanctumWeb.SearchHelpLive do
   # An inline query snippet.
   defp q(assigns) do
     ~H"""
-    <code class="whitespace-nowrap bg-base-300 px-1.5 py-0.5 font-mono text-[13px] text-base-content">{@c}</code>
+    <code class="whitespace-nowrap bg-base-300 px-1.5 py-0.5 font-mono text-sm text-base-content">{@c}</code>
     """
   end
 
@@ -169,7 +169,7 @@ defmodule SanctumWeb.SearchHelpLive do
     ~H"""
     <.link
       navigate={"#{@base_path}?#{URI.encode_query(query: @query)}"}
-      class="whitespace-nowrap bg-base-300 px-1.5 py-0.5 font-mono text-[13px] text-secondary underline decoration-secondary/40 underline-offset-2 hover:text-primary"
+      class="whitespace-nowrap bg-base-300 px-1.5 py-0.5 font-mono text-sm text-secondary underline decoration-secondary/40 underline-offset-2 hover:text-primary"
     >
       {@query}
     </.link>
@@ -196,7 +196,7 @@ defmodule SanctumWeb.SearchHelpLive do
             </span>
           </td>
           <td class="!whitespace-normal">{matches(field)}</td>
-          <td class="whitespace-nowrap font-mono text-[12.5px]">{ops(field)}</td>
+          <td class="whitespace-nowrap font-mono text-sm">{ops(field)}</td>
           <td>
             <.try_link :if={field.example} query={field.example} base_path={@base_path} />
           </td>

--- a/lib/sanctum_web/live/stats_live/index.ex
+++ b/lib/sanctum_web/live/stats_live/index.ex
@@ -172,13 +172,13 @@ defmodule SanctumWeb.StatsLive.Index do
       >
       </div>
       <details class="mt-3">
-        <summary class="cursor-pointer font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+        <summary class="cursor-pointer font-ibm-mono text-xs uppercase tracking-[0.15em] text-base-content/55">
           View data
         </summary>
         <div class="mt-2 max-h-64 overflow-y-auto">
           <table class="font-barlow-condensed text-sm">
             <thead>
-              <tr class="font-ibm-mono text-[11px] uppercase tracking-[0.15em] text-base-content/55">
+              <tr class="font-ibm-mono text-xs uppercase tracking-[0.15em] text-base-content/55">
                 {render_slot(@table_head)}
               </tr>
             </thead>


### PR DESCRIPTION
Replaces arbitrary pixel/rem font sizes (text-[11px], 0.9rem, …) with
the --text-* scale across the app shell, components, live views, and
the deck-writeup/query-input CSS.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>