### PR TITLE
feat(cards): show boost icons and boost star on the card tile

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -591,6 +591,13 @@ textarea::placeholder {
     box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.85);
   }
 
+  /* White keyline drawn behind a glyph's fill — the HTML-text analogue of
+     the SVG paint-order:stroke the stat badges use. Boost-bar icons. */
+  .text-stroke-white {
+    -webkit-text-stroke: 2px #fbfbfb;
+    paint-order: stroke fill;
+  }
+
   /* Halftone dot texture overlay for page canvases */
   .bg-halftone {
     background-image: radial-gradient(circle, rgba(255, 255, 255, 0.04) 1.1px, transparent 1.5px);

--- a/lib/sanctum_web/components/card_side_tile.ex
+++ b/lib/sanctum_web/components/card_side_tile.ex
@@ -194,7 +194,7 @@ defmodule SanctumWeb.Components.CardSideTile do
         </div>
 
         <div
-          :if={@side.pips != [] or (@side.is_hero and @side.hand_size)}
+          :if={@side.pips != [] or @side.show_boost or (@side.is_hero and @side.hand_size)}
           class={["flex items-center gap-1", (@lg? && "mt-4") || "mt-2.5"]}
         >
           <.champions_icon :for={token <- @side.pips} token={token} class="text-2xl" />
@@ -203,6 +203,13 @@ defmodule SanctumWeb.Components.CardSideTile do
             value={@side.hand_size}
             class="ml-auto text-base-content/75"
           />
+          <div :if={@side.show_boost} class="ml-auto flex items-center gap-0.5">
+            <.star_icon :if={@side.boost_star} class="text-xl text-aspect-hero text-stroke-white" />
+            <.boost_icon
+              :for={_ <- 1..@side.boost//1}
+              class="text-xl text-aspect-hero text-stroke-white"
+            />
+          </div>
         </div>
 
         <div
@@ -328,6 +335,9 @@ defmodule SanctumWeb.Components.CardSideTile do
       escalation_threat: stat_value(side.escalation_threat),
       escalation_threat_pp: stat_per_player(side.escalation_threat),
       stage_label: stage_label(side),
+      boost: side.boost || 0,
+      boost_star: side.boost_star == true,
+      show_boost: (side.boost || 0) > 0 or side.boost_star == true,
       image_url: side.image_url,
       owned: owned_flag(side)
     }


### PR DESCRIPTION
## Summary

Encounter-card tiles (card pool, detail page, hover preview, homebrew, home feed) now show the printed boost bar in the bottom-right corner of the tile — opposite the left-aligned resource pips — mirroring the boost strip on the physical cards.

- `CardSideTile.side_view/2` exposes `boost`, `boost_star`, and `show_boost` from the already-synced `CardSide` fields; every tile consumer picks it up automatically.
- The pips row renders the boost-effect star (when present) followed by one `boost_icon` glyph per printed icon, pushed right with `ml-auto`, using the established `ChampionsIcons` components.
- Icons render red (`--color-aspect-hero`) with a white keyline via a new `text-stroke-white` utility — `-webkit-text-stroke` + `paint-order: stroke fill`, the HTML-text analogue of the SVG `paint-order:stroke` the stat badges already use. (Firefox lacks `paint-order` on HTML text, so the outline there draws centered on the glyph edge — slightly thinner, still legible.)

## Test plan

- `mix compile --warnings-as-errors`, `mix ck` clean
- Verified in the browser against the dev server:
  - `boost>=2` pool search — Charge / Enhanced Ivory Horn show two boost glyphs bottom-right
  - Whirlwind (Masters of Evil) — `boost: nil` + `boost_star: true` renders a lone star
  - Kree Private — star + boost icon together, star first, matching the printed card
  - Player/hero cards unaffected (no boost bar; hand-size badge placement unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)