### PR TITLE
feat(catalog): add Fear No Evil (fne) release support

### DIFF
--- a/lib/sanctum/catalog/curated.ex
+++ b/lib/sanctum/catalog/curated.ex
@@ -17,7 +17,7 @@ defmodule Sanctum.Catalog.Curated do
 
   alias Sanctum.Catalog
 
-  @waves for n <- 1..10, do: %{number: n, name: "Wave #{n}"}
+  @waves for n <- 1..11, do: %{number: n, name: "Wave #{n}"}
 
   # Pack code => {product_type, wave number (nil for no wave)}. Only packs
   # MarvelCDB actually returns are overlaid; unknown codes are ignored.
@@ -91,6 +91,8 @@ defmodule Sanctum.Catalog.Curated do
     "synthezoid" => {:scenario_pack, 10},
     "wonder_man" => {:hero_pack, 10},
     "hercules" => {:hero_pack, 10},
+    # Wave 11 — Fear No Evil
+    "fne" => {:campaign_expansion, 11},
     # No wave — standalone organized-play modular set
     "ron" => {:promo, nil}
   }


### PR DESCRIPTION
Adds support for the **Fear No Evil** (`fne`) release — a Wave 11 campaign expansion (Daredevil + Echo, published to MarvelCDB 2026-07-24).

## Change

Registers `fne` in the curated release-taxonomy overlay (`Sanctum.Catalog.Curated`), which is the only hand-maintained piece since MarvelCDB doesn't expose product-type or wave:

- Extend the wave range `1..10` → `1..11`
- Add `"fne" => {:campaign_expansion, 11}` (a full box with 2 heroes + villains + modular sets, same format as Civil War)

Everything else flows automatically from the MarvelCDB sync — packs, card sets, cards, heroes, and villains. The Sense deck's new `hero_special` card-set type already maps to `:hero` in `marvel_cdb.ex`, so no enum change was needed.

## Verified (full `CardSync.run` in dev — 3951 cards, 0 failures)

- Pack `fne`: `product_type = campaign_expansion`, `wave = 11`
- 5 card sets typed/linked: `daredevil`, `daredevil_sense_deck`, `daredevil_nemesis`, `echo`, `echo_nemesis`
- Both heroes multi-sided with alter-egos + gradient colors: Daredevil / Matt Murdock, Echo / Maya Lopez

## Follow-ups (out of scope, not blocking)

- **Scenarios aren't playable yet.** MarvelCDB carries no encounter-card data for the fne villains/modular sets (Kingpin, Bullseye, Electro; The Getaway, Protection Racket, The Raft Breakout), so no `Scenario` rows were seeded — they'd otherwise build empty encounter decks.
- **Images need mirroring.** The fne scans require the one-time bucket mirror in prod (`Sanctum.Release.sync_cards()` with bucket creds) to render.
- **Gotcha noted:** `mix sanctum.sync_cards --pack <code>` is incomplete for multi-sided hero cards (the `/cards/{pack}` endpoint nests alter-egos as `linked_card`); only the full sync assembles them. The prod path (`Sanctum.Release.sync_cards()`) uses the full sync, so this is fine in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)