### PR TITLE
feat(admin): trigger deck sync from a chosen start date

### DIFF
--- a/lib/sanctum/decks/decklist_sync_worker.ex
+++ b/lib/sanctum/decks/decklist_sync_worker.ex
@@ -8,18 +8,29 @@ defmodule Sanctum.Decks.DecklistSyncWorker do
   executing, but a fresh run proceeds once the prior one reaches a terminal
   state. This matters because a single run mutates the shared sync cursor and
   makes a burst of MarvelCDB calls — two at once would race and double the load.
+  Uniqueness is keyed on `[:worker, :queue]` (not `:args`) so an ad-hoc
+  `since` backfill still debounces against the plain hourly run rather than
+  racing it.
+
+  Optional job args:
+
+    * `"since"` — an ISO-8601 date string (`"2024-01-01"`). Runs a historical
+      backfill from that day to today instead of resuming from the stored
+      cursor. A historical `since` never rewinds the cursor (see `DeckSync`),
+      so it's a safe way to re-walk and pick up decks a past run missed.
   """
 
   use Oban.Worker,
     queue: :default,
     max_attempts: 5,
-    unique: [period: :infinity, states: :incomplete]
+    unique: [fields: [:worker, :queue], period: :infinity, states: :incomplete]
 
   @impl Oban.Worker
-  def perform(_job) do
+  def perform(%Oban.Job{args: args}) do
     # Route progress into the Monitor so the admin dashboard can watch the run
     # live (and see its outcome afterward); the Monitor also handles logging.
-    result = Sanctum.DeckSync.run(progress_fun: &Sanctum.DeckSync.Monitor.report/1)
+    opts = maybe_put_since([progress_fun: &Sanctum.DeckSync.Monitor.report/1], args)
+    result = Sanctum.DeckSync.run(opts)
 
     # Uniqueness recompute is left to the nightly ComputeUniquenessWorker cron:
     # enqueueing it after every sync run meant the full-library sweep (a
@@ -39,4 +50,16 @@ defmodule Sanctum.Decks.DecklistSyncWorker do
         {:error, "deck sync halted at #{summary.halted.date}: #{inspect(summary.halted.reason)}"}
     end
   end
+
+  # Oban serializes args to JSON, so `since` arrives as a string. A malformed
+  # value is ignored (falls back to a normal cursor-resuming run) rather than
+  # failing the job.
+  defp maybe_put_since(opts, %{"since" => since}) when is_binary(since) do
+    case Date.from_iso8601(since) do
+      {:ok, date} -> Keyword.put(opts, :since, date)
+      {:error, _} -> opts
+    end
+  end
+
+  defp maybe_put_since(opts, _args), do: opts
 end

--- a/lib/sanctum_web/live/admin_live/index.ex
+++ b/lib/sanctum_web/live/admin_live/index.ex
@@ -85,6 +85,28 @@ defmodule SanctumWeb.AdminLive.Index do
             </button>
           </div>
 
+          <form
+            phx-submit="sync_decks_from"
+            class="flex flex-col gap-3 border-t-2 border-neutral/50 pt-4 sm:flex-row sm:items-end"
+          >
+            <div class="w-full sm:w-auto">
+              <.input type="date" name="since" value={@deck_sync_since} label="Backfill from" />
+            </div>
+            <.button
+              variant="ghost"
+              type="submit"
+              disabled={@deck_sync.status == :running}
+              class="whitespace-nowrap"
+            >
+              <.icon name="hero-calendar-days" class="size-4" /> Sync from date
+            </.button>
+          </form>
+          <p class="font-ibm-mono text-xs text-base-content/40">
+            Re-walks MarvelCDB day by day from the chosen date to today, importing any
+            decks a past run missed. Imports upsert, so re-running is safe, and a
+            historical date never rewinds the live cursor.
+          </p>
+
           <div :if={@deck_sync.status == :running} class="space-y-2">
             <div class="flex items-baseline justify-between font-ibm-mono text-xs text-base-content/70">
               <span>
@@ -299,6 +321,7 @@ defmodule SanctumWeb.AdminLive.Index do
       |> assign(:deck_sync, Sanctum.DeckSync.Monitor.status())
       |> assign(:deck_health, %{cursor: nil, last_run: nil})
       |> assign(:deck_import, %{status: :idle, deck: nil, error: nil, url: ""})
+      |> assign(:deck_sync_since, "")
 
     # Skip the ~10 count/aggregate queries on the static render; load them
     # asynchronously once the socket connects so the shell paints immediately.
@@ -333,6 +356,33 @@ defmodule SanctumWeb.AdminLive.Index do
         else: "Deck sync enqueued."
 
     {:noreply, put_flash(socket, :info, message)}
+  end
+
+  # Enqueue a historical backfill from a chosen start date. Same worker and
+  # `unique` debounce as "Sync now", but with a `since` arg — `DeckSync` walks
+  # from that day to today, re-importing (idempotently) any decks a prior run
+  # missed. A historical date never rewinds the live cursor.
+  @impl true
+  def handle_event("sync_decks_from", %{"since" => since}, socket) do
+    socket = assign(socket, :deck_sync_since, since)
+
+    case Date.from_iso8601(since) do
+      {:ok, date} ->
+        {:ok, job} =
+          %{since: Date.to_iso8601(date)}
+          |> Sanctum.Decks.DecklistSyncWorker.new()
+          |> Oban.insert()
+
+        message =
+          if job.conflict?,
+            do: "A deck sync is already queued or running.",
+            else: "Deck sync enqueued from #{Date.to_iso8601(date)}."
+
+        {:noreply, put_flash(socket, :info, message)}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Enter a valid start date.")}
+    end
   end
 
   @impl true

--- a/test/sanctum_web/live/admin_live/index_test.exs
+++ b/test/sanctum_web/live/admin_live/index_test.exs
@@ -4,6 +4,7 @@ defmodule SanctumWeb.AdminLive.IndexTest do
   # async: false — the import test toggles the global `:marvel_cdb_req_options`
   # env to route MarvelCDB requests to a Req.Test stub.
   use SanctumWeb.ConnCase, async: false
+  use Oban.Testing, repo: Sanctum.Repo
 
   import Phoenix.LiveViewTest
   import Sanctum.Factory
@@ -61,6 +62,35 @@ defmodule SanctumWeb.AdminLive.IndexTest do
     {:ok, deck} = Sanctum.Decks.get_deck_by_mcdb_id("55555")
     assert deck
     assert html =~ ~p"/decks/#{deck.id}"
+  end
+
+  test "renders the deck-sync backfill form", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/admin")
+
+    assert html =~ "Backfill from"
+    assert html =~ "sync_decks_from"
+  end
+
+  test "rejects an invalid backfill start date without enqueuing a sync", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin")
+
+    html =
+      view
+      |> form("form[phx-submit=sync_decks_from]", %{"since" => ""})
+      |> render_submit()
+
+    assert html =~ "Enter a valid start date"
+    refute_enqueued(worker: Sanctum.Decks.DecklistSyncWorker)
+  end
+
+  test "enqueues a backfill sync from the chosen start date", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin")
+
+    view
+    |> form("form[phx-submit=sync_decks_from]", %{"since" => "2024-01-01"})
+    |> render_submit()
+
+    assert_enqueued(worker: Sanctum.Decks.DecklistSyncWorker, args: %{since: "2024-01-01"})
   end
 
   # The hero (both sides) and one player card, so the decklist import resolves


### PR DESCRIPTION
## What

Adds a **Backfill from** date field to the admin Deck Sync panel. It enqueues the
existing `DecklistSyncWorker` with a `since` arg, so `DeckSync` re-walks MarvelCDB
day by day from the chosen date to today and imports any decks a past run missed.

## Why

An old bug (#123 — SP//dr's missing alter-ego side raised a `KeyError` that crashed
the whole sync run and froze the cursor) left a backlog of un-imported decks. The
fix is live, but the by-date sync only walks forward from its cursor, so decks
published on days it never reached won't be picked up on their own. This gives us a
safe, idempotent way to re-walk a historical range and close the gap (e.g. SP//dr,
whose earliest MarvelCDB deck is 2022-07-15 — set the field there to backfill it).

## Changes

- **Worker** reads an optional ISO-8601 `since` job arg; absent → normal
  cursor-resuming run; a malformed value is ignored rather than failing the job.
  Uniqueness re-keyed on `[:worker, :queue]` (not `:args`) so a dated backfill still
  debounces against the hourly cron run rather than racing it (one sync in flight).
- A historical `since` **never rewinds the live cursor** (`DeckSync` only advances
  it), and imports upsert on `[:mcdb_type, :mcdb_id]`, so re-running is safe.
- **Admin LiveView**: date input + "Sync from date" button, validated and flashed;
  reuses the existing Monitor progress bar and cursor tile.

## Testing

- `mix test test/sanctum_web/live/admin_live/index_test.exs` — 3 new tests (form
  renders, invalid date rejected without enqueuing, valid date enqueues with the
  right args). Full admin suite green.
- `mix ck` clean (format + Credo + Sobelow).
- Verified the resolved Oban `unique` config keys on `[:worker, :queue]` with the
  `since` job.

## Operational notes

- If the hourly job happens to be in flight, the button flashes "already queued or
  running" — retry when idle.
- Because a historical backfill doesn't advance the cursor, an Oban retry after a
  transient MarvelCDB failure restarts from the `since` date (idempotent, but redoes
  work). One rough edge on large ranges, not a correctness issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)