### PR TITLE
refactor(ui): shared components for ChampionsIcons glyphs

### DIFF
--- a/lib/sanctum_web.ex
+++ b/lib/sanctum_web.ex
@@ -88,6 +88,7 @@ defmodule SanctumWeb do
       import SanctumWeb.CoreComponents
       import SanctumWeb.Components.Avatar
       import SanctumWeb.Components.Card
+      import SanctumWeb.Components.ChampionsIcons
       import SanctumWeb.Components.Collection
       import SanctumWeb.Components.DeckBuilder
       import SanctumWeb.Components.Skeleton

--- a/lib/sanctum_web/components/card.ex
+++ b/lib/sanctum_web/components/card.ex
@@ -13,6 +13,8 @@ defmodule SanctumWeb.Components.Card do
   """
   use Phoenix.Component
 
+  import SanctumWeb.Components.ChampionsIcons
+
   # Tailwind color-class trio per aspect (backed by the --color-aspect-*
   # tokens in app.css). Full literal class names so Tailwind's source
   # scanner detects them; do not build these by interpolation.
@@ -45,13 +47,6 @@ defmodule SanctumWeb.Components.Card do
       bg: "bg-aspect-encounter",
       border: "border-aspect-encounter"
     }
-  }
-
-  @res %{
-    "energy" => {"text-res-energy", "E"},
-    "mental" => {"text-res-mental", "M"},
-    "physical" => {"text-res-physical", "P"},
-    "wild" => {"text-res-wild", "W"}
   }
 
   @dims %{
@@ -113,11 +108,7 @@ defmodule SanctumWeb.Components.Card do
     aspect_classes = aspect_classes(aspect)
     dims = Map.get(@dims, assigns.size, @dims["md"])
 
-    pips =
-      assigns.resources
-      |> Enum.map(&to_s/1)
-      |> Enum.map(&Map.get(@res, &1))
-      |> Enum.reject(&is_nil/1)
+    pips = resource_pips(assigns.resources)
 
     has_cost? = assigns.show_cost and assigns.cost not in [nil, ""] and type != "resource"
 
@@ -199,13 +190,11 @@ defmodule SanctumWeb.Components.Card do
 
       <!-- resource pips -->
       <div :if={@show_res?} class="absolute right-[6px] top-[6px] z-[3] flex gap-[3px]">
-        <span
-          :for={{color_class, glyph} <- @pips}
-          class={["font-champions leading-none", color_class]}
+        <.champions_icon
+          :for={token <- @pips}
+          token={token}
           style={"font-size:#{@dims.res}px;text-shadow:0 1px 2px rgba(0,0,0,.95),0 0 3px rgba(0,0,0,.8);"}
-        >
-          {glyph}
-        </span>
+        />
       </div>
 
       <!-- quantity badge -->
@@ -240,19 +229,6 @@ defmodule SanctumWeb.Components.Card do
       </div>
     </div>
     """
-  end
-
-  @doc """
-  Maps a list of resource atoms/strings to `{text_color_class, glyph}` tuples
-  for rendering ChampionsIcons pips outside a card face (e.g. a detail row).
-  The class (e.g. `"text-res-energy"`) goes on the element's `class`, not an
-  inline style. Unknown resources are dropped.
-  """
-  def resource_pips(resources) do
-    resources
-    |> Enum.map(&to_s/1)
-    |> Enum.map(&Map.get(@res, &1))
-    |> Enum.reject(&is_nil/1)
   end
 
   @doc """

--- a/lib/sanctum_web/components/card_side_tile.ex
+++ b/lib/sanctum_web/components/card_side_tile.ex
@@ -11,6 +11,7 @@ defmodule SanctumWeb.Components.CardSideTile do
   use Phoenix.Component
 
   import SanctumWeb.Components.Card
+  import SanctumWeb.Components.ChampionsIcons
   import SanctumWeb.Components.Collection
   import SanctumWeb.Components.HandSizeBadge
   import SanctumWeb.Components.HealthBadge
@@ -187,12 +188,7 @@ defmodule SanctumWeb.Components.CardSideTile do
           :if={@side.pips != [] or (@side.is_hero and @side.hand_size)}
           class={["flex items-center gap-1", (@lg? && "mt-4") || "mt-2.5"]}
         >
-          <span
-            :for={{color_class, glyph} <- @side.pips}
-            class={["font-champions text-2xl leading-none", color_class]}
-          >
-            {glyph}
-          </span>
+          <.champions_icon :for={token <- @side.pips} token={token} class="text-2xl" />
           <.hand_size_badge
             :if={@side.is_hero and @side.hand_size}
             value={@side.hand_size}
@@ -241,9 +237,7 @@ defmodule SanctumWeb.Components.CardSideTile do
     ~H"""
     <div class="flex skew-x-[9deg] items-baseline gap-0.5 px-2 font-elektra-med text-2xl/snug">
       {scheme_value(@value, @sign)}
-      <span :if={@per_player} class="font-champions text-xs leading-none text-white">
-        v
-      </span>
+      <.player_icon :if={@per_player} class="text-xs text-white" />
     </div>
     """
   end

--- a/lib/sanctum_web/components/champions_icons.ex
+++ b/lib/sanctum_web/components/champions_icons.ex
@@ -1,0 +1,162 @@
+defmodule SanctumWeb.Components.ChampionsIcons do
+  @moduledoc """
+  Function components for the ChampionsIcons glyph font — one component per
+  icon, so call sites never hard-code `font-champions` spans or raw glyph
+  letters.
+
+  Each component renders an inline `<span>` with the right glyph and (for the
+  four resources) its `text-res-*` color. Icons size with `font-size`, so pass
+  a text-size class: `<.energy_icon class="text-2xl" />`. `normal-case` is
+  baked in because the glyph letters are case-sensitive — an inherited
+  `uppercase` would swap them for different icons.
+
+  For dynamic icon lists (resource pips, the icon picker) use the
+  `champions_icon` dispatcher with a token from `Sanctum.CardText.icons/0`,
+  which remains the single source of truth for the token → glyph map. The two
+  glyphs with no card-text token — the per-player marker and the stat star —
+  live here under the `"player"` and `"stat_star"` tokens.
+
+  Not covered here: the SVG badges (`StatBadge`, `HealthBadge`) draw their
+  glyphs as `<tspan>`s inside SVG `<text>`, where an HTML span can't go.
+  """
+  use Phoenix.Component
+
+  # Card-text tokens (from CardText, the source of truth) plus the two
+  # glyphs that only appear outside card text: the per-player marker ("v",
+  # threat plates / health badges) and the stat-effect star ("s", stat badges).
+  @glyphs Map.merge(Sanctum.CardText.icons(), %{
+            "player" => {"v", nil},
+            "stat_star" => {"s", nil}
+          })
+
+  @resources ~w(energy mental physical wild)
+
+  @doc """
+  Renders the icon for a ChampionsIcons token — for call sites that pick the
+  icon at runtime (resource pips, the icon picker). Unknown tokens render
+  nothing, mirroring `resource_pips/1` dropping unknown resources.
+
+  ## Examples
+
+      <.champions_icon token="energy" class="text-2xl" />
+      <.champions_icon :for={token <- @side.pips} token={token} class="text-sm" />
+  """
+  attr :token, :any, required: true, doc: "token atom/string from Sanctum.CardText.icons/0"
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  def champions_icon(assigns) do
+    case Map.get(@glyphs, to_string(assigns.token)) do
+      {glyph, color} ->
+        assigns = assign(assigns, glyph: glyph, color: color)
+
+        ~H"""
+        <span class={["font-champions normal-case leading-none", @color, @class]} {@rest}>
+          {@glyph}
+        </span>
+        """
+
+      nil ->
+        ~H""
+    end
+  end
+
+  @doc "The energy resource icon (`[energy]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def energy_icon(assigns), do: icon(assigns, "energy")
+
+  @doc "The mental resource icon (`[mental]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def mental_icon(assigns), do: icon(assigns, "mental")
+
+  @doc "The physical resource icon (`[physical]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def physical_icon(assigns), do: icon(assigns, "physical")
+
+  @doc "The wild resource icon (`[wild]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def wild_icon(assigns), do: icon(assigns, "wild")
+
+  @doc "The resource-cost icon (`[cost]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def cost_icon(assigns), do: icon(assigns, "cost")
+
+  @doc "The card-text star icon (`[star]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def star_icon(assigns), do: icon(assigns, "star")
+
+  @doc "The boost icon (`[boost]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def boost_icon(assigns), do: icon(assigns, "boost")
+
+  @doc "The crisis icon (`[crisis]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def crisis_icon(assigns), do: icon(assigns, "crisis")
+
+  @doc "The hazard icon (`[hazard]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def hazard_icon(assigns), do: icon(assigns, "hazard")
+
+  @doc "The acceleration icon (`[acceleration]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def acceleration_icon(assigns), do: icon(assigns, "acceleration")
+
+  @doc "The amplify icon (`[amplify]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def amplify_icon(assigns), do: icon(assigns, "amplify")
+
+  @doc "The per-hero icon (`[per_hero]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def per_hero_icon(assigns), do: icon(assigns, "per_hero")
+
+  @doc "The per-group icon (`[per_group]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def per_group_icon(assigns), do: icon(assigns, "per_group")
+
+  @doc "The uniqueness icon (`[unique]`)."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def unique_icon(assigns), do: icon(assigns, "unique")
+
+  @doc "The per-player marker — scheme threat plates, health badges."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def player_icon(assigns), do: icon(assigns, "player")
+
+  @doc "The stat-effect star — marks a stat with an associated special effect."
+  attr :class, :any, default: nil
+  attr :rest, :global
+  def stat_star_icon(assigns), do: icon(assigns, "stat_star")
+
+  defp icon(assigns, token) do
+    {glyph, color} = Map.fetch!(@glyphs, token)
+    assigns = assign(assigns, glyph: glyph, color: color)
+
+    ~H"""
+    <span class={["font-champions normal-case leading-none", @color, @class]} {@rest}>
+      {@glyph}
+    </span>
+    """
+  end
+
+  @doc """
+  Normalizes a list of resource atoms/strings into pip tokens for
+  `champions_icon/1` — one entry per pip, unknown resources dropped.
+  """
+  def resource_pips(resources) do
+    resources |> Enum.map(&to_string/1) |> Enum.filter(&(&1 in @resources))
+  end
+end

--- a/lib/sanctum_web/components/deck_cards.ex
+++ b/lib/sanctum_web/components/deck_cards.ex
@@ -13,6 +13,7 @@ defmodule SanctumWeb.Components.DeckCards do
   import SanctumWeb.CoreComponents, only: [icon: 1]
 
   alias SanctumWeb.Components.Card, as: CardComponent
+  alias SanctumWeb.Components.ChampionsIcons
 
   @type_order [:ally, :event, :support, :upgrade, :resource, :player_side_scheme]
   @type_labels %{
@@ -43,7 +44,7 @@ defmodule SanctumWeb.Components.DeckCards do
       hero?: side.ownership == :hero,
       aspect_key: aspect_key,
       aspect_bg: CardComponent.aspect_classes(aspect_key).bg,
-      pips: CardComponent.resource_pips(side_resources(side)),
+      pips: ChampionsIcons.resource_pips(side_resources(side)),
       image_url: side.image_url,
       gradient_from: gf,
       gradient_to: gt,

--- a/lib/sanctum_web/live/card_live/show.ex
+++ b/lib/sanctum_web/live/card_live/show.ex
@@ -84,12 +84,7 @@ defmodule SanctumWeb.CardLive.Show do
 
             <!-- resource pips -->
             <div :if={side.pips != []} class="mt-3 flex items-center gap-1.5">
-              <span
-                :for={{color_class, glyph} <- side.pips}
-                class={["font-champions text-lg leading-none", color_class]}
-              >
-                {glyph}
-              </span>
+              <.champions_icon :for={token <- side.pips} token={token} class="text-lg" />
             </div>
 
             <div
@@ -452,7 +447,7 @@ defmodule SanctumWeb.CardLive.Show do
       aspect_text_class:
         CardComponent.aspect_classes(if(hero_face?, do: :hero, else: side.aspect)).text,
       resources: resources,
-      pips: CardComponent.resource_pips(resources),
+      pips: SanctumWeb.Components.ChampionsIcons.resource_pips(resources),
       traits: format_traits(side.traits),
       text: side.text,
       image_url: side.image_url,

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -1042,9 +1042,7 @@ defmodule SanctumWeb.DeckLive.Build do
                   phx-value-index={i}
                   class="flex min-h-[64px] cursor-pointer flex-col items-center justify-center gap-1.5 border-2 border-neutral bg-base-200 px-2 py-2 transition-colors hover:border-primary"
                 >
-                  <span class={["font-champions text-2xl leading-none", icon.color]}>
-                    {icon.glyph}
-                  </span>
+                  <.champions_icon token={icon.token} class="text-2xl" />
                   <span class="font-barlow-condensed text-xs font-bold uppercase tracking-[0.06em] text-base-content/70">
                     {icon.label}
                   </span>
@@ -1276,12 +1274,7 @@ defmodule SanctumWeb.DeckLive.Build do
             <!-- pips column: always rendered so every row's icons share one
                  right edge, independent of what the controls column holds -->
             <span class="flex w-8 flex-none items-center justify-end gap-1">
-              <span
-                :for={{color_class, glyph} <- row.pips}
-                class={["font-champions text-sm leading-none", color_class]}
-              >
-                {glyph}
-              </span>
+              <.champions_icon :for={token <- row.pips} token={token} class="text-sm" />
             </span>
             <!-- controls column: fixed width whether it holds a lock or steppers -->
             <span class="flex w-[84px] flex-none items-center justify-end gap-0.5 sm:w-[52px]">

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -223,12 +223,7 @@ defmodule SanctumWeb.DeckLive.Show do
                         ×{c.qty}
                       </span>
                       <span class="flex w-8 flex-none items-center justify-end gap-1">
-                        <span
-                          :for={{color_class, glyph} <- c.pips}
-                          class={["font-champions text-sm leading-none", color_class]}
-                        >
-                          {glyph}
-                        </span>
+                        <.champions_icon :for={token <- c.pips} token={token} class="text-sm" />
                       </span>
                     </.link>
                   </div>


### PR DESCRIPTION
## Summary

- New `SanctumWeb.Components.ChampionsIcons` module: one function component per glyph (`energy_icon`, `mental_icon`, …, `player_icon`, `stat_star_icon`) plus a `champions_icon token={...}` dispatcher for dynamic lists, so call sites never hard-code `font-champions` spans or raw glyph letters.
- Replaces the ad-hoc spans in the card tiles, mc_card resource pips, deck list rows, the builder's icon picker, the scheme threat plate's per-player marker, and the homebrew editor's star column header.
- `Sanctum.CardText.icons/0` stays the single source of truth for the token → glyph map; `resource_pips/1` moves from `Card` into the new module and now returns plain tokens instead of `{class, glyph}` tuples.
- Every icon span bakes in `normal-case` — the glyph letters are case-sensitive, so an inherited `uppercase` could previously swap a glyph for a different icon (only the homebrew editor defended against this).
- Intentionally untouched: `CardText.icon_span/1` string rendering (iodata pipeline, no function components possible), the SVG `<tspan>` glyphs inside `StatBadge`/`HealthBadge` (SVG text context), and the client-side description-editor JS.

Stacked on `refactor/type-scale` (#280): the replaced spans in `card_live/show`, `deck_live/build`, and `deck_live/show` sit on lines that branch retokenized.

Note: `feat/homebrew-alt-art`'s edit-card page also calls `stat_star_icon`, so this branch should land before it.

## Test plan

- `mix test`, `mix ck` clean
- Visually verified against the dev server: pool tiles (resource pips), main-scheme threat plates (per-player marker), card detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)