### PR TITLE
fix(cards): keep pool total denominator at full catalog size

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -6,6 +6,11 @@ import Config
 # cold CI runner, so give async loads generous headroom.
 config :ex_unit, assert_receive_timeout: 2000
 
+# The pool card-count cache is node-global `:persistent_term`; a 0 TTL forces
+# every fetch to recompute against the calling test's Ecto sandbox instead of
+# leaking a count between `async: true` tests.
+config :sanctum, Sanctum.Games.CardPoolCount, ttl: 0
+
 config :sanctum, Oban, testing: :manual
 config :sanctum, :marvel_cdb_req_options, plug: {Req.Test, Sanctum.MarvelCdb}
 config :sanctum, token_signing_secret: "/oZ9ck2w3h4oPYA4x7ZebHnqCh1MKXIp"

--- a/lib/sanctum/games/card_pool_count.ex
+++ b/lib/sanctum/games/card_pool_count.ex
@@ -1,0 +1,83 @@
+defmodule Sanctum.Games.CardPoolCount do
+  @moduledoc """
+  Cached total-count of the browsable card pool for the "/ N cards" denominator
+  on `SanctumWeb.CardLive.Pool`.
+
+  `total` is the full **unfiltered** catalog size for the current viewer — it
+  must never be derived from a filtered load (arriving at `/cards` from the
+  global search seeds the page with a query, so the first load is already
+  filtered; taking its count as the total is what produced the "4161 / 15"
+  bug). The catalog only changes on a card sync, so the count is memoised
+  per-node in `:persistent_term` with a short TTL, keyed by everything that can
+  change which rows a viewer may see (browse `scope` + actor). Mirrors the
+  `Sanctum.Search.ValueCache` approach — no invalidation wiring, lazy refresh.
+
+  The loader runs in the calling process (the LiveView's async task), so the
+  Ecto sandbox connection ownership just works in tests.
+  """
+
+  require Ash.Query
+
+  alias Sanctum.Games.CardSide
+
+  @default_ttl :timer.minutes(10)
+
+  # Overridable per-env: config/test.exs sets it to 0 so every fetch recomputes
+  # against the calling test's Ecto sandbox instead of leaking a count between
+  # `async: true` tests that share this node-global `:persistent_term`.
+  defp ttl_default, do: Application.get_env(:sanctum, __MODULE__, [])[:ttl] || @default_ttl
+
+  @doc """
+  Return the cached unfiltered pool count for `actor` + `scope`, running the
+  count query (and caching it) when the entry is missing or expired.
+
+  Returns `nil` if the count query fails, so the LiveView degrades to its
+  loading state instead of crashing.
+  """
+  @spec total(term(), String.t() | nil, keyword()) :: non_neg_integer() | nil
+  def total(actor, scope \\ nil, opts \\ []) do
+    ttl = Keyword.get(opts, :ttl, ttl_default())
+    key = {actor_key(actor), scope}
+    now = System.monotonic_time(:millisecond)
+
+    case :persistent_term.get({__MODULE__, key}, :miss) do
+      {count, expires_at} when expires_at > now ->
+        count
+
+      _ ->
+        load(key, actor, scope, now + ttl)
+    end
+  end
+
+  @doc "Drop every cached count (used by tests and after manual syncs)."
+  @spec reset() :: :ok
+  def reset do
+    for {{__MODULE__, _key} = key, _value} <- :persistent_term.get() do
+      :persistent_term.erase(key)
+    end
+
+    :ok
+  end
+
+  defp load(key, actor, scope, expires_at) do
+    count =
+      CardSide
+      |> Ash.Query.for_read(:browse, %{scope: scope}, actor: actor)
+      |> Ash.count!()
+
+    :persistent_term.put({__MODULE__, key}, {count, expires_at})
+    count
+  rescue
+    error ->
+      require Logger
+
+      Logger.warning("card pool count loader failed: #{Exception.message(error)}")
+
+      nil
+  end
+
+  # Actor visibility only differs by the actor's own homebrew, so keying by id
+  # (nil when anonymous) is enough to keep distinct viewers from sharing a count.
+  defp actor_key(%{id: id}), do: id
+  defp actor_key(_), do: nil
+end

--- a/lib/sanctum_web/infinite_scroll.ex
+++ b/lib/sanctum_web/infinite_scroll.ex
@@ -60,6 +60,24 @@ defmodule SanctumWeb.InfiniteScroll do
       else: socket
   end
 
+  @doc """
+  Assign the unfiltered catalog `:total` (the "/ N" denominator). `nil` means
+  this load didn't refetch it — only the first/reset load does — so the
+  existing total is left untouched. It must be computed independently of the
+  visible page: deriving it from a filtered load's count breaks whenever that
+  load already carries a query (e.g. arriving from global search).
+  """
+  def assign_total(socket, nil), do: socket
+  def assign_total(socket, total), do: assign(socket, :total, total)
+
+  @doc """
+  Assign the filtered visible `:count` on reset loads only — `page.count` is
+  queried just on resets (`count: reset?`), so non-reset (scroll) loads keep
+  the prior count.
+  """
+  def assign_count(socket, false, _count), do: socket
+  def assign_count(socket, true, count), do: assign(socket, :count, count)
+
   defp confirm_scroll_restore(socket) do
     socket
     |> assign(:scroll_restore_pending?, false)

--- a/lib/sanctum_web/live/card_live/pool.ex
+++ b/lib/sanctum_web/live/card_live/pool.ex
@@ -243,7 +243,7 @@ defmodule SanctumWeb.CardLive.Pool do
 
   @impl true
   def handle_async(:load_cards, {:ok, result}, socket) do
-    %{req: req, offset: offset, reset?: reset?, page: page, colors: colors} = result
+    %{req: req, offset: offset, reset?: reset?, page: page, total: total, colors: colors} = result
 
     # A newer filter/search/page request has since fired; drop these stale
     # results so out-of-order completions can't clobber the current view.
@@ -256,7 +256,8 @@ defmodule SanctumWeb.CardLive.Pool do
         |> assign(:offset, offset)
         |> assign(:end_of_timeline?, !page.more?)
         |> assign(:loading?, false)
-        |> maybe_assign_count(reset?, page.count)
+        |> InfiniteScroll.assign_total(total)
+        |> InfiniteScroll.assign_count(reset?, page.count)
         |> stream(
           :cards,
           Enum.map(page.results, &side_view(&1, hero_colors)),
@@ -299,6 +300,7 @@ defmodule SanctumWeb.CardLive.Pool do
     filters = filters(socket.assigns)
     actor = socket.assigns[:current_user]
     fetch_colors? = socket.assigns.hero_colors == %{}
+    fetch_total? = is_nil(socket.assigns.total)
 
     socket
     |> assign(:req_id, req)
@@ -309,9 +311,10 @@ defmodule SanctumWeb.CardLive.Pool do
         |> Ash.Query.for_read(:browse, filters, actor: actor)
         |> Ash.read!(page: [limit: limit, offset: query_offset, count: reset?])
 
+      total = if fetch_total?, do: Sanctum.Games.CardPoolCount.total(actor), else: nil
       colors = if fetch_colors?, do: Sanctum.Heroes.hero_color_map(), else: nil
 
-      %{req: req, offset: offset, reset?: reset?, page: page, colors: colors}
+      %{req: req, offset: offset, reset?: reset?, page: page, total: total, colors: colors}
     end)
   end
 
@@ -321,17 +324,6 @@ defmodule SanctumWeb.CardLive.Pool do
     params = if f.query == "", do: [], else: [query: f.query]
 
     ~p"/cards?#{params}"
-  end
-
-  # `page.count` is only queried on reset loads (count: reset?). `total` is the
-  # full unfiltered catalog size — set once from the first load (mount always
-  # runs unfiltered) and left untouched as filters narrow the visible count.
-  defp maybe_assign_count(socket, false, _count), do: socket
-
-  defp maybe_assign_count(socket, true, count) do
-    socket
-    |> assign(:count, count)
-    |> then(fn s -> if is_nil(s.assigns.total), do: assign(s, :total, count), else: s end)
   end
 
   defp filters(assigns) do

--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -347,8 +347,8 @@ defmodule SanctumWeb.DeckLive.Index do
         |> assign(:offset, offset)
         |> assign(:end_of_timeline?, !page.more?)
         |> assign(:loading?, false)
-        |> maybe_assign_total(total)
-        |> maybe_assign_count(reset?, page.count)
+        |> InfiniteScroll.assign_total(total)
+        |> InfiniteScroll.assign_count(reset?, page.count)
         |> stream(:decks, Enum.map(page.results, &deck_view(&1, socket.assigns.timezone)),
           reset: reset?
         )
@@ -431,16 +431,6 @@ defmodule SanctumWeb.DeckLive.Index do
 
     ~p"/decks?#{params}"
   end
-
-  # `total` (the unfiltered catalog size) is fetched once via `load_total/1` and
-  # then left untouched. nil means this load didn't refetch it.
-  defp maybe_assign_total(socket, nil), do: socket
-  defp maybe_assign_total(socket, total), do: assign(socket, :total, total)
-
-  # `page.count` is only queried on reset loads (count: reset?) — it's the
-  # filtered visible count, distinct from the unfiltered `total`.
-  defp maybe_assign_count(socket, false, _count), do: socket
-  defp maybe_assign_count(socket, true, count), do: assign(socket, :count, count)
 
   defp filters(a) do
     %{query: a.query, sort: a.sort}

--- a/test/sanctum_web/live/card_live/pool_test.exs
+++ b/test/sanctum_web/live/card_live/pool_test.exs
@@ -94,6 +94,31 @@ defmodule SanctumWeb.CardLive.PoolTest do
     refute html =~ "Spider-Man"
   end
 
+  test "mounting with a filter keeps the total denominator at the full catalog size",
+       %{conn: conn} do
+    # Regression: arriving at /cards from the global search seeds the first load
+    # with a query, so it's already filtered. The "/ N cards" denominator must
+    # still report the full catalog (2), not the filtered count (1) — otherwise
+    # clearing the filter showed the "2 / 1 cards" bug.
+    make_card(%{code: "01001a", name: "Spider-Man", type: :hero})
+    make_card(%{code: "01003a", name: "Web Kick", type: :event, ownership: :hero})
+
+    {:ok, lv, _html} = live(conn, ~p"/cards?query=web")
+    html = render_async(lv)
+
+    assert html =~ "Web Kick"
+    refute html =~ "Spider-Man"
+    assert html =~ "/ 2 cards"
+
+    # Clearing the filter must not leave a stale denominator behind.
+    lv |> form("#card-search", query: "") |> render_change()
+    html = render_async(lv)
+
+    assert html =~ "Spider-Man"
+    assert html =~ "Web Kick"
+    assert html =~ "/ 2 cards"
+  end
+
   test "unknown filter params fall back to defaults", %{conn: conn} do
     make_card(%{code: "01001a", name: "Spider-Man", type: :hero})
 


### PR DESCRIPTION
Navigating to `/cards` from the global search (which carries a `?query=` in the URL) showed a wrong denominator in the "N / total cards" header — e.g. **4161 / 15**. The second number should always be the full catalog size.

## Root cause

`CardLive.Pool` derived `total` from the **first page load's count**, on the assumption (stated in a comment) that the initial mount always runs unfiltered. Arriving from global search breaks that: the first load is already filtered, so `total` got seeded with the filtered count (15). Clearing the filter then recomputed the visible `count` to 4161 but left the stale `total`.

## Fix

- Compute `total` from a **separate unfiltered browse count**, decoupled from the visible page — mirroring the pattern already used in `deck_live/index.ex`.
- Cache it per-node in `:persistent_term` (new `Sanctum.Games.CardPoolCount`), keyed by actor + browse scope, since the catalog only changes on a card sync. Follows the existing `Sanctum.Search.ValueCache` approach (lazy TTL refresh, no invalidation wiring).
- A `0` TTL in test env forces every fetch to recompute against the calling `async: true` test's Ecto sandbox instead of leaking a count through the node-global cache.

## Testing

- New regression test: mount with `?query=web`, assert the denominator stays `/ 2 cards` while filtered and after clearing the filter.
- `mix test test/sanctum_web/live/card_live/pool_test.exs` → 12 passing.
- `mix format` + `mix credo` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)