### PR TITLE
feat(auth): return to originating page (and scroll) after sign-in

### DIFF
--- a/lib/sanctum_web/live/deck_live/index.ex
+++ b/lib/sanctum_web/live/deck_live/index.ex
@@ -247,6 +247,7 @@ defmodule SanctumWeb.DeckLive.Index do
       |> assign(:req_id, 0)
       |> assign(:loading?, true)
       |> assign(:scroll_restore_pending?, false)
+      |> assign(:return_path, ~p"/decks")
       |> stream(:decks, [])
 
     {:ok, socket}
@@ -258,7 +259,7 @@ defmodule SanctumWeb.DeckLive.Index do
   # data load also starts here — only on the connected mount (req_id == 0
   # guards the first pass); the static render just paints the shell.
   @impl true
-  def handle_params(params, _uri, socket) do
+  def handle_params(params, uri, socket) do
     query = params["query"] || ""
     sort = if params["sort"] in @sort_keys, do: params["sort"], else: "new"
 
@@ -270,6 +271,9 @@ defmodule SanctumWeb.DeckLive.Index do
           assign(socket,
             query: query,
             sort: sort,
+            # Full path+query of the current view — where a signed-out favorite
+            # click returns to after sign-in (and the scroll-restore key).
+            return_path: request_path(uri),
             search_diagnostics: search_diagnostics(query),
             filter_count: FormSync.active_count(query, Sanctum.Search.DeckFields)
           )
@@ -375,7 +379,8 @@ defmodule SanctumWeb.DeckLive.Index do
   def handle_event("toggle_favorite", %{"id" => id, "favorited" => favorited}, socket) do
     case socket.assigns.current_user do
       nil ->
-        {:noreply, push_navigate(socket, to: ~p"/sign-in")}
+        to = SanctumWeb.ReturnTo.sign_in_path(socket.assigns.return_path)
+        {:noreply, push_navigate(socket, to: to)}
 
       actor ->
         now_favorited = favorited != "true"
@@ -493,6 +498,15 @@ defmodule SanctumWeb.DeckLive.Index do
 
   defp filters(a) do
     %{query: a.query, sort: a.sort}
+  end
+
+  # Path + query of the current view, from handle_params' uri — the local path
+  # ReturnTo sends a signed-out favoriter back to (and the scroll-restore key).
+  defp request_path(uri) do
+    case URI.parse(uri) do
+      %URI{path: path, query: nil} -> path
+      %URI{path: path, query: query} -> path <> "?" <> query
+    end
   end
 
   # Advisory parse/compile problems shown under the query input ("unknown

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -371,7 +371,8 @@ defmodule SanctumWeb.DeckLive.Show do
   # Pushed by the favorite_button hook. `favorited` is the state at click time;
   # we flip to the opposite. Signed-out visitors are sent to sign-in instead.
   def handle_event("toggle_favorite", _params, %{assigns: %{current_user: nil}} = socket) do
-    {:noreply, push_navigate(socket, to: ~p"/sign-in")}
+    to = SanctumWeb.ReturnTo.sign_in_path(~p"/decks/#{socket.assigns.deck.id}")
+    {:noreply, push_navigate(socket, to: to)}
   end
 
   def handle_event("toggle_favorite", %{"favorited" => favorited}, socket) do

--- a/lib/sanctum_web/return_to.ex
+++ b/lib/sanctum_web/return_to.ex
@@ -1,0 +1,57 @@
+defmodule SanctumWeb.ReturnTo do
+  @moduledoc """
+  Post-sign-in return-path handling.
+
+  Two cooperating pieces:
+
+    * `sign_in_path/1` builds the sign-in URL carrying a `return_to` query param
+      — used by LiveViews that bounce a signed-out action (e.g. favoriting a
+      deck) to sign-in.
+    * the plug (`call/2`) persists that `return_to` into the session on the way
+      through the auth routes, so `SanctumWeb.AuthController.success/4` (which
+      reads `get_session(conn, :return_to)`) sends the user back where they came
+      from once authenticated.
+
+  Both validate that the path is a same-origin absolute path, never a full URL
+  or scheme-relative `//host`, so a crafted `return_to` can't become an open
+  redirect.
+  """
+
+  use SanctumWeb, :verified_routes
+
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    case conn.params["return_to"] do
+      path when is_binary(path) ->
+        if local_path?(path), do: put_session(conn, :return_to, path), else: conn
+
+      _ ->
+        conn
+    end
+  end
+
+  @doc """
+  The sign-in URL, returning the user to `path` afterwards when it's a safe
+  local path; otherwise the plain sign-in URL.
+  """
+  def sign_in_path(path) do
+    if is_binary(path) and local_path?(path) do
+      ~p"/sign-in?#{[return_to: path]}"
+    else
+      ~p"/sign-in"
+    end
+  end
+
+  # Same-origin absolute path only. Rejects "" (not absolute), "//evil.com"
+  # (scheme-relative) and "https://evil.com" (absolute URL).
+  defp local_path?(path) do
+    String.starts_with?(path, "/") and not String.starts_with?(path, "//")
+  end
+end

--- a/lib/sanctum_web/router.ex
+++ b/lib/sanctum_web/router.ex
@@ -43,6 +43,13 @@ defmodule SanctumWeb.Router do
     plug :accepts, ["json"]
   end
 
+  # Persists a validated `?return_to` path into the session so
+  # AuthController.success/4 can send the user back after they sign in
+  # (e.g. after favoriting a deck while signed out). Scoped to the auth routes.
+  pipeline :capture_return_to do
+    plug SanctumWeb.ReturnTo
+  end
+
   scope "/", SanctumWeb do
     pipe_through :browser
 
@@ -150,7 +157,7 @@ defmodule SanctumWeb.Router do
   end
 
   scope "/", SanctumWeb do
-    pipe_through :browser
+    pipe_through [:browser, :capture_return_to]
 
     auth_routes AuthController, Sanctum.Accounts.User, path: "/auth"
 

--- a/test/sanctum_web/live/deck_live/index_test.exs
+++ b/test/sanctum_web/live/deck_live/index_test.exs
@@ -105,17 +105,23 @@ defmodule SanctumWeb.DeckLive.IndexTest do
     test "anonymous visitors see the star but get routed to sign-in", %{conn: conn} do
       deck = make_deck("Web Warrior", "spider_man", "90001", "Spider-Man", [:justice])
 
-      {:ok, view, _html} = live(conn, ~p"/decks")
+      # Mount with a filter in the URL so we can assert it's preserved in the
+      # return path.
+      {:ok, view, _html} = live(conn, ~p"/decks?sort=title")
       render_async(view)
 
       # The star renders for everyone, labelled for the signed-out case.
       assert has_element?(view, "button[title='Sign in to favorite decks']")
 
-      # Clicking it redirects to sign-in rather than creating a favorite.
-      assert {:error, {redirect_kind, %{to: "/sign-in"}}} =
+      # Clicking it redirects to sign-in, carrying the current path (query and
+      # all, so the user returns to the same filtered view + scroll afterwards)
+      # rather than creating a favorite.
+      assert {:error, {redirect_kind, %{to: to}}} =
                view |> element("#fav-#{deck.id}") |> render_click()
 
       assert redirect_kind in [:live_redirect, :redirect]
+      assert %URI{path: "/sign-in", query: query} = URI.parse(to)
+      assert URI.decode_query(query) == %{"return_to" => "/decks?sort=title"}
 
       assert Sanctum.Decks.DeckFavorite
              |> Ash.Query.filter(deck_id == ^deck.id)

--- a/test/sanctum_web/live/deck_live/show_test.exs
+++ b/test/sanctum_web/live/deck_live/show_test.exs
@@ -224,11 +224,14 @@ defmodule SanctumWeb.DeckLive.ShowTest do
       assert has_element?(view, "button[title='Sign in to favorite decks']")
       refute has_element?(view, "button[title='Add to favorites']")
 
-      # Clicking it redirects to sign-in rather than creating a favorite.
-      assert {:error, {redirect_kind, %{to: "/sign-in"}}} =
+      # Clicking it redirects to sign-in (carrying the deck's path so the user
+      # returns here afterwards) rather than creating a favorite.
+      assert {:error, {redirect_kind, %{to: to}}} =
                view |> element("button[title='Sign in to favorite decks']") |> render_click()
 
       assert redirect_kind in [:live_redirect, :redirect]
+      assert %URI{path: "/sign-in", query: query} = URI.parse(to)
+      assert URI.decode_query(query) == %{"return_to" => "/decks/#{deck.id}"}
 
       assert Sanctum.Decks.DeckFavorite
              |> Ash.Query.filter(deck_id == ^deck.id)

--- a/test/sanctum_web/return_to_test.exs
+++ b/test/sanctum_web/return_to_test.exs
@@ -1,0 +1,46 @@
+defmodule SanctumWeb.ReturnToTest do
+  @moduledoc false
+  use SanctumWeb.ConnCase, async: true
+
+  alias SanctumWeb.ReturnTo
+
+  describe "sign_in_path/1" do
+    test "carries a safe local path as return_to" do
+      assert ReturnTo.sign_in_path("/decks") == "/sign-in?return_to=%2Fdecks"
+
+      assert %URI{path: "/sign-in", query: query} =
+               URI.parse(ReturnTo.sign_in_path("/decks?query=hero:spider"))
+
+      assert URI.decode_query(query) == %{"return_to" => "/decks?query=hero:spider"}
+    end
+
+    test "falls back to plain sign-in for unsafe or missing paths" do
+      # Open-redirect vectors and non-paths must not become a return_to.
+      for bad <- ["//evil.com", "https://evil.com", "http://evil.com", "", "decks", nil] do
+        assert ReturnTo.sign_in_path(bad) == "/sign-in"
+      end
+    end
+  end
+
+  describe "call/2 (plug)" do
+    setup do
+      {:ok, conn: Plug.Test.init_test_session(build_conn(), %{})}
+    end
+
+    test "persists a safe local return_to into the session", %{conn: conn} do
+      conn = %{conn | params: %{"return_to" => "/decks?query=hero:spider"}}
+      conn = ReturnTo.call(conn, [])
+
+      assert get_session(conn, :return_to) == "/decks?query=hero:spider"
+    end
+
+    test "ignores unsafe or absent return_to", %{conn: conn} do
+      for bad <- ["//evil.com", "https://evil.com"] do
+        result = ReturnTo.call(%{conn | params: %{"return_to" => bad}}, [])
+        assert get_session(result, :return_to) == nil
+      end
+
+      assert ReturnTo.call(%{conn | params: %{}}, []) |> get_session(:return_to) == nil
+    end
+  end
+end


### PR DESCRIPTION
## What

When a signed-out visitor clicks the favorite star, they're sent to sign-in and — after authenticating — returned to the exact page they were on, scroll position included.

> Stacked on #312 (deck favorites). Review/merge that first.

## How

- **`SanctumWeb.ReturnTo`** is both a plug and a helper:
  - **plug** — persists a validated `?return_to` into the session on the auth routes (via a new `:capture_return_to` pipeline), which `AuthController.success/4` already reads to redirect after sign-in.
  - **helper** — `sign_in_path/1` builds `/sign-in?return_to=…`.
  - Both reject non-local paths (`//host`, absolute URLs) so a crafted `return_to` can't become an open redirect.
- The signed-out toggle handlers build the return path **server-side** — the deck browser's current URL (from `handle_params`) or the deck's own path on the detail page — so nothing extra is sent from the client.
- **Scroll restores for free**: the existing `ScrollRestore` hook keys `sessionStorage` on `path + query`, which survives the sign-in round-trip. Returning to the *exact* same URL restores both scroll offset and infinite-scroll page depth.

## Testing

- Verified the real round-trip in the browser: clicking the star while signed out redirects to `/sign-in?return_to=%2Fdecks%3Fsort%3Dtitle` (originating URL preserved).
- Unit tests for `ReturnTo` (open-redirect rejection + session persistence); the deck LiveView tests assert the signed-out redirect now carries `return_to`. Full deck LiveView + return_to suites pass; `mix ck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #313 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #312
<!-- GitButler Footer Boundary Bottom -->

