### PR TITLE
fix: PWA-safe confirmations app-wide + narrow-card layout fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,14 @@ personal use, designed with room to grow into multiplayer.
   migrations to model domain data — change the resource and run codegen.
 - **Single dark theme.** The UI is a pinned dark "comic-dossier" design. There is
   no light/dark toggle — do not reintroduce daisyUI theme switching.
+- **Never use `data-confirm` for confirmations.** It calls `window.confirm`,
+  which WebKit **suppresses in iOS standalone / Add-to-Home-Screen (PWA) mode** —
+  the dialog never shows, `confirm()` returns false, and LiveView silently
+  cancels the action (the button appears dead). Use the PWA-safe
+  `confirm_button` / `confirm_dialog` components (with `open_confirm/1`) in
+  `SanctumWeb.CoreComponents` instead — they use a native `<dialog>` opened by a
+  colocated JS hook. Put the real `phx-click` / `phx-value-*` on the component;
+  it fires only after the user confirms.
 - There are often several agents making changes and working in the single shared gitbutler workspace. Make sure that when you are committing your change you FIRST STAGE THE SPECIFIC HUNK and then review the staged changes before committing. We have already gotten into situations where work got mixed up. 
 
 ## Technical Stack

--- a/lib/sanctum_web/live/card_live/index.ex
+++ b/lib/sanctum_web/live/card_live/index.ex
@@ -79,12 +79,15 @@ defmodule SanctumWeb.CardLive.Index do
           </:action>
 
           <:action :let={{id, card}}>
-            <.link
-              phx-click={JS.push("delete", value: %{id: card.id}) |> hide("##{id}")}
-              data-confirm="Are you sure?"
-            >
+            <.link phx-click={open_confirm("confirm-delete-card-#{card.id}")}>
               Delete
             </.link>
+            <.confirm_dialog
+              id={"confirm-delete-card-#{card.id}"}
+              message="Delete this card? This cannot be undone."
+              confirm_label="Delete card"
+              phx-click={JS.push("delete", value: %{id: card.id}) |> hide("##{id}")}
+            />
           </:action>
         </.table>
       </div>

--- a/lib/sanctum_web/live/event_live/show.ex
+++ b/lib/sanctum_web/live/event_live/show.ex
@@ -695,17 +695,21 @@ defmodule SanctumWeb.EventLive.Show do
         {@put_label}
       </button>
 
-      <div :if={@in_play} class="flex items-center gap-1.5">
-        <.delta_button event={@delta_event} id={@id} amount="-1" label="−1" />
-        <span class={["flex-1 text-center font-anton text-xl leading-none", tone_value(@tone)]}>
-          {@value}<span class="font-barlow-condensed text-xs text-base-content/40">{@unit}</span>
-        </span>
-        <.delta_button event={@delta_event} id={@id} amount="1" label="+1" />
+      <%!-- The −1 / value / +1 stepper stays together; the resolve button
+           wraps below it when the card is too narrow to fit on one row. --%>
+      <div :if={@in_play} class="flex flex-wrap items-center gap-1.5">
+        <div class="flex min-w-[7.5rem] flex-1 items-center gap-1.5">
+          <.delta_button event={@delta_event} id={@id} amount="-1" label="−1" />
+          <span class={["flex-1 text-center font-anton text-xl leading-none", tone_value(@tone)]}>
+            {@value}<span class="font-barlow-condensed text-xs text-base-content/40">{@unit}</span>
+          </span>
+          <.delta_button event={@delta_event} id={@id} amount="1" label="+1" />
+        </div>
         <button
           type="button"
           phx-click={@resolve_event}
           phx-value-id={@id}
-          class="border-2 border-secondary bg-secondary/15 px-2.5 py-1.5 font-barlow-condensed text-[0.7rem] font-bold uppercase tracking-[0.05em] text-secondary hover:bg-secondary/25"
+          class="shrink-0 border-2 border-secondary bg-secondary/15 px-2.5 py-1.5 font-barlow-condensed text-[0.7rem] font-bold uppercase tracking-[0.05em] text-secondary hover:bg-secondary/25"
         >
           {@resolve_label}
         </button>

--- a/lib/sanctum_web/live/game_live/show.ex
+++ b/lib/sanctum_web/live/game_live/show.ex
@@ -835,7 +835,7 @@ defmodule SanctumWeb.GameLive.Show do
         class="dropdown-content menu bg-gray-900 rounded-box z-1 w-52 p-2 shadow-sm"
       >
         <li class="hover:text-orange-400">
-          <a data-confirm="Are you sure? This will reset the game." phx-click="show-player-form">
+          <a phx-click={open_confirm("confirm-change-deck")}>
             Change Deck
           </a>
         </li>
@@ -850,6 +850,12 @@ defmodule SanctumWeb.GameLive.Show do
           </.link>
         </li>
       </ul>
+      <.confirm_dialog
+        id="confirm-change-deck"
+        message="Are you sure? This will reset the game."
+        confirm_label="Change deck"
+        phx-click="show-player-form"
+      />
     </div>
     """
   end

--- a/lib/sanctum_web/live/homebrew_live/edit_card.ex
+++ b/lib/sanctum_web/live/homebrew_live/edit_card.ex
@@ -402,15 +402,16 @@ defmodule SanctumWeb.HomebrewLive.EditCard do
         </.inputs_for>
 
         <div class="flex items-center gap-3 pb-16">
-          <button
+          <.confirm_button
             :if={@card.is_multi_sided}
-            type="button"
+            id="confirm-split-card"
+            message="Split this card into two single-sided cards?"
+            confirm_label="Split card"
             phx-click="unpair_card"
-            data-confirm="Split this card into two single-sided cards?"
-            class="font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-error/80 hover:text-error"
+            class="cursor-pointer font-barlow-condensed text-sm font-bold uppercase tracking-[0.08em] text-error/80 hover:text-error"
           >
             Split into two cards
-          </button>
+          </.confirm_button>
           <button
             :if={!@card.is_multi_sided}
             type="button"

--- a/lib/sanctum_web/live/homebrew_live/show.ex
+++ b/lib/sanctum_web/live/homebrew_live/show.ex
@@ -364,13 +364,19 @@ defmodule SanctumWeb.HomebrewLive.Show do
                 <.button
                   :if={!@pair_mode?}
                   variant="ghost"
-                  phx-click="delete_card"
-                  phx-value-id={card.id}
-                  data-confirm="Delete this card?"
+                  phx-click={open_confirm("confirm-del-card-#{card.id}")}
                   class="px-3 py-1.5 text-error hover:text-error"
                 >
                   Delete
                 </.button>
+                <.confirm_dialog
+                  :if={!@pair_mode?}
+                  id={"confirm-del-card-#{card.id}"}
+                  message="Delete this card?"
+                  confirm_label="Delete card"
+                  phx-click="delete_card"
+                  phx-value-id={card.id}
+                />
               </:actions>
             </.card_side_tile>
           </div>
@@ -416,22 +422,32 @@ defmodule SanctumWeb.HomebrewLive.Show do
               </span>
               <.button
                 variant="ghost"
-                phx-click="revert_alt"
-                phx-value-id={alt.id}
-                data-confirm="Convert back to a standalone card in this project?"
+                phx-click={open_confirm("confirm-revert-alt-#{alt.id}")}
                 class="ml-auto px-3 py-1.5"
               >
                 Revert
               </.button>
+              <.confirm_dialog
+                id={"confirm-revert-alt-#{alt.id}"}
+                message="Convert back to a standalone card in this project?"
+                confirm_label="Revert"
+                phx-click="revert_alt"
+                phx-value-id={alt.id}
+              />
               <.button
                 variant="ghost"
-                phx-click="delete_alt"
-                phx-value-id={alt.id}
-                data-confirm="Delete this alt art permanently?"
+                phx-click={open_confirm("confirm-del-alt-#{alt.id}")}
                 class="px-3 py-1.5 text-error hover:text-error"
               >
                 Delete
               </.button>
+              <.confirm_dialog
+                id={"confirm-del-alt-#{alt.id}"}
+                message="Delete this alt art permanently?"
+                confirm_label="Delete alt art"
+                phx-click="delete_alt"
+                phx-value-id={alt.id}
+              />
             </:actions>
           </.card_side_tile>
         </div>


### PR DESCRIPTION
Follow-up to #294 (which made the Loki event confirmations PWA-safe).

## App-wide confirmation sweep
Scanned the whole app for `data-confirm` (which calls `window.confirm` — suppressed by WebKit in iOS standalone / Add-to-Home-Screen PWA mode, so the action silently cancels). Converted every remaining usage to the `confirm_button` / `confirm_dialog` native-`<dialog>` helpers:

- Card admin: delete card
- Game board: "Change Deck" (resets the game)
- Homebrew: delete card, revert alt, delete alt, split card

There are now **no `data-confirm` usages left** in the app. Also documented the convention in `CLAUDE.md` so future work reaches for the helpers instead of `data-confirm`.

## Narrow-card layout fix
On the Loki dashboard, a group card's in-play Mangog/Door row (`−1 / value / +1 / Defeated|Cleared`) overflowed when the card was narrow. The stepper now stays together and the resolve button wraps onto its own line when there isn't room. Verified in the browser at the squeezed width.

## Testing
Full suite (677) green; `mix ck`, `mix ex_dna` (no duplication), unused-deps clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)