### PR TITLE
fix(events): PWA-safe confirmation dialogs

### DIFF
--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -133,6 +133,124 @@ defmodule SanctumWeb.CoreComponents do
   end
 
   @doc """
+  A destructive-action button that confirms via a native `<dialog>` instead of
+  the browser's `window.confirm`.
+
+  `window.confirm` (what `data-confirm` uses) is suppressed by WebKit when a
+  site runs in iOS standalone / "Add to Home Screen" PWA mode — the dialog
+  never shows and the action is silently cancelled. A `<dialog>` element works
+  in that mode, so this is the PWA-safe replacement.
+
+  The real action goes on this component as `phx-click` / `phx-value-*`
+  (forwarded to the confirm button through the global attrs); it only fires
+  after the user confirms.
+
+  ## Examples
+
+      <.confirm_button id="reset" message="Reset to full HP?" phx-click="reset">
+        Reset
+      </.confirm_button>
+  """
+  attr :id, :string, required: true, doc: "unique id for the dialog"
+  attr :message, :string, required: true, doc: "confirmation prompt shown in the dialog"
+  attr :confirm_label, :string, default: "Confirm"
+  attr :cancel_label, :string, default: "Cancel"
+  attr :class, :string, default: "", doc: "classes for the trigger button"
+  attr :aria_label, :string, default: nil, doc: "aria-label for the trigger button"
+  attr :disabled, :boolean, default: false
+
+  attr :rest, :global,
+    doc: "phx-click / phx-value-* for the confirmed action (fires only after confirming)"
+
+  slot :inner_block, required: true, doc: "the trigger button's content"
+
+  def confirm_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      class={@class}
+      disabled={@disabled}
+      aria-label={@aria_label}
+      phx-click={open_confirm(@id)}
+    >
+      {render_slot(@inner_block)}
+    </button>
+    <.confirm_dialog
+      id={@id}
+      message={@message}
+      confirm_label={@confirm_label}
+      cancel_label={@cancel_label}
+      {@rest}
+    />
+    """
+  end
+
+  @doc """
+  The `<dialog>` half of `confirm_button`, usable on its own when the trigger is
+  a differently-styled button (e.g. `<.button variant="icon">`). Open it from
+  any trigger with `phx-click={open_confirm("the-id")}`. The confirmed action
+  (`phx-click` / `phx-value-*`) is placed on this component and fires only after
+  the user confirms.
+  """
+  attr :id, :string, required: true
+  attr :message, :string, required: true
+  attr :confirm_label, :string, default: "Confirm"
+  attr :cancel_label, :string, default: "Cancel"
+  attr :rest, :global, doc: "phx-click / phx-value-* for the confirmed action"
+
+  def confirm_dialog(assigns) do
+    ~H"""
+    <dialog
+      id={@id}
+      phx-hook=".ConfirmDialog"
+      class="m-auto w-[min(22rem,90vw)] border-2 border-neutral bg-base-200 p-0 text-base-content shadow-comic backdrop:bg-black/70"
+    >
+      <div class="flex flex-col gap-4 bg-halftone p-5">
+        <p class="font-barlow-condensed text-base font-bold uppercase tracking-[0.04em]">
+          {@message}
+        </p>
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            data-confirm-cancel
+            class="cursor-pointer border-2 border-neutral bg-base-300 px-3 py-2 font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] hover:text-white"
+          >
+            {@cancel_label}
+          </button>
+          <button
+            type="button"
+            data-confirm-ok
+            {@rest}
+            class="cursor-pointer border-2 border-transparent bg-error px-3 py-2 font-barlow-condensed text-sm font-extrabold uppercase tracking-[0.08em] text-white shadow-comic-sm hover:shadow-comic"
+          >
+            {@confirm_label}
+          </button>
+        </div>
+      </div>
+      <script :type={Phoenix.LiveView.ColocatedHook} name=".ConfirmDialog">
+        export default {
+          mounted() {
+            this.open = () => { if (typeof this.el.showModal === "function") this.el.showModal() }
+            this.el.addEventListener("sanctum:confirm-open", this.open)
+            // Cancel and confirm both close the dialog; the confirm button also
+            // carries the real phx-click, which fires on the same click.
+            this.el.querySelectorAll("[data-confirm-cancel],[data-confirm-ok]").forEach((b) =>
+              b.addEventListener("click", () => this.el.close())
+            )
+            // Click on the backdrop (outside the inner box) dismisses.
+            this.el.addEventListener("click", (e) => { if (e.target === this.el) this.el.close() })
+          },
+          destroyed() { this.el.removeEventListener("sanctum:confirm-open", this.open) },
+        }
+      </script>
+    </dialog>
+    """
+  end
+
+  @doc "JS command that opens a `confirm_dialog` / `confirm_button` by id."
+  def open_confirm(id), do: JS.dispatch("sanctum:confirm-open", to: "##{id}")
+
+  @doc """
   Renders a "← Back" button that returns the user to wherever they came from
   (`history.back()`), so list pages restore their query/scroll state via the
   ScrollRestore hook instead of landing at the top. When there's nothing

--- a/lib/sanctum_web/live/event_live/index.ex
+++ b/lib/sanctum_web/live/event_live/index.ex
@@ -96,13 +96,18 @@ defmodule SanctumWeb.EventLive.Index do
             </.button>
             <.button
               variant="icon"
-              phx-click="delete"
-              phx-value-id={event.id}
-              data-confirm={"Delete #{event.name}? This cannot be undone."}
+              phx-click={open_confirm("confirm-delete-event-#{event.id}")}
               aria-label="Delete event"
             >
               <.icon name="hero-trash" class="size-4" />
             </.button>
+            <.confirm_dialog
+              id={"confirm-delete-event-#{event.id}"}
+              message={"Delete #{event.name}? This cannot be undone."}
+              confirm_label="Delete event"
+              phx-click="delete"
+              phx-value-id={event.id}
+            />
           </div>
         </.panel>
       </div>

--- a/lib/sanctum_web/live/event_live/setup.ex
+++ b/lib/sanctum_web/live/event_live/setup.ex
@@ -139,13 +139,15 @@ defmodule SanctumWeb.EventLive.Setup do
         {@event.name} <span class="text-base-content/40">— Roster</span>
         <:actions>
           <.button variant="ghost" navigate={~p"/events"}>Back</.button>
-          <.button
-            variant="primary"
-            phx-click="start"
-            data-confirm="Lock the roster and start the clocks?"
-          >
+          <.button variant="primary" phx-click={open_confirm("confirm-start")}>
             Start event
           </.button>
+          <.confirm_dialog
+            id="confirm-start"
+            message="Lock the roster and start the clocks?"
+            confirm_label="Start event"
+            phx-click="start"
+          />
         </:actions>
       </.header>
 
@@ -173,13 +175,18 @@ defmodule SanctumWeb.EventLive.Setup do
               </.button>
               <.button
                 variant="icon"
-                phx-click="delete_pod"
-                phx-value-id={pod.id}
-                data-confirm={"Delete #{pod.name} and its groups?"}
+                phx-click={open_confirm("confirm-delete-pod-#{pod.id}")}
                 aria-label="Delete pod"
               >
                 <.icon name="hero-trash" class="size-4" />
               </.button>
+              <.confirm_dialog
+                id={"confirm-delete-pod-#{pod.id}"}
+                message={"Delete #{pod.name} and its groups?"}
+                confirm_label="Delete pod"
+                phx-click="delete_pod"
+                phx-value-id={pod.id}
+              />
             </div>
           </div>
 

--- a/lib/sanctum_web/live/event_live/show.ex
+++ b/lib/sanctum_web/live/event_live/show.ex
@@ -98,14 +98,15 @@ defmodule SanctumWeb.EventLive.Show do
           <span class="mt-2 font-ibm-mono text-xs text-base-content/45">
             of {@event.time_limit_minutes} min
           </span>
-          <button
-            type="button"
+          <.confirm_button
+            id="confirm-reset-timer"
+            message="Restart the countdown from the full time limit?"
+            confirm_label="Reset clock"
             phx-click="reset_timer"
-            data-confirm="Restart the countdown from the full time limit?"
-            class="mt-4 border-2 border-neutral bg-base-300 py-2 font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] hover:text-white"
+            class="mt-4 w-full cursor-pointer border-2 border-neutral bg-base-300 py-2 font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] hover:text-white"
           >
             Reset clock
-          </button>
+          </.confirm_button>
           <div class="mt-auto pt-6">
             <div class="font-bangers text-3xl italic tracking-wide text-primary">SANCTUM</div>
             <span class="font-ibm-mono text-xs tracking-[0.14em] text-base-content/40">
@@ -157,14 +158,15 @@ defmodule SanctumWeb.EventLive.Show do
             </form>
             <.delta_button event="loki_delta" amount="-1" label="−1" />
             <.delta_button event="loki_delta" amount="1" label="+1" />
-            <button
-              type="button"
+            <.confirm_button
+              id="confirm-loki-reset"
+              message="Reset Loki, God of Lies to full hit points?"
+              confirm_label="Reset"
               phx-click="loki_reset"
-              data-confirm="Reset Loki, God of Lies to full hit points?"
-              class="border-2 border-neutral bg-base-300 px-3 py-2.5 font-barlow-condensed text-sm font-bold uppercase tracking-[0.06em] text-base-content/70 hover:text-white"
+              class="cursor-pointer border-2 border-neutral bg-base-300 px-3 py-2.5 font-barlow-condensed text-sm font-bold uppercase tracking-[0.06em] text-base-content/70 hover:text-white"
             >
               Reset
-            </button>
+            </.confirm_button>
           </div>
         </div>
 


### PR DESCRIPTION
The reset/delete buttons on the Loki event surfaces used `data-confirm`, which calls the browser's synchronous `window.confirm`. WebKit **suppresses** `alert`/`confirm`/`prompt` when a site runs in iOS standalone / "Add to Home Screen" (PWA) mode — the dialog never appears and `confirm()` returns `false`, so LiveView treats the action as cancelled. The result: those buttons did nothing on an installed iPhone PWA (they work in normal Safari).

## Fix

Add a reusable, PWA-safe confirmation built on the native `<dialog>` element (which *does* work in iOS standalone):

- `confirm_button` / `confirm_dialog` components + `open_confirm/1` in `CoreComponents` — a `<dialog>` styled in the comic-dossier theme, opened by a small colocated JS hook. The confirmed action's `phx-click` / `phx-value-*` lives on the dialog's OK button and fires **only** after the user confirms; Cancel and backdrop clicks just close it.

Replaced all five `data-confirm` usages across the events surfaces:
- Dashboard: **Reset clock**, **Reset Loki**
- Setup: **Start event**, **Delete pod**
- Index: **Delete event**

## Testing
- 16 events tests + full suite (677) green; `mix ck`, `mix ex_dna` (no duplication), unused-deps all clean.
- Verified in the browser: the trigger opens the modal, **Confirm** fires the action and closes, **Cancel** closes without acting — no `window.confirm` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)