### PR TITLE
fix(icons): restore resource icon colors purged from prod CSS

### DIFF
--- a/lib/sanctum/card_text.ex
+++ b/lib/sanctum/card_text.ex
@@ -21,24 +21,32 @@ defmodule Sanctum.CardText do
   """
   import Phoenix.HTML, only: [html_escape: 1, safe_to_string: 1]
 
-  # token => {glyph, resource-color class | nil}. The glyph letters are the
-  # ChampionsIcons cmap, verified against MarvelCDB's own icon CSS.
+  # token => glyph. The glyph letters are the ChampionsIcons cmap, verified
+  # against MarvelCDB's own icon CSS.
   @icons %{
-    "energy" => {"E", "text-res-energy"},
-    "mental" => {"M", "text-res-mental"},
-    "physical" => {"P", "text-res-physical"},
-    "wild" => {"W", "text-res-wild"},
-    "cost" => {"D", nil},
-    "star" => {"S", nil},
-    "boost" => {"B", nil},
-    "crisis" => {"C", nil},
-    "hazard" => {"H", nil},
-    "acceleration" => {"A", nil},
-    "amplify" => {"F", nil},
-    "per_hero" => {"G", nil},
-    "per_group" => {"T", nil},
-    "unique" => {"U", nil}
+    "energy" => "E",
+    "mental" => "M",
+    "physical" => "P",
+    "wild" => "W",
+    "cost" => "D",
+    "star" => "S",
+    "boost" => "B",
+    "crisis" => "C",
+    "hazard" => "H",
+    "acceleration" => "A",
+    "amplify" => "F",
+    "per_hero" => "G",
+    "per_group" => "T",
+    "unique" => "U"
   }
+
+  # The four resource glyphs render in their resource color: `icon_span/1`
+  # emits `text-res-<token>` for these. This module is outside Tailwind's
+  # `@source` scan path, so the literal class names that keep those utilities
+  # in the compiled CSS live in `SanctumWeb.Components.ChampionsIcons`
+  # (`resource_color/1`) — a class name that appears only here would be
+  # purged from production builds.
+  @resources ~w(energy mental physical wild)
 
   # Splits a line into whitelisted tags (`<b>`/`<i>`/`<em>` emphasis and the
   # `<hr />` divider), `[[Trait]]` references, icon tokens, and the plain text
@@ -55,23 +63,23 @@ defmodule Sanctum.CardText do
   @trait ~r/^\[\[(.+)\]\]$/
 
   @doc """
-  The `token => {glyph, color class | nil}` map of ChampionsIcons tokens.
-  Consumers outside card text (the deck writeup renderer, the description
-  editor's icon picker) share this as the single source of truth.
+  The `token => glyph` map of ChampionsIcons tokens. Consumers outside card
+  text (the deck writeup renderer, the description editor's icon picker)
+  share this as the single source of truth for which tokens have a glyph.
   """
   def icons, do: @icons
 
   @doc """
   The ChampionsIcons `<span>` for `token`, or `nil` when the font has no
-  glyph for it.
+  glyph for it. Resource glyphs carry their `text-res-*` color class.
   """
   def icon_span(token) do
     case Map.fetch(@icons, token) do
-      {:ok, {glyph, nil}} ->
-        ~s(<span class="font-champions leading-none">#{glyph}</span>)
+      {:ok, glyph} when token in @resources ->
+        ~s(<span class="font-champions leading-none text-res-#{token}">#{glyph}</span>)
 
-      {:ok, {glyph, color}} ->
-        ~s(<span class="font-champions leading-none #{color}">#{glyph}</span>)
+      {:ok, glyph} ->
+        ~s(<span class="font-champions leading-none">#{glyph}</span>)
 
       :error ->
         nil

--- a/lib/sanctum_web/components/champions_icons.ex
+++ b/lib/sanctum_web/components/champions_icons.ex
@@ -25,11 +25,24 @@ defmodule SanctumWeb.Components.ChampionsIcons do
   # glyphs that only appear outside card text: the per-player marker ("v",
   # threat plates / health badges) and the stat-effect star ("s", stat badges).
   @glyphs Map.merge(Sanctum.CardText.icons(), %{
-            "player" => {"v", nil},
-            "stat_star" => {"s", nil}
+            "player" => "v",
+            "stat_star" => "s"
           })
 
   @resources ~w(energy mental physical wild)
+
+  # token => color utility for the four resource glyphs. These literal class
+  # names — written out, never interpolated — are load-bearing for Tailwind:
+  # this file is inside the `@source` scan path in assets/css/app.css, so they
+  # are what keep the `text-res-*` utilities in the compiled CSS.
+  # `Sanctum.CardText.icon_span/1` emits the same class names at runtime but
+  # lives outside the scan path, so this map must stay in the web layer.
+  @resource_colors %{
+    "energy" => "text-res-energy",
+    "mental" => "text-res-mental",
+    "physical" => "text-res-physical",
+    "wild" => "text-res-wild"
+  }
 
   @doc """
   Renders the icon for a ChampionsIcons token — for call sites that pick the
@@ -46,18 +59,20 @@ defmodule SanctumWeb.Components.ChampionsIcons do
   attr :rest, :global
 
   def champions_icon(assigns) do
-    case Map.get(@glyphs, to_string(assigns.token)) do
-      {glyph, color} ->
-        assigns = assign(assigns, glyph: glyph, color: color)
+    token = to_string(assigns.token)
+
+    case Map.get(@glyphs, token) do
+      nil ->
+        ~H""
+
+      glyph ->
+        assigns = assign(assigns, glyph: glyph, color: resource_color(token))
 
         ~H"""
         <span class={["font-champions normal-case leading-none", @color, @class]} {@rest}>
           {@glyph}
         </span>
         """
-
-      nil ->
-        ~H""
     end
   end
 
@@ -142,8 +157,7 @@ defmodule SanctumWeb.Components.ChampionsIcons do
   def stat_star_icon(assigns), do: icon(assigns, "stat_star")
 
   defp icon(assigns, token) do
-    {glyph, color} = Map.fetch!(@glyphs, token)
-    assigns = assign(assigns, glyph: glyph, color: color)
+    assigns = assign(assigns, glyph: Map.fetch!(@glyphs, token), color: resource_color(token))
 
     ~H"""
     <span class={["font-champions normal-case leading-none", @color, @class]} {@rest}>
@@ -151,6 +165,13 @@ defmodule SanctumWeb.Components.ChampionsIcons do
     </span>
     """
   end
+
+  @doc """
+  The `text-res-*` color class for a resource token, or `nil` for tokens
+  that render uncolored. The map behind this is where the class names appear
+  literally for Tailwind's source scan — see the comment on `@resource_colors`.
+  """
+  def resource_color(token), do: Map.get(@resource_colors, to_string(token))
 
   @doc """
   Normalizes a list of resource atoms/strings into pip tokens for

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -581,8 +581,13 @@ defmodule SanctumWeb.DeckLive.Build do
   defp mention_icons do
     Sanctum.CardText.icons()
     |> Enum.sort_by(fn {token, _} -> {Map.get(@icon_order, token, 99), token} end)
-    |> Enum.map(fn {token, {glyph, color}} ->
-      %{token: token, glyph: glyph, color: color, label: Phoenix.Naming.humanize(token)}
+    |> Enum.map(fn {token, glyph} ->
+      %{
+        token: token,
+        glyph: glyph,
+        color: SanctumWeb.Components.ChampionsIcons.resource_color(token),
+        label: Phoenix.Naming.humanize(token)
+      }
     end)
   end
 

--- a/test/sanctum_web/components/champions_icons_test.exs
+++ b/test/sanctum_web/components/champions_icons_test.exs
@@ -1,0 +1,27 @@
+defmodule SanctumWeb.Components.ChampionsIconsTest do
+  use ExUnit.Case, async: true
+
+  alias SanctumWeb.Components.ChampionsIcons
+
+  describe "resource_color/1" do
+    # Sanctum.CardText.icon_span/1 emits `text-res-<token>` at runtime, but
+    # only the literal class names in ChampionsIcons' @resource_colors keep
+    # those utilities in the compiled CSS (CardText is outside Tailwind's
+    # @source scan path). This pins the two to the same naming convention so
+    # a rename in either place can't silently ship colorless icons again.
+    test "matches the class names CardText emits for every resource token" do
+      for token <- ~w(energy mental physical wild) do
+        assert ChampionsIcons.resource_color(token) == "text-res-#{token}"
+
+        assert Sanctum.CardText.icon_span(token) ==
+                 ~s(<span class="font-champions leading-none text-res-#{token}">) <>
+                   Map.fetch!(Sanctum.CardText.icons(), token) <> "</span>"
+      end
+    end
+
+    test "returns nil for non-resource tokens" do
+      assert ChampionsIcons.resource_color("boost") == nil
+      assert ChampionsIcons.resource_color(:cost) == nil
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Resource icons ([energy]/[mental]/[physical]/[wild]) render colorless on prod. The champions-icons refactor (#282) moved the literal `text-res-*` class names out of `lib/sanctum_web/components/card.ex` into `Sanctum.CardText` — which is outside Tailwind's `@source` scan path (`assets/css/app.css` only scans `lib/sanctum_web`, `assets/*`, and `ash_authentication_phoenix`). Fresh builds (i.e. `assets.deploy` on prod) therefore purged the four `text-res-*` utilities; dev looked fine only because the watcher's CSS predated the refactor.

## Fix

Move color ownership into the web layer so the class names live where Tailwind scans:

- `SanctumWeb.Components.ChampionsIcons` owns a literal `token → text-res-*` map (`resource_color/1`); its components and the deck-builder icon picker read colors from it.
- `Sanctum.CardText` keeps a glyph-only `@icons` map and emits the same `text-res-<token>` names by convention in `icon_span/1` (card text + deck writeups), with comments on both sides explaining the Tailwind-scan constraint.
- A sync test pins the two to the same naming convention so a rename in either place can't silently ship colorless icons again.

## Verification

- Fresh `mix tailwind sanctum --minify` build now contains all four `text-res-*` utilities (it contained none before this change).
- `mix test` (651 tests) and `mix ck` pass; `CardText.icon_span/1` output is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)