### PR TITLE
refactor(homebrew): stat star header uses the shared stat_star_icon

### DIFF
--- a/lib/sanctum_web/live/homebrew_live/edit_card.ex
+++ b/lib/sanctum_web/live/homebrew_live/edit_card.ex
@@ -354,15 +354,10 @@ defmodule SanctumWeb.HomebrewLive.EditCard do
                   <div class="grid grid-cols-[42px_1fr_52px_1fr] items-end gap-2">
                     <span></span>
                     <span class={stat_col_label_class()}>Value</span>
-                    <%!-- "s" is the ChampionsIcons star glyph (see stat_badge);
-                         normal-case so the label style can't uppercase it into
-                         a different glyph. --%>
-                    <span
-                      class="text-center font-champions text-sm normal-case text-base-content/60"
+                    <.stat_star_icon
+                      class="text-center text-sm text-base-content/60"
                       aria-label="star effect"
-                    >
-                      s
-                    </span>
+                    />
                     <span class={stat_col_label_class()}>Conseq. dmg</span>
                   </div>
                   <.stat_row form={side} stat={:attack} label="ATK" consequential />


### PR DESCRIPTION
## Summary

Follow-up sweep after #282 (shared ChampionsIcons components). The alt-art branch (#281) merged carrying the raw `font-champions` span for the star column header in the homebrew card editor — it had been reverted there so that branch could compile independently of #282. With the components now on main, the header uses `<.stat_star_icon>` like every other glyph call site, and the last hand-rolled `font-champions` span outside the two intentional homes (`CardText.icon_span/1` string rendering, `ChampionsIcons` itself) is gone.

Sweep coverage: this was the only regression. The other post-#282 merges (homepage, Flavor Town game component) render no ChampionsIcons glyphs — the guess-game resource hints are deliberately plain prose.

## Test plan

- `mix compile --warnings-as-errors` clean
- `mix test test/sanctum_web/live/homebrew_live/` — 16 tests, 0 failures
- `grep -rn "font-champions" lib` → only `champions_icons.ex` and `card_text.ex` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)