### PR TITLE
fix(ui): restore pointer cursor on all clickable elements

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -532,6 +532,23 @@ main, #game-board {
     color: var(--sanctum-ink);
     font-family: 'Barlow Condensed', system-ui, sans-serif;
   }
+
+  /* Tailwind v4 preflight dropped the default pointer cursor on buttons.
+     Restore it for everything clickable — including LiveView phx-click
+     targets on non-button elements. Utility classes (cursor-default,
+     cursor-grab, …) still win because they live in a later cascade layer. */
+  button:not(:disabled),
+  [role='button']:not(:disabled),
+  input[type='submit']:not(:disabled),
+  input[type='button']:not(:disabled),
+  input[type='reset']:not(:disabled),
+  input[type='checkbox']:not(:disabled),
+  input[type='radio']:not(:disabled),
+  select:not(:disabled),
+  summary,
+  [phx-click] {
+    cursor: pointer;
+  }
 }
 
 /* Global comic-dossier chrome (kept outside @layer so it wins over

--- a/lib/sanctum_web/components/core_components.ex
+++ b/lib/sanctum_web/components/core_components.ex
@@ -461,7 +461,7 @@ defmodule SanctumWeb.CoreComponents do
 
     ~H"""
     <div class="fieldset">
-      <label>
+      <label class="cursor-pointer">
         <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
         <span class="label">
           <input

--- a/lib/sanctum_web/live/card_live/sync.ex
+++ b/lib/sanctum_web/live/card_live/sync.ex
@@ -66,11 +66,11 @@ defmodule SanctumWeb.CardLive.Sync do
         </div>
 
         <form phx-submit="start" class="rounded-lg border border-base-300 bg-base-200 p-4 space-y-3">
-          <label class="flex items-center gap-2 text-sm">
+          <label class="flex cursor-pointer items-center gap-2 text-sm">
             <input type="checkbox" name="skip_images" value="true" class="checkbox checkbox-sm" />
             Skip images (card data only)
           </label>
-          <label class="flex items-center gap-2 text-sm">
+          <label class="flex cursor-pointer items-center gap-2 text-sm">
             <input type="checkbox" name="force" value="true" class="checkbox checkbox-sm" />
             Force re-upload of images already in the bucket
           </label>

--- a/lib/sanctum_web/live/dev_live/stat_badges.ex
+++ b/lib/sanctum_web/live/dev_live/stat_badges.ex
@@ -71,7 +71,7 @@ defmodule SanctumWeb.DevLive.StatBadges do
           <input type="range" name="consequential" min="0" max="4" value={@consequential} />
           <span class="font-mono w-6 text-right">{@consequential}</span>
         </label>
-        <label class="flex items-center gap-2 text-sm">
+        <label class="flex cursor-pointer items-center gap-2 text-sm">
           <input type="hidden" name="star" value="false" />
           <input type="checkbox" name="star" value="true" checked={@star} />
           <span class="uppercase tracking-widest text-xs font-bold text-base-content/70">Star</span>

--- a/lib/sanctum_web/live/game_live/game_components.ex
+++ b/lib/sanctum_web/live/game_live/game_components.ex
@@ -122,7 +122,7 @@ defmodule SanctumWeb.GameLive.GameComponents do
       <div
         id={@id <> "-drag"}
         class={[
-          "game-card max-w-fit peer relative p-1 bg-black border border-gray-700 shadow shadow-black hover:z-50 focus:z-50",
+          "game-card max-w-fit peer relative cursor-grab active:cursor-grabbing p-1 bg-black border border-gray-700 shadow shadow-black hover:z-50 focus:z-50",
           @zone == "hero_hand" &&
             "not-[.game-card-dragging]:transition-all hover:not-[.game-card-dragging]:scale-115 hover:not-[.game-card-dragging]:-translate-y-6",
           @class

--- a/lib/sanctum_web/live/game_live/new_player_component.ex
+++ b/lib/sanctum_web/live/game_live/new_player_component.ex
@@ -91,7 +91,7 @@ defmodule SanctumWeb.GameLive.NewPlayerComponent do
               prompt="Select a Deck"
               field={@form[:deck_id]}
               options={@decks}
-              class="w-full input rounded text-base-content"
+              class="w-full input rounded text-base-content cursor-pointer"
             />
             <div>
               <.button type="submit">Select</.button>


### PR DESCRIPTION
## Summary

Tailwind v4's preflight removed the default `cursor: pointer` on buttons, leaving many buttons and clickable elements with the default arrow cursor unless `cursor-pointer` was added by hand.

- **Global base-layer rule** in `app.css`: `cursor: pointer` for non-disabled buttons, `[role="button"]`, submit/button/reset inputs, checkboxes, radios, selects, `<summary>`, and any element with `[phx-click]` — covering LiveView click targets on divs/spans/li. Utility classes (`cursor-default`, `cursor-grab`) still override it from the later cascade layer, and `disabled` buttons keep the default cursor.
- **Checkbox-wrapping labels** get `cursor-pointer`: the shared `<.input type="checkbox">` component, card sync options, and the dev stat-badges page.
- **Deck select** in the game player form: daisyUI's `input` class forces `cursor: text` on the `<select>`; added `cursor-pointer`.
- **Draggable game cards** (`CardDrag` hook) now show `cursor-grab` / `active:cursor-grabbing` instead of inheriting the parent's pointer.

## Verification

Audited every route with a playwright script checking the computed cursor of all clickable elements (`/`, `/cards`, `/decks`, `/games`, `/stats`, `/profile`, sign-in, game board). Remaining non-pointer cursors are intentional (daisyUI drawer scrim when pinned open on desktop, text-field labels). `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)