### PR TITLE
feat(homebrew): enrichment UX — per-card metadata, stat axes, side pairing

### DIFF
--- a/lib/sanctum/games/card.ex
+++ b/lib/sanctum/games/card.ex
@@ -140,8 +140,46 @@ defmodule Sanctum.Games.Card do
     end
 
     update :update_custom do
+      description "Enriches a custom card: card-level flags plus per-side metadata."
+
       accept [:deck_limit, :unique, :permanent]
       require_atomic? false
+
+      # Each map must carry the side's :id — sides are matched by primary key
+      # against this card's own sides. Omitted sides are left alone (never
+      # destroyed), unknown ids error, and matches run through CardSide's
+      # narrow :enrich action so codes/images can't be smuggled.
+      argument :card_sides, {:array, :map}
+
+      change manage_relationship(:card_sides,
+               on_lookup: :ignore,
+               on_no_match: :error,
+               on_match: {:update, :enrich},
+               on_missing: :ignore
+             )
+    end
+
+    update :pair_custom do
+      description "Merges another single-sided custom card into this one as side b; " <>
+                    "the donor card row is destroyed."
+
+      accept []
+      require_atomic? false
+
+      argument :donor_card_id, :uuid, allow_nil?: false
+
+      change set_attribute(:is_multi_sided, true)
+      change Sanctum.Games.Changes.PairCustomCard
+    end
+
+    update :unpair_custom do
+      description "Splits side b off into its own single-sided card in the same project."
+
+      accept []
+      require_atomic? false
+
+      change set_attribute(:is_multi_sided, false)
+      change Sanctum.Games.Changes.UnpairCustomCard
     end
 
     destroy :destroy_custom do
@@ -174,7 +212,7 @@ defmodule Sanctum.Games.Card do
 
     # Filter checks: someone else's custom (or any official card) is simply
     # not found through these actions.
-    policy action([:update_custom, :destroy_custom]) do
+    policy action([:update_custom, :destroy_custom, :pair_custom, :unpair_custom]) do
       authorize_if expr(origin == :custom and homebrew_project.creator_id == ^actor(:id))
     end
 

--- a/lib/sanctum/games/card_side.ex
+++ b/lib/sanctum/games/card_side.ex
@@ -84,6 +84,30 @@ defmodule Sanctum.Games.CardSide do
       accept [:*]
     end
 
+    # Creator-editable homebrew metadata only — never code / side_identifier /
+    # is_primary_side / image_url (those are minted or content-addressed).
+    # Reached exclusively through Card.update_custom's manage_relationship;
+    # the accessing_from policy below keeps direct calls admin-only.
+    update :enrich do
+      accept [
+        :name,
+        :subname,
+        :ownership,
+        :type,
+        :aspect,
+        :cost,
+        :attack,
+        :thwart,
+        :defense,
+        :health,
+        :recover,
+        :scheme,
+        :traits,
+        :text,
+        :flavor
+      ]
+    end
+
     read :primary_sides do
       filter expr(is_primary_side == true)
     end

--- a/lib/sanctum/games/changes/generate_custom_code.ex
+++ b/lib/sanctum/games/changes/generate_custom_code.ex
@@ -16,12 +16,11 @@ defmodule Sanctum.Games.Changes.GenerateCustomCode do
   use Ash.Resource.Change
 
   alias Ash.Changeset
-
-  @side_letters ~w(a b c d e f)
+  alias Sanctum.Games.CustomCode
 
   @impl true
   def change(changeset, _opts, _context) do
-    code = "custom-" <> Ash.UUID.generate()
+    code = CustomCode.mint()
 
     sides =
       changeset
@@ -46,13 +45,13 @@ defmodule Sanctum.Games.Changes.GenerateCustomCode do
 
   defp build_sides(sides, code) do
     sides
-    |> Enum.zip(@side_letters)
+    |> Enum.zip(CustomCode.side_letters())
     |> Enum.map(fn {side, letter} ->
       normalized = Map.new(side, fn {key, value} -> {to_atom_key(key), value} end)
 
       normalized
       |> Map.delete(:filename)
-      |> Map.put(:code, code <> letter)
+      |> Map.put(:code, CustomCode.side_code(code, letter))
       |> Map.put(:side_identifier, letter)
       |> Map.put(:is_primary_side, letter == "a")
       |> Map.put(:name, side_name(normalized))

--- a/lib/sanctum/games/changes/pair_custom_card.ex
+++ b/lib/sanctum/games/changes/pair_custom_card.ex
@@ -1,0 +1,83 @@
+defmodule Sanctum.Games.Changes.PairCustomCard do
+  @moduledoc """
+  Merges a donor single-sided custom card into the target as side "b".
+
+  The donor's side is re-parented BEFORE the donor row is destroyed — the
+  `card_sides.card_id` FK cascades on card delete. Internal writes run with
+  `authorize?: false`: the action's policy already proved the actor owns the
+  target's project, and the same-project validation below makes the donor the
+  same creator's (projects have a single creator; the origin check constraint
+  guarantees a same-project donor is custom).
+  """
+
+  use Ash.Resource.Change
+
+  alias Ash.Changeset
+  alias Sanctum.Games.CustomCode
+
+  @impl true
+  def change(changeset, _opts, context) do
+    changeset
+    |> Changeset.before_action(fn changeset ->
+      donor_id = Changeset.get_argument(changeset, :donor_card_id)
+      target = changeset.data
+
+      with {:ok, donor} <- fetch_donor(donor_id, context.actor),
+           :ok <- validate_pairable(target, donor) do
+        Changeset.put_context(changeset, :pair_donor, donor)
+      else
+        {:error, field, message} ->
+          Changeset.add_error(changeset, field: field, message: message)
+      end
+    end)
+    |> Changeset.after_action(fn changeset, target ->
+      donor = changeset.context.pair_donor
+      [donor_side] = donor.card_sides
+
+      # Re-parent FIRST (destroying the donor would cascade its sides away).
+      donor_side
+      |> Changeset.for_update(:update, %{
+        card_id: target.id,
+        side_identifier: "b",
+        code: CustomCode.side_code(target.code, "b"),
+        is_primary_side: false
+      })
+      |> Ash.update!(authorize?: false)
+
+      # TODO(play-slice): a donor referenced by DeckCard/GameCard raises a raw
+      # FK error here — turn that into a friendly validation when customs
+      # become deckable/playable.
+      Ash.destroy!(donor, action: :destroy_custom, authorize?: false)
+
+      {:ok, target}
+    end)
+  end
+
+  defp fetch_donor(donor_id, actor) do
+    # Actor-scoped read: someone else's private custom is simply not found.
+    case Ash.get(Sanctum.Games.Card, donor_id, actor: actor, load: :card_sides) do
+      {:ok, donor} -> {:ok, donor}
+      {:error, _not_found} -> {:error, :donor_card_id, "card not found"}
+    end
+  end
+
+  defp validate_pairable(target, donor) do
+    cond do
+      donor.id == target.id ->
+        {:error, :donor_card_id, "a card cannot be paired with itself"}
+
+      donor.homebrew_project_id != target.homebrew_project_id ->
+        # Covers cross-project, cross-user, and official donors in one check.
+        {:error, :donor_card_id, "both cards must belong to the same project"}
+
+      target.is_multi_sided ->
+        {:error, :id, "this card already has two sides"}
+
+      donor.is_multi_sided or length(donor.card_sides) != 1 ->
+        {:error, :donor_card_id, "the other card must be single-sided"}
+
+      true ->
+        :ok
+    end
+  end
+end

--- a/lib/sanctum/games/changes/unpair_custom_card.ex
+++ b/lib/sanctum/games/changes/unpair_custom_card.ex
@@ -1,0 +1,65 @@
+defmodule Sanctum.Games.Changes.UnpairCustomCard do
+  @moduledoc """
+  Splits a two-sided custom card: side "b" moves onto a fresh single-sided
+  card in the same project (re-lettered as its "a"/primary side, code
+  re-minted). The new card rides back to the caller as the `:unpaired_card`
+  record metadata. Internal writes are `authorize?: false` — the action's
+  policy already proved the actor owns this project.
+  """
+
+  use Ash.Resource.Change
+
+  alias Ash.Changeset
+  alias Sanctum.Games.CustomCode
+
+  @impl true
+  def change(changeset, _opts, _context) do
+    changeset
+    |> Changeset.before_action(fn changeset ->
+      sides =
+        changeset.data
+        |> Ash.load!(:card_sides, authorize?: false)
+        |> Map.fetch!(:card_sides)
+
+      case Enum.find(sides, &(&1.side_identifier == "b")) do
+        nil ->
+          Changeset.add_error(changeset, field: :id, message: "card is not two-sided")
+
+        side_b ->
+          Changeset.put_context(changeset, :unpair_side_b, side_b)
+      end
+    end)
+    |> Changeset.after_action(fn changeset, card ->
+      side_b = changeset.context.unpair_side_b
+      code = CustomCode.mint()
+
+      # The primary :create (not :create_custom — that demands image maps and
+      # re-mints codes). The fresh uuid code can't collide with its upsert
+      # identity, so this is a plain insert.
+      new_card =
+        Sanctum.Games.Card
+        |> Changeset.for_create(:create, %{
+          origin: :custom,
+          homebrew_project_id: card.homebrew_project_id,
+          code: code,
+          base_code: code,
+          is_multi_sided: false,
+          deck_limit: card.deck_limit,
+          unique: card.unique,
+          permanent: card.permanent
+        })
+        |> Ash.create!(authorize?: false)
+
+      side_b
+      |> Changeset.for_update(:update, %{
+        card_id: new_card.id,
+        side_identifier: "a",
+        code: CustomCode.side_code(code, "a"),
+        is_primary_side: true
+      })
+      |> Ash.update!(authorize?: false)
+
+      {:ok, Ash.Resource.put_metadata(card, :unpaired_card, new_card)}
+    end)
+  end
+end

--- a/lib/sanctum/games/custom_code.ex
+++ b/lib/sanctum/games/custom_code.ex
@@ -1,0 +1,17 @@
+defmodule Sanctum.Games.CustomCode do
+  @moduledoc """
+  Code minting for custom (homebrew) cards.
+
+  Card codes are `custom-<uuid>` — outside MarvelCDB's numeric space, so they
+  can never collide with (or be captured by) a catalog-sync upsert. Side codes
+  follow the official convention: `<card code><letter>` with letters a..f.
+  """
+
+  @side_letters ~w(a b c d e f)
+
+  def side_letters, do: @side_letters
+
+  def mint, do: "custom-" <> Ash.UUID.generate()
+
+  def side_code(card_code, letter) when letter in @side_letters, do: card_code <> letter
+end

--- a/lib/sanctum/games/stat.ex
+++ b/lib/sanctum/games/stat.ex
@@ -23,6 +23,30 @@ defmodule Sanctum.Games.Stat do
 
   defstruct value: nil, star: false, scaling: :flat, consequential: nil
 
+  @doc """
+  The bare value for a number input editing this stat. Tolerates the raw
+  string/integer/map params a form round-trips between validates.
+  """
+  def input_value(%__MODULE__{value: value}), do: value
+  def input_value(%{} = params), do: fetch(params, :value)
+  def input_value(value) when is_integer(value) or is_binary(value), do: value
+  def input_value(_), do: nil
+
+  @doc "Whether the ★ box should be checked; tolerates form params."
+  def input_star(%__MODULE__{star: star}), do: star
+  def input_star(%{} = params), do: truthy(fetch(params, :star))
+  def input_star(_), do: false
+
+  @doc "The consequential-damage input value; tolerates form params."
+  def input_consequential(%__MODULE__{consequential: consequential}), do: consequential
+  def input_consequential(%{} = params), do: fetch(params, :consequential)
+  def input_consequential(_), do: nil
+
+  @doc "The scaling select value; tolerates form params."
+  def input_scaling(%__MODULE__{scaling: scaling}), do: scaling
+  def input_scaling(%{} = params), do: to_scaling(fetch(params, :scaling))
+  def input_scaling(_), do: :flat
+
   @scalings [:flat, :per_player, :per_group]
 
   @impl true
@@ -46,7 +70,15 @@ defmodule Sanctum.Games.Stat do
     end
   end
 
-  def cast_input(%{} = map, _), do: {:ok, from_map(map)}
+  # An all-default map (blank form inputs) collapses to nil so an untouched
+  # stat stays "absent" rather than becoming an empty struct.
+  def cast_input(%{} = map, _) do
+    case from_map(map) do
+      %__MODULE__{value: nil, star: false, scaling: :flat, consequential: nil} -> {:ok, nil}
+      stat -> {:ok, stat}
+    end
+  end
+
   def cast_input(_, _), do: :error
 
   @impl true

--- a/lib/sanctum/homebrew.ex
+++ b/lib/sanctum/homebrew.ex
@@ -58,4 +58,49 @@ defmodule Sanctum.Homebrew do
       Ash.destroy(card, action: :destroy_custom, actor: actor)
     end
   end
+
+  @doc """
+  Enriches one of the actor's custom cards: card-level flags plus per-side
+  metadata. `attrs` may include `:card_sides` — a list of maps each carrying
+  the side's `:id` plus any enrichable field. Sides omitted from the list are
+  untouched; unknown ids are rejected. Nothing is ever required.
+  """
+  def enrich_custom_card(%Sanctum.Games.Card{} = card, attrs, actor) do
+    card
+    |> Ash.Changeset.for_update(:update_custom, attrs, actor: actor)
+    |> Ash.update()
+  end
+
+  def enrich_custom_card(card_id, attrs, actor) do
+    with {:ok, card} <- Ash.get(Sanctum.Games.Card, card_id, actor: actor) do
+      enrich_custom_card(card, attrs, actor)
+    end
+  end
+
+  @doc """
+  Merges `donor_card_id` into the target card as its back ("b") side — both
+  must be single-sided customs in the same project. The donor card row is
+  destroyed; its side (and image) live on under the target.
+  """
+  def pair_custom_cards(target_card_id, donor_card_id, actor) do
+    with {:ok, target} <- Ash.get(Sanctum.Games.Card, target_card_id, actor: actor) do
+      target
+      |> Ash.Changeset.for_update(:pair_custom, %{donor_card_id: donor_card_id}, actor: actor)
+      |> Ash.update()
+    end
+  end
+
+  @doc """
+  Splits a two-sided custom card. Returns `{:ok, {updated_card, new_card}}` —
+  the original keeps side "a"; side "b" becomes `new_card`'s front.
+  """
+  def unpair_custom_card(card_id, actor) do
+    with {:ok, card} <- Ash.get(Sanctum.Games.Card, card_id, actor: actor),
+         {:ok, updated} <-
+           card
+           |> Ash.Changeset.for_update(:unpair_custom, %{}, actor: actor)
+           |> Ash.update() do
+      {:ok, {updated, updated.__metadata__.unpaired_card}}
+    end
+  end
 end

--- a/lib/sanctum_web/live/card_live/form.ex
+++ b/lib/sanctum_web/live/card_live/form.ex
@@ -123,11 +123,7 @@ defmodule SanctumWeb.CardLive.Form do
 
   defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 
-  # Stats are stored as Sanctum.Games.Stat structs; the number inputs edit only
-  # the value (a bare number casts to a flat, unstarred stat).
-  defp stat_value(%Sanctum.Games.Stat{value: value}), do: value
-  defp stat_value(value) when is_integer(value) or is_binary(value), do: value
-  defp stat_value(_), do: nil
+  defdelegate stat_value(value), to: Sanctum.Games.Stat, as: :input_value
 
   defp assign_forms(%{assigns: %{card: card}} = socket) do
     card_form =

--- a/lib/sanctum_web/live/homebrew_live/show.ex
+++ b/lib/sanctum_web/live/homebrew_live/show.ex
@@ -1,15 +1,18 @@
 defmodule SanctumWeb.HomebrewLive.Show do
   @moduledoc """
-  A homebrew project page: drag-drop image upload plus the project's cards as
-  an art grid. Every uploaded image immediately becomes a playable custom card
-  — name is prefilled from the filename, all other metadata is optional
-  (enrichment ships later).
+  A homebrew project page: drag-drop image upload, the project's cards as an
+  art grid, per-card enrichment (a bottom sheet — never a modal — editing
+  optional metadata), and front/back pairing of two single-sided cards.
+  Every uploaded image immediately becomes a playable custom card; metadata
+  is progressive and never required.
   """
 
   use SanctumWeb, :live_view
 
+  alias Sanctum.Games.Stat
   alias Sanctum.Homebrew
   alias Sanctum.HomebrewImages
+  alias SanctumWeb.Components.Card, as: CardComponents
 
   on_mount {SanctumWeb.LiveUserAuth, :live_user_required}
 
@@ -22,6 +25,10 @@ defmodule SanctumWeb.HomebrewLive.Show do
          |> assign(:page_title, project.name)
          |> assign(:project, project)
          |> assign(:uploads_configured?, HomebrewImages.configured?())
+         |> assign(:editing_card, nil)
+         |> assign(:enrich_form, nil)
+         |> assign(:pair_mode?, false)
+         |> assign(:pair_selection, [])
          |> assign_cards()
          |> allow_upload(:card_images,
            accept: ~w(.png .jpg .jpeg .webp),
@@ -70,6 +77,126 @@ defmodule SanctumWeb.HomebrewLive.Show do
     end
   end
 
+  # -- Enrichment sheet -----------------------------------------------------
+
+  def handle_event("edit_card", %{"id" => id}, socket) do
+    case Ash.get(Sanctum.Games.Card, id,
+           actor: socket.assigns.current_user,
+           load: [:card_sides]
+         ) do
+      {:ok, card} ->
+        form =
+          AshPhoenix.Form.for_update(card, :update_custom,
+            as: "card",
+            actor: socket.assigns.current_user
+          )
+
+        {:noreply,
+         socket
+         |> assign(:editing_card, card)
+         |> assign(:enrich_form, to_form(form))}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Card not found.")}
+    end
+  end
+
+  def handle_event("close_enrichment", _params, socket) do
+    {:noreply, socket |> assign(:editing_card, nil) |> assign(:enrich_form, nil)}
+  end
+
+  def handle_event("enrich_validate", %{"card" => params}, socket) do
+    params = splice_traits(params)
+
+    {:noreply,
+     assign(socket, :enrich_form, AshPhoenix.Form.validate(socket.assigns.enrich_form, params))}
+  end
+
+  def handle_event("enrich_save", %{"card" => params}, socket) do
+    params = splice_traits(params)
+
+    case AshPhoenix.Form.submit(socket.assigns.enrich_form, params: params) do
+      {:ok, _card} ->
+        {:noreply,
+         socket
+         |> assign(:editing_card, nil)
+         |> assign(:enrich_form, nil)
+         |> assign_cards()
+         |> put_flash(:info, "Card updated.")}
+
+      {:error, form} ->
+        {:noreply, assign(socket, :enrich_form, form)}
+    end
+  end
+
+  def handle_event("unpair_card", %{"id" => id}, socket) do
+    case Homebrew.unpair_custom_card(id, socket.assigns.current_user) do
+      {:ok, {_updated, _new_card}} ->
+        {:noreply,
+         socket
+         |> assign(:editing_card, nil)
+         |> assign(:enrich_form, nil)
+         |> assign_cards()
+         |> put_flash(:info, "Card split into two.")}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Could not split the card.")}
+    end
+  end
+
+  # -- Pairing --------------------------------------------------------------
+
+  def handle_event("toggle_pair_mode", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:pair_mode?, !socket.assigns.pair_mode?)
+     |> assign(:pair_selection, [])
+     |> assign(:editing_card, nil)
+     |> assign(:enrich_form, nil)}
+  end
+
+  def handle_event("toggle_pair_select", %{"id" => id}, socket) do
+    selection = socket.assigns.pair_selection
+    card = Enum.find(socket.assigns.cards, &(&1.id == id))
+
+    selection =
+      cond do
+        is_nil(card) or card.is_multi_sided -> selection
+        id in selection -> List.delete(selection, id)
+        length(selection) >= 2 -> selection
+        true -> selection ++ [id]
+      end
+
+    {:noreply, assign(socket, :pair_selection, selection)}
+  end
+
+  def handle_event("swap_pair_order", _params, socket) do
+    {:noreply, assign(socket, :pair_selection, Enum.reverse(socket.assigns.pair_selection))}
+  end
+
+  def handle_event("pair_cards", _params, socket) do
+    case socket.assigns.pair_selection do
+      [front_id, back_id] ->
+        case Homebrew.pair_custom_cards(front_id, back_id, socket.assigns.current_user) do
+          {:ok, _paired} ->
+            {:noreply,
+             socket
+             |> assign(:pair_mode?, false)
+             |> assign(:pair_selection, [])
+             |> assign_cards()
+             |> put_flash(:info, "Cards paired.")}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Could not pair the cards.")}
+        end
+
+      _incomplete ->
+        {:noreply, socket}
+    end
+  end
+
+  # -- Upload plumbing --------------------------------------------------------
+
   # consume_uploaded_entries callback body: read the temp file, store the
   # normalized image under its content-addressed key, and mint the custom
   # card. Always consumed; per-entry outcome inspected by the caller.
@@ -113,6 +240,115 @@ defmodule SanctumWeb.HomebrewLive.Show do
     assign(socket, :cards, cards)
   end
 
+  # -- Form helpers -----------------------------------------------------------
+
+  # Splices each side's comma-separated traits_string into the traits array.
+  # Runs on validate AND submit so the traits input round-trips morphdom
+  # re-renders (splicing only pre-submit reverts the input on every validate).
+  defp splice_traits(%{"card_sides" => %{}} = params) do
+    Map.update!(params, "card_sides", fn sides ->
+      Map.new(sides, fn {index, side} -> {index, put_side_traits(side)} end)
+    end)
+  end
+
+  defp splice_traits(params), do: params
+
+  defp put_side_traits(%{"traits_string" => traits_string} = side) do
+    traits =
+      traits_string
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+
+    Map.put(side, "traits", traits)
+  end
+
+  defp put_side_traits(side), do: side
+
+  defp traits_value(side_form) do
+    side_form.params["traits_string"] ||
+      case side_form[:traits].value do
+        traits when is_list(traits) -> Enum.join(traits, ", ")
+        traits when is_binary(traits) -> traits
+        _ -> ""
+      end
+  end
+
+  defp stat_col_label_class,
+    do: "font-ibm-mono text-[10px] uppercase tracking-[0.2em] text-base-content/60"
+
+  # One editable stat: value + ★ + (consequential damage | health scaling).
+  # Inputs are nested-map params (e.g. side[attack][consequential]) so
+  # Stat.cast_input's map branch rebuilds the full struct on save.
+  attr :form, Phoenix.HTML.Form, required: true
+  attr :stat, :atom, required: true
+  attr :label, :string, required: true
+  attr :consequential, :boolean, default: false
+  attr :scaling, :boolean, default: false
+
+  defp stat_row(assigns) do
+    assigns =
+      assigns
+      |> assign(:base, assigns.form.name <> "[#{assigns.stat}]")
+      |> assign(:current, assigns.form[assigns.stat].value)
+
+    ~H"""
+    <div class="grid grid-cols-[42px_1fr_52px_1fr] items-center gap-2">
+      <span class={stat_col_label_class()}>{@label}</span>
+      <.input type="number" name={@base <> "[value]"} value={Stat.input_value(@current)} />
+      <div class="flex justify-center">
+        <.input
+          type="checkbox"
+          name={@base <> "[star]"}
+          checked={Stat.input_star(@current)}
+          aria-label={"#{@label} star effect"}
+        />
+      </div>
+      <.input
+        :if={@consequential}
+        type="number"
+        name={@base <> "[consequential]"}
+        value={Stat.input_consequential(@current)}
+        aria-label={"#{@label} consequential damage"}
+      />
+      <.input
+        :if={@scaling}
+        type="select"
+        name={@base <> "[scaling]"}
+        value={to_string(Stat.input_scaling(@current))}
+        options={[{"Flat", "flat"}, {"Per player", "per_player"}, {"Per group", "per_group"}]}
+        aria-label={"#{@label} scaling"}
+      />
+      <span :if={!@consequential && !@scaling}></span>
+    </div>
+    """
+  end
+
+  defp enum_options(enum_module) do
+    Enum.map(enum_module.values(), &{Phoenix.Naming.humanize(&1), to_string(&1)})
+  end
+
+  defp tile_frame_class(card) do
+    if CardComponents.landscape_type?(card.primary_side && card.primary_side.type) do
+      "aspect-[88/63]"
+    else
+      "aspect-[63/88]"
+    end
+  end
+
+  defp pair_role(id, [id | _]), do: "FRONT"
+  defp pair_role(id, [_, id]), do: "BACK"
+  defp pair_role(_id, _selection), do: nil
+
+  defp card_name(cards, id) do
+    case Enum.find(cards, &(&1.id == id)) do
+      %{primary_side: %{name: name}} -> name
+      _ -> "?"
+    end
+  end
+
+  defp single_sided_count(cards), do: Enum.count(cards, &(!&1.is_multi_sided))
+
   defp upload_error_to_string(:too_large), do: "File is too large (max 20 MB)."
   defp upload_error_to_string(:not_accepted), do: "Unsupported file type (use PNG, JPG, or WebP)."
   defp upload_error_to_string(:too_many_files), do: "Too many files (max 30 at a time)."
@@ -125,6 +361,13 @@ defmodule SanctumWeb.HomebrewLive.Show do
       <.header>
         {@project.name}
       </.header>
+
+      <%!-- Not a header subtitle (that slot was dropped): the meta line is page
+           content, and the "unofficial fan content" labeling is required on all
+           homebrew surfaces (IP posture). --%>
+      <p class="-mt-4 mb-5 font-barlow-condensed text-[14px] text-base-content/55">
+        {length(@cards)} {if length(@cards) == 1, do: "card", else: "cards"} &middot; {@project.visibility} &middot; unofficial fan content
+      </p>
 
       <.panel :if={!@uploads_configured?} class="mb-6 p-5">
         <p class="font-barlow-condensed text-base-content/70">
@@ -184,11 +427,7 @@ defmodule SanctumWeb.HomebrewLive.Show do
             {upload_error_to_string(err)}
           </p>
 
-          <.button
-            :if={@uploads.card_images.entries != []}
-            variant="primary"
-            type="submit"
-          >
+          <.button :if={@uploads.card_images.entries != []} variant="primary" type="submit">
             Add {length(@uploads.card_images.entries)} {if length(@uploads.card_images.entries) == 1,
               do: "card",
               else: "cards"}
@@ -196,38 +435,288 @@ defmodule SanctumWeb.HomebrewLive.Show do
         </div>
       </form>
 
-      <div
-        :if={@cards == []}
-        class="border-2 border-dashed border-neutral p-10 text-center"
-      >
+      <div :if={single_sided_count(@cards) >= 2} class="mb-3 flex items-center gap-3">
+        <.button phx-click="toggle_pair_mode">
+          {(@pair_mode? && "Cancel pairing") || "Pair fronts & backs"}
+        </.button>
+        <span :if={@pair_mode?} class="font-barlow-condensed text-[13px] text-base-content/60">
+          Tap two cards to pair them as one two-sided card.
+        </span>
+      </div>
+
+      <div :if={@cards == []} class="border-2 border-dashed border-neutral p-10 text-center">
         <p class="font-barlow-condensed text-base-content/60">
           No cards yet — drop images above to add some.
         </p>
       </div>
 
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(110px,1fr))] gap-2.5">
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(110px,1fr))] gap-2.5 pb-28">
         <div :for={card <- @cards} class="group relative">
-          <div class="aspect-[63/88] border-2 border-neutral shadow-comic-sm">
+          <div class={[
+            "border-2 border-neutral shadow-comic-sm",
+            tile_frame_class(card),
+            pair_role(card.id, @pair_selection) &&
+              "outline outline-[3px] outline-primary -translate-y-0.5",
+            @pair_mode? && card.is_multi_sided && "opacity-40"
+          ]}>
             <.mc_card
               name={card.primary_side && card.primary_side.name}
               image_url={card.primary_side && card.primary_side.image_url}
+              cost={card.primary_side && card.primary_side.cost}
+              type={(card.primary_side && card.primary_side.type) || "event"}
+              aspect={(card.primary_side && card.primary_side.aspect) || :hero}
               size="md"
-              show_cost={false}
             />
           </div>
+
           <button
+            :if={!@pair_mode?}
+            type="button"
+            phx-click="edit_card"
+            phx-value-id={card.id}
+            aria-label={"Edit #{(card.primary_side && card.primary_side.name) || "card"}"}
+            class="absolute inset-0 z-[3] cursor-pointer"
+          ></button>
+          <button
+            :if={@pair_mode? && !card.is_multi_sided}
+            type="button"
+            phx-click="toggle_pair_select"
+            phx-value-id={card.id}
+            aria-label={"Select #{(card.primary_side && card.primary_side.name) || "card"} for pairing"}
+            class="absolute inset-0 z-[3] cursor-pointer"
+          ></button>
+
+          <span
+            :if={role = pair_role(card.id, @pair_selection)}
+            class="absolute left-1 top-1 z-[4] border-2 border-neutral bg-primary px-1.5 font-barlow-condensed text-[11px] font-bold text-primary-content"
+          >
+            {role}
+          </span>
+          <span
+            :if={@pair_mode? && card.is_multi_sided}
+            class="absolute left-1 top-1 z-[4] border-2 border-neutral bg-base-300 px-1.5 font-barlow-condensed text-[11px] font-bold text-base-content/70"
+          >
+            2-SIDED
+          </span>
+
+          <button
+            :if={!@pair_mode?}
             type="button"
             phx-click="delete_card"
             phx-value-id={card.id}
             data-confirm="Delete this card?"
             aria-label="delete card"
-            class="absolute right-1 top-1 hidden border-2 border-neutral bg-base-100/90 px-1.5 font-bold text-error group-hover:block"
+            class="absolute right-1 top-1 z-[4] hidden border-2 border-neutral bg-base-100/90 px-1.5 font-bold text-error group-hover:block"
           >
             &times;
           </button>
         </div>
       </div>
+
+      <.pair_strip
+        :if={@pair_mode? && length(@pair_selection) == 2}
+        pair_selection={@pair_selection}
+        cards={@cards}
+      />
+
+      <.enrichment_sheet editing_card={@editing_card} enrich_form={@enrich_form} />
     </Layouts.app>
+    """
+  end
+
+  # Fixed bottom action strip once two cards are selected for pairing —
+  # deck_live/new.ex's confirm-strip recipe (never a modal).
+  defp pair_strip(assigns) do
+    ~H"""
+    <div class="fixed inset-x-0 bottom-0 z-20 border-t-2 border-neutral bg-base-100/95 px-4 py-3 backdrop-blur sm:sticky sm:bottom-4 sm:border-2 sm:bg-base-200 sm:px-5 sm:py-4 sm:shadow-comic">
+      <div class="mx-auto flex max-w-3xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <span class="font-barlow-condensed text-[14px] font-bold uppercase tracking-[0.05em]">
+          Front: {card_name(@cards, Enum.at(@pair_selection, 0))}
+          <span class="text-base-content/50">→</span>
+          Back: {card_name(@cards, Enum.at(@pair_selection, 1))}
+        </span>
+        <div class="flex items-center gap-2">
+          <.button type="button" phx-click="swap_pair_order">Swap</.button>
+          <.button variant="primary" type="button" phx-click="pair_cards">
+            Pair as one card
+          </.button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  # The enrichment bottom sheet (filter_sheet's shell recipe): rendered once,
+  # unconditionally, so the mobile slide-up transition works; openness keys
+  # off @editing_card. All input values derive from @enrich_form so upload-
+  # progress re-renders can't clobber in-flight edits.
+  defp enrichment_sheet(assigns) do
+    ~H"""
+    <div
+      :if={@editing_card}
+      phx-click="close_enrichment"
+      phx-window-keydown="close_enrichment"
+      phx-key="escape"
+      aria-hidden="true"
+      class="fixed inset-0 z-40 bg-black/60"
+    >
+    </div>
+    <section
+      id="enrichment-sheet"
+      phx-hook="PaneDrag"
+      data-dismiss-event="close_enrichment"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Edit card"
+      inert={!@editing_card}
+      class={[
+        "fixed inset-x-0 bottom-0 z-50 flex max-h-[85dvh] flex-col border-t-2 border-neutral bg-base-100",
+        "transition-transform duration-200",
+        "sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-[7dvh] sm:max-h-[86dvh] sm:w-[560px]",
+        "sm:-translate-x-1/2 sm:border-2 sm:shadow-comic sm:transition-none",
+        (@editing_card && "translate-y-0") || "translate-y-full sm:hidden"
+      ]}
+    >
+      <button
+        type="button"
+        data-drag-handle
+        data-haptic
+        class="flex w-full flex-none cursor-grab touch-none items-center justify-center gap-2 py-3 text-base-content/50 sm:hidden"
+        title="Close editor"
+      >
+        <span class="h-1 w-10 rounded-full bg-base-content/25"></span>
+        <.icon name="hero-chevron-down" class="size-4" />
+      </button>
+
+      <header class="hidden flex-none items-center justify-between border-b-2 border-line px-5 py-3 sm:flex">
+        <h2 class="font-bangers text-[22px] tracking-[0.02em] text-primary">Edit Card</h2>
+        <button
+          type="button"
+          phx-click="close_enrichment"
+          aria-label="Close editor"
+          class="grid size-8 cursor-pointer place-items-center text-base-content/50 hover:text-white"
+        >
+          <.icon name="hero-x-mark" class="size-5" />
+        </button>
+      </header>
+
+      <.form
+        :if={@enrich_form}
+        for={@enrich_form}
+        id={"enrichment-form-#{@editing_card.id}"}
+        phx-change="enrich_validate"
+        phx-submit="enrich_save"
+        class="flex min-h-0 flex-1 flex-col"
+      >
+        <div class="min-h-0 flex-1 overflow-y-auto px-4 py-3 sm:px-5">
+          <section class="mb-6">
+            <h3 class="mb-2.5 font-anton text-[13px] uppercase tracking-[0.08em] text-base-content/45">
+              Card
+            </h3>
+            <div class="grid grid-cols-2 gap-3">
+              <.input field={@enrich_form[:deck_limit]} type="number" label="Deck limit" />
+              <div class="self-end pb-1">
+                <.input field={@enrich_form[:unique]} type="checkbox" label="Unique" />
+              </div>
+            </div>
+          </section>
+
+          <.inputs_for :let={side} field={@enrich_form[:card_sides]}>
+            <section class="mb-6 border-t border-line/70 pt-4">
+              <h3
+                :if={@editing_card.is_multi_sided}
+                class="mb-2.5 font-anton text-[13px] uppercase tracking-[0.08em] text-base-content/45"
+              >
+                Side {String.upcase(side[:side_identifier].value || "")}
+              </h3>
+              <div class="flex flex-col gap-3">
+                <div class="grid grid-cols-2 gap-3">
+                  <.input field={side[:name]} type="text" label="Name" />
+                  <.input field={side[:subname]} type="text" label="Subname" />
+                </div>
+                <div class="grid grid-cols-3 gap-3">
+                  <.input
+                    field={side[:ownership]}
+                    type="select"
+                    label="Pool"
+                    prompt="—"
+                    options={enum_options(Sanctum.Games.CardOwnership)}
+                  />
+                  <.input
+                    field={side[:type]}
+                    type="select"
+                    label="Type"
+                    prompt="—"
+                    options={enum_options(Sanctum.Games.CardType)}
+                  />
+                  <.input
+                    field={side[:aspect]}
+                    type="select"
+                    label="Aspect"
+                    prompt="—"
+                    options={enum_options(Sanctum.Games.CardAspect)}
+                  />
+                </div>
+                <p class="-mt-1 font-barlow-condensed text-[12px] text-base-content/45">
+                  Schemes render landscape.
+                </p>
+                <div class="grid grid-cols-3 gap-3">
+                  <.input field={side[:cost]} type="number" label="Cost" />
+                </div>
+
+                <%!-- Full stat axes: value, ★ (a star effect relates to the
+                     stat), consequential damage (atk/thw/def), and health
+                     scaling. Nested-map params cast through Stat.cast_input;
+                     all-blank rows collapse back to an absent stat. --%>
+                <div class="flex flex-col gap-2">
+                  <div class="grid grid-cols-[42px_1fr_52px_1fr] items-end gap-2">
+                    <span></span>
+                    <span class={stat_col_label_class()}>Value</span>
+                    <%!-- "s" is the ChampionsIcons star glyph (see stat_badge);
+                         normal-case so the label style can't uppercase it into
+                         a different glyph. --%>
+                    <span
+                      class="text-center font-champions text-[13px] normal-case text-base-content/60"
+                      aria-label="star effect"
+                    >
+                      s
+                    </span>
+                    <span class={stat_col_label_class()}>Conseq. dmg</span>
+                  </div>
+                  <.stat_row form={side} stat={:attack} label="ATK" consequential />
+                  <.stat_row form={side} stat={:thwart} label="THW" consequential />
+                  <.stat_row form={side} stat={:defense} label="DEF" consequential />
+                  <.stat_row form={side} stat={:health} label="HP" scaling />
+                  <.stat_row form={side} stat={:recover} label="REC" />
+                </div>
+                <.input
+                  type="text"
+                  name={side.name <> "[traits_string]"}
+                  label="Traits (comma-separated)"
+                  value={traits_value(side)}
+                />
+                <.input field={side[:text]} type="textarea" label="Text" />
+                <.input field={side[:flavor]} type="textarea" label="Flavor" />
+              </div>
+            </section>
+          </.inputs_for>
+        </div>
+
+        <footer class="flex flex-none items-center gap-3 border-t-2 border-line bg-base-100 px-4 py-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] sm:px-5">
+          <button
+            :if={@editing_card && @editing_card.is_multi_sided}
+            type="button"
+            phx-click="unpair_card"
+            phx-value-id={@editing_card.id}
+            data-confirm="Split this card into two single-sided cards?"
+            class="font-barlow-condensed text-[13px] font-bold uppercase tracking-[0.08em] text-error/80 hover:text-error"
+          >
+            Split into two cards
+          </button>
+          <.button variant="primary" type="submit" class="ml-auto">Save</.button>
+        </footer>
+      </.form>
+    </section>
     """
   end
 end

--- a/test/sanctum/homebrew/custom_card_test.exs
+++ b/test/sanctum/homebrew/custom_card_test.exs
@@ -150,6 +150,302 @@ defmodule Sanctum.Homebrew.CustomCardTest do
     end
   end
 
+  describe "enrichment (update_custom card_sides)" do
+    setup ctx do
+      %{card: create_card!(ctx.project, ctx.creator, [%{image_url: "https://img.test/a.png"}])}
+    end
+
+    test "creator enriches side metadata and card flags in one call", ctx do
+      [side] = ctx.card.card_sides
+
+      {:ok, updated} =
+        Homebrew.enrich_custom_card(
+          ctx.card,
+          %{
+            deck_limit: 1,
+            unique: true,
+            card_sides: [
+              %{
+                id: side.id,
+                name: "Web Kick",
+                type: :event,
+                aspect: :justice,
+                cost: 2,
+                attack: 3,
+                traits: ["Aerial", "Attack"],
+                text: "Deal 5 damage."
+              }
+            ]
+          },
+          ctx.creator
+        )
+
+      assert updated.deck_limit == 1
+      assert updated.unique
+
+      side = Ash.get!(Sanctum.Games.CardSide, side.id, authorize?: false)
+      assert side.name == "Web Kick"
+      assert side.type == :event
+      assert side.aspect == :justice
+      assert side.cost == 2
+      assert %Sanctum.Games.Stat{value: 3} = side.attack
+      assert side.traits == ["Aerial", "Attack"]
+      assert side.text == "Deal 5 damage."
+      # Minted fields untouched
+      assert side.code == ctx.card.code <> "a"
+      assert side.is_primary_side
+    end
+
+    test "omitting a side never destroys it", ctx do
+      two_sided =
+        create_card!(ctx.project, ctx.creator, [
+          %{image_url: "https://img.test/f.png", name: "Front"},
+          %{image_url: "https://img.test/b.png", name: "Back"}
+        ])
+
+      [side_a, side_b] = Enum.sort_by(two_sided.card_sides, & &1.side_identifier)
+
+      {:ok, _} =
+        Homebrew.enrich_custom_card(
+          two_sided,
+          %{card_sides: [%{id: side_a.id, name: "Front Enriched"}]},
+          ctx.creator
+        )
+
+      assert {:ok, _} = Ash.get(Sanctum.Games.CardSide, side_b.id, authorize?: false)
+    end
+
+    # manage_relationship filters side maps to :enrich's accept list, so
+    # non-enrichable keys are silently dropped — never applied.
+    test "minted/image fields cannot be smuggled through enrichment", ctx do
+      [side] = ctx.card.card_sides
+
+      for forbidden <- [
+            %{code: "01001a"},
+            %{side_identifier: "b"},
+            %{is_primary_side: false},
+            %{image_url: "https://evil.test/x.png"}
+          ] do
+        {:ok, _} =
+          Homebrew.enrich_custom_card(
+            ctx.card,
+            %{card_sides: [Map.put(forbidden, :id, side.id)]},
+            ctx.creator
+          )
+      end
+
+      unchanged = Ash.get!(Sanctum.Games.CardSide, side.id, authorize?: false)
+      assert unchanged.code == side.code
+      assert unchanged.side_identifier == "a"
+      assert unchanged.is_primary_side
+      assert unchanged.image_url == side.image_url
+    end
+
+    test "a foreign side id is rejected", ctx do
+      other_card =
+        create_card!(ctx.project, ctx.creator, [%{image_url: "https://img.test/o.png"}])
+
+      [foreign_side] = other_card.card_sides
+
+      assert {:error, _} =
+               Homebrew.enrich_custom_card(
+                 ctx.card,
+                 %{card_sides: [%{id: foreign_side.id, name: "Hijack"}]},
+                 ctx.creator
+               )
+    end
+
+    test "another user cannot enrich; direct :enrich on a side is forbidden", ctx do
+      [side] = ctx.card.card_sides
+
+      assert {:error, _} =
+               Homebrew.enrich_custom_card(
+                 ctx.card.id,
+                 %{card_sides: [%{id: side.id, name: "Hijack"}]},
+                 ctx.other
+               )
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               side
+               |> Ash.Changeset.for_update(:enrich, %{name: "Hijack"}, actor: ctx.creator)
+               |> Ash.update()
+    end
+
+    test "full stat axes round-trip through map params", ctx do
+      [side] = ctx.card.card_sides
+
+      {:ok, _} =
+        Homebrew.enrich_custom_card(
+          ctx.card,
+          %{
+            card_sides: [
+              %{
+                id: side.id,
+                attack: %{"value" => "2", "star" => "true", "consequential" => "1"},
+                health: %{value: 12, scaling: :per_player}
+              }
+            ]
+          },
+          ctx.creator
+        )
+
+      side = Ash.get!(Sanctum.Games.CardSide, side.id, authorize?: false)
+
+      assert %Sanctum.Games.Stat{value: 2, star: true, consequential: 1, scaling: :flat} =
+               side.attack
+
+      assert %Sanctum.Games.Stat{value: 12, scaling: :per_player} = side.health
+
+      # An all-blank stat map (an untouched form row) collapses back to absent.
+      {:ok, _} =
+        Homebrew.enrich_custom_card(
+          ctx.card,
+          %{
+            card_sides: [
+              %{id: side.id, attack: %{"value" => "", "star" => "false", "consequential" => ""}}
+            ]
+          },
+          ctx.creator
+        )
+
+      assert is_nil(Ash.get!(Sanctum.Games.CardSide, side.id, authorize?: false).attack)
+    end
+
+    test "blank optional inputs stay blank", ctx do
+      [side] = ctx.card.card_sides
+
+      {:ok, _} =
+        Homebrew.enrich_custom_card(
+          ctx.card,
+          %{card_sides: [%{id: side.id, cost: "", attack: "", aspect: nil}]},
+          ctx.creator
+        )
+
+      side = Ash.get!(Sanctum.Games.CardSide, side.id, authorize?: false)
+      assert is_nil(side.cost)
+      assert is_nil(side.attack)
+      assert is_nil(side.aspect)
+    end
+  end
+
+  describe "pair_custom" do
+    setup ctx do
+      front = create_card!(ctx.project, ctx.creator, [%{image_url: "https://img.test/f.png"}])
+      back = create_card!(ctx.project, ctx.creator, [%{image_url: "https://img.test/b.png"}])
+      %{front: front, back: back}
+    end
+
+    test "merges the donor as side b and destroys its card row", ctx do
+      [donor_side] = ctx.back.card_sides
+
+      {:ok, paired} = Homebrew.pair_custom_cards(ctx.front.id, ctx.back.id, ctx.creator)
+
+      assert paired.is_multi_sided
+
+      sides =
+        paired
+        |> Ash.load!(:card_sides, authorize?: false)
+        |> Map.fetch!(:card_sides)
+        |> Enum.sort_by(& &1.side_identifier)
+
+      assert [%{side_identifier: "a", is_primary_side: true}, side_b] = sides
+      assert side_b.side_identifier == "b"
+      refute side_b.is_primary_side
+      assert side_b.code == ctx.front.code <> "b"
+      assert side_b.card_id == ctx.front.id
+      # The donor's side ROW survived, re-parented (same id, image intact).
+      assert side_b.id == donor_side.id
+      assert side_b.image_url == "https://img.test/b.png"
+
+      assert {:error, _} = Ash.get(Sanctum.Games.Card, ctx.back.id, authorize?: false)
+    end
+
+    test "donor from another user's project is not found", ctx do
+      other_project =
+        Homebrew.create_project!(%{name: "Other's", attestation: true}, actor: ctx.other)
+
+      donor = create_card!(other_project, ctx.other, [%{image_url: "https://img.test/x.png"}])
+
+      assert {:error, _} = Homebrew.pair_custom_cards(ctx.front.id, donor.id, ctx.creator)
+    end
+
+    test "donor from the actor's other project is rejected", ctx do
+      second_project =
+        Homebrew.create_project!(%{name: "Second", attestation: true}, actor: ctx.creator)
+
+      donor = create_card!(second_project, ctx.creator, [%{image_url: "https://img.test/x.png"}])
+
+      assert {:error, error} = Homebrew.pair_custom_cards(ctx.front.id, donor.id, ctx.creator)
+      assert Exception.message(error) =~ "same project"
+    end
+
+    test "multi-sided cards and self-pairs are rejected", ctx do
+      {:ok, paired} = Homebrew.pair_custom_cards(ctx.front.id, ctx.back.id, ctx.creator)
+
+      extra = create_card!(ctx.project, ctx.creator, [%{image_url: "https://img.test/e.png"}])
+
+      # Multi-sided target
+      assert {:error, _} = Homebrew.pair_custom_cards(paired.id, extra.id, ctx.creator)
+      # Multi-sided donor
+      assert {:error, _} = Homebrew.pair_custom_cards(extra.id, paired.id, ctx.creator)
+      # Self
+      assert {:error, _} = Homebrew.pair_custom_cards(extra.id, extra.id, ctx.creator)
+    end
+
+    test "another user cannot pair the creator's cards", ctx do
+      assert {:error, _} = Homebrew.pair_custom_cards(ctx.front.id, ctx.back.id, ctx.other)
+    end
+  end
+
+  describe "unpair_custom" do
+    setup ctx do
+      front = create_card!(ctx.project, ctx.creator, [%{image_url: "https://img.test/f.png"}])
+      back = create_card!(ctx.project, ctx.creator, [%{image_url: "https://img.test/b.png"}])
+      {:ok, paired} = Homebrew.pair_custom_cards(front.id, back.id, ctx.creator)
+      %{paired: paired}
+    end
+
+    test "splits side b into a fresh single-sided card", ctx do
+      {:ok, {updated, new_card}} = Homebrew.unpair_custom_card(ctx.paired.id, ctx.creator)
+
+      refute updated.is_multi_sided
+      refute new_card.is_multi_sided
+      assert new_card.origin == :custom
+      assert new_card.homebrew_project_id == ctx.paired.homebrew_project_id
+      assert "custom-" <> _ = new_card.code
+      assert new_card.base_code == new_card.code
+      assert new_card.deck_limit == ctx.paired.deck_limit
+
+      [moved] =
+        new_card |> Ash.load!(:card_sides, authorize?: false) |> Map.fetch!(:card_sides)
+
+      assert moved.side_identifier == "a"
+      assert moved.is_primary_side
+      assert moved.code == new_card.code <> "a"
+      assert moved.image_url == "https://img.test/b.png"
+
+      [remaining] =
+        updated |> Ash.load!(:card_sides, authorize?: false) |> Map.fetch!(:card_sides)
+
+      assert remaining.side_identifier == "a"
+      assert remaining.image_url == "https://img.test/f.png"
+    end
+
+    test "single-sided cards cannot be unpaired; other users get not-found", ctx do
+      single = create_card!(ctx.project, ctx.creator, [%{image_url: "https://img.test/s.png"}])
+
+      assert {:error, _} = Homebrew.unpair_custom_card(single.id, ctx.creator)
+      assert {:error, _} = Homebrew.unpair_custom_card(ctx.paired.id, ctx.other)
+    end
+
+    test "privacy is unaffected after pair/unpair", ctx do
+      {:ok, {updated, new_card}} = Homebrew.unpair_custom_card(ctx.paired.id, ctx.creator)
+
+      assert {:error, _} = Ash.get(Sanctum.Games.Card, updated.id, actor: ctx.other)
+      assert {:error, _} = Ash.get(Sanctum.Games.Card, new_card.id, actor: ctx.other)
+    end
+  end
+
   describe "official catalog boundaries" do
     test "non-admins cannot use the official mutations", ctx do
       assert {:error, %Ash.Error.Forbidden{}} =

--- a/test/sanctum_web/live/homebrew_live/show_test.exs
+++ b/test/sanctum_web/live/homebrew_live/show_test.exs
@@ -1,0 +1,223 @@
+defmodule SanctumWeb.HomebrewLive.ShowTest do
+  @moduledoc false
+
+  use SanctumWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Sanctum.AccountsFixtures
+
+  alias Sanctum.Homebrew
+
+  defp project_fixture(actor) do
+    Homebrew.create_project!(%{name: "Test Pack", attestation: true}, actor: actor)
+  end
+
+  defp card_fixture(project, actor, attrs \\ %{}) do
+    {:ok, card} =
+      Homebrew.create_custom_card(
+        %{
+          homebrew_project_id: project.id,
+          card_sides: [
+            Map.merge(%{image_url: "https://img.test/a.png", filename: "test-card.png"}, attrs)
+          ]
+        },
+        actor
+      )
+
+    Ash.load!(card, [:card_sides, :primary_side], authorize?: false)
+  end
+
+  setup %{conn: conn} do
+    creator = user_fixture()
+    project = project_fixture(creator)
+    %{conn: log_in_user(conn, creator), creator: creator, project: project}
+  end
+
+  test "anonymous visitors are redirected to sign-in", %{project: project} do
+    conn = Phoenix.ConnTest.build_conn()
+    assert {:error, {:redirect, %{to: "/sign-in"}}} = live(conn, ~p"/homebrew/#{project.id}")
+  end
+
+  test "another user's project is not found", %{project: project} do
+    conn = Phoenix.ConnTest.build_conn() |> log_in_user(user_fixture())
+
+    assert {:error, {:live_redirect, %{to: "/homebrew"}}} =
+             live(conn, ~p"/homebrew/#{project.id}")
+  end
+
+  describe "enrichment sheet" do
+    test "opens with prefilled fields and full enum options", ctx do
+      card = card_fixture(ctx.project, ctx.creator)
+      {:ok, lv, _html} = live(ctx.conn, ~p"/homebrew/#{ctx.project.id}")
+
+      html =
+        lv
+        |> element("button[phx-click='edit_card'][phx-value-id='#{card.id}']")
+        |> render_click()
+
+      assert html =~ "enrichment-form-#{card.id}"
+      assert html =~ "Test Card"
+      assert html =~ "player_side_scheme"
+    end
+
+    test "submitting enrichment persists and updates the grid tile", ctx do
+      card = card_fixture(ctx.project, ctx.creator)
+      [side] = card.card_sides
+      {:ok, lv, _html} = live(ctx.conn, ~p"/homebrew/#{ctx.project.id}")
+
+      lv
+      |> element("button[phx-click='edit_card'][phx-value-id='#{card.id}']")
+      |> render_click()
+
+      html =
+        lv
+        |> form("#enrichment-form-#{card.id}", %{
+          "card" => %{
+            "deck_limit" => "1",
+            "card_sides" => %{
+              "0" => %{
+                "id" => side.id,
+                "name" => "Web Kick",
+                "type" => "side_scheme",
+                "cost" => "2",
+                "traits_string" => "Aerial, Attack",
+                "attack" => %{"value" => "3", "star" => "true", "consequential" => "1"},
+                "health" => %{"value" => "4", "star" => "false", "scaling" => "per_player"}
+              }
+            }
+          }
+        })
+        |> render_submit()
+
+      updated_side = Ash.get!(Sanctum.Games.CardSide, side.id, authorize?: false)
+      assert updated_side.name == "Web Kick"
+      assert updated_side.type == :side_scheme
+      assert updated_side.cost == 2
+      assert updated_side.traits == ["Aerial", "Attack"]
+
+      assert %Sanctum.Games.Stat{value: 3, star: true, consequential: 1} = updated_side.attack
+      assert %Sanctum.Games.Stat{value: 4, scaling: :per_player} = updated_side.health
+
+      # Scheme types render landscape; the sheet closed on save.
+      assert html =~ "aspect-[88/63]"
+      assert html =~ "Web Kick"
+    end
+
+    test "blank optional fields stay blank", ctx do
+      card = card_fixture(ctx.project, ctx.creator)
+      [side] = card.card_sides
+      {:ok, lv, _html} = live(ctx.conn, ~p"/homebrew/#{ctx.project.id}")
+
+      lv
+      |> element("button[phx-click='edit_card'][phx-value-id='#{card.id}']")
+      |> render_click()
+
+      lv
+      |> form("#enrichment-form-#{card.id}", %{
+        "card" => %{
+          "card_sides" => %{
+            "0" => %{
+              "id" => side.id,
+              "cost" => "",
+              "traits_string" => "",
+              # An untouched stat row submits all-blank map params — the stat
+              # must collapse back to absent, not an empty struct.
+              "attack" => %{"value" => "", "star" => "false", "consequential" => ""},
+              "health" => %{"value" => "", "star" => "false", "scaling" => "flat"}
+            }
+          }
+        }
+      })
+      |> render_submit()
+
+      updated_side = Ash.get!(Sanctum.Games.CardSide, side.id, authorize?: false)
+      assert is_nil(updated_side.cost)
+      assert is_nil(updated_side.attack)
+      assert is_nil(updated_side.health)
+      assert updated_side.traits == []
+    end
+
+    test "two-sided cards show both fieldsets and can be split", ctx do
+      front = card_fixture(ctx.project, ctx.creator, %{filename: "front.png"})
+      back = card_fixture(ctx.project, ctx.creator, %{filename: "back.png"})
+      {:ok, paired} = Homebrew.pair_custom_cards(front.id, back.id, ctx.creator)
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/homebrew/#{ctx.project.id}")
+
+      html =
+        lv
+        |> element("button[phx-click='edit_card'][phx-value-id='#{paired.id}']")
+        |> render_click()
+
+      assert html =~ "Side A"
+      assert html =~ "Side B"
+      assert html =~ "Split into two cards"
+
+      lv
+      |> element("button[phx-click='unpair_card']")
+      |> render_click()
+
+      # Two single-sided tiles again.
+      html = render(lv)
+      assert html =~ "2 cards"
+      refute html =~ "Side B"
+    end
+  end
+
+  describe "pairing" do
+    test "full pair flow: select two, swap, pair", ctx do
+      front = card_fixture(ctx.project, ctx.creator, %{filename: "front-face.png"})
+      back = card_fixture(ctx.project, ctx.creator, %{filename: "back-face.png"})
+
+      {:ok, lv, html} = live(ctx.conn, ~p"/homebrew/#{ctx.project.id}")
+      assert html =~ "Pair fronts &amp; backs"
+
+      lv |> element("button[phx-click='toggle_pair_mode']") |> render_click()
+
+      lv
+      |> element("button[phx-click='toggle_pair_select'][phx-value-id='#{front.id}']")
+      |> render_click()
+
+      html =
+        lv
+        |> element("button[phx-click='toggle_pair_select'][phx-value-id='#{back.id}']")
+        |> render_click()
+
+      assert html =~ "FRONT"
+      assert html =~ "BACK"
+      assert html =~ "Front: Front Face"
+
+      html = lv |> element("button[phx-click='swap_pair_order']") |> render_click()
+      assert html =~ "Front: Back Face"
+      html = lv |> element("button[phx-click='swap_pair_order']") |> render_click()
+      assert html =~ "Front: Front Face"
+
+      html = lv |> element("button[phx-click='pair_cards']") |> render_click()
+
+      assert html =~ "Cards paired."
+      assert html =~ "1 card"
+
+      paired = Ash.get!(Sanctum.Games.Card, front.id, authorize?: false)
+      assert paired.is_multi_sided
+      assert {:error, _} = Ash.get(Sanctum.Games.Card, back.id, authorize?: false)
+    end
+
+    test "multi-sided cards are not selectable in pair mode", ctx do
+      a = card_fixture(ctx.project, ctx.creator)
+      b = card_fixture(ctx.project, ctx.creator)
+      {:ok, paired} = Homebrew.pair_custom_cards(a.id, b.id, ctx.creator)
+      card_fixture(ctx.project, ctx.creator)
+      card_fixture(ctx.project, ctx.creator)
+
+      {:ok, lv, _html} = live(ctx.conn, ~p"/homebrew/#{ctx.project.id}")
+      html = lv |> element("button[phx-click='toggle_pair_mode']") |> render_click()
+
+      assert html =~ "2-SIDED"
+
+      refute has_element?(
+               lv,
+               "button[phx-click='toggle_pair_select'][phx-value-id='#{paired.id}']"
+             )
+    end
+  end
+end


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #281
- <kbd>&nbsp;3&nbsp;</kbd> #275
- <kbd>&nbsp;2&nbsp;</kbd> #274 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #266
<!-- GitButler Footer Boundary Bottom -->
