### PR TITLE
feat(vision): pluggable providers + model eval harness for card extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,8 @@ mix ecto.reset               # drop + recreate database
 
 mix sanctum.sync_cards       # sync card catalog from MarvelCDB (dev)
 mix sanctum.sync_decks       # sync decks from MarvelCDB (dev)
+mix sanctum.vision_eval      # benchmark vision models on card-field extraction
+                             #   (--models anthropic,ollama:qwen3-vl:8b,openrouter:… ; --card <code|url> for one card)
 
 scripts/prod_local           # run locally AGAINST THE PROD DB (MIX_ENV=prod_local, port 4151)
 scripts/pull_prod_db         # dump prod (Neon) → restore into local sanctum_dev

--- a/CUSTOM_CONTENT_ROADMAP.md
+++ b/CUSTOM_CONTENT_ROADMAP.md
@@ -223,6 +223,54 @@ Notes:
   verification entirely. Reach for B (with testing-mode allowlisting, not
   full verification) only if importing from *private* Drives is required.
 
+### Vision extraction: model benchmark & economics (2026-07-28)
+
+The "fill from art" extractor (`Sanctum.CardVision`) was benchmarked against
+the official catalog as ground truth via `mix sanctum.vision_eval` (PR #322:
+pluggable providers — Anthropic native, plus any OpenAI-compatible endpoint
+(Ollama local / OpenRouter hosted); batch mode scores per-field accuracy on a
+seeded card sample, `--card` mode diffs several models on one card for manual
+review). Numbers below are a 12-card seeded sample, identical inputs, strict
+scoring (text = Jaro ≥0.95 after normalization).
+
+| Model | Accuracy | ¢/card | Notes |
+|---|---|---|---|
+| Claude Opus 5 | 93% | 3.3¢ | best; not worth 2.5× Sonnet for human-reviewed fills |
+| Kimi K3 (open) | 91% | 2.0¢ | reasoning tokens price it above Sonnet 5 — no niche |
+| **Claude Sonnet 5** | **90%** | **1.2¢**\* | **new default** (was Opus 4.8); \*intro pricing, 1.8¢ after Aug 2026 |
+| Claude Opus 4.8 | 88% | 3.0¢ | old default — beaten on accuracy AND cost |
+| Gemma 4 31B (local) | 78% | ~0 | free on an M-series Mac, ~29s/card |
+| Claude Haiku 4.5 | 76% | 0.5¢ | fails stat blocks |
+| Qwen3.5-122B (open) | 75% | 0.26¢ | best hosted-cheap tier |
+| Qwen3-VL-235B (open) | 57% | 0.05¢ | hallucinates zero-value stats; reputation didn't transfer |
+
+Findings that shape the roadmap:
+
+- **Cost is a non-issue at homebrew scale.** A 300-card project costs
+  ~$4–5 to fully auto-enrich on Sonnet 5 — cheap enough to offer "extract
+  all" per project rather than per-card button presses. Bulk/batch tiers
+  only matter if we ever enrich thousands of cards at once (e.g. Drive
+  imports of whole back catalogs); for that, a two-tier flow (Qwen3.5-122B
+  or local Gemma first, Sonnet 5 escalation on validation failures) cuts
+  cost ~5–10× at similar quality. Not built; revisit with Drive import.
+- **The stat block (ATK/HP/SCH on allies/minions/villains) is the
+  discriminator field** — everything ≥ Sonnet-class reads it perfectly,
+  everything below misreads or hallucinates it. Name/type/ownership/cost
+  are easy everywhere; don't pay frontier prices for text-only card types.
+- **Anthropic tokenizes card scans at ~4.8k input tokens** (~2–3× other
+  providers' image tokenizers) — real Claude vision cost is roughly double
+  naive estimates; measured, not estimated, in the eval's token columns.
+- **Text transcription scores low everywhere (≤36%)** but it's threshold
+  artifact, not misreads — models lose points on `<b>`/icon-token
+  formatting conventions. Fine for human-reviewed fills; a prompt-tuning
+  problem if it ever matters.
+- Gotchas fixed en route (in PR #322): Tigris serves JPEG bytes under
+  `.png` names → data-URL media type is now sniffed from magic bytes
+  (Anthropic 400s on mismatch); hybrid-thinking open models (qwen3-vl) burn
+  the whole token budget reasoning unless `reasoning_effort` is set.
+- Full per-card mismatch reports in `tmp/vision_eval/`; decision + model
+  comparison recorded in the vault (Decisions, 2026-07-27).
+
 ## 3. Play integration (private-first MVP exit criteria) — NEXT
 
 Recommended split: **3a (player cards)** then **3b (scenarios)**.

--- a/lib/mix/tasks/sanctum.vision_eval.ex
+++ b/lib/mix/tasks/sanctum.vision_eval.ex
@@ -103,7 +103,8 @@ defmodule Mix.Tasks.Sanctum.VisionEval do
       ],
       ["errors" | Enum.map(results, &to_string(&1.score.errors))],
       ["avg latency" | Enum.map(results, &avg_latency(&1.runs))],
-      ["avg out tokens" | Enum.map(results, &avg_out_tokens(&1.runs))]
+      ["avg in tokens" | Enum.map(results, &avg_tokens(&1.runs, :input))],
+      ["avg out tokens" | Enum.map(results, &avg_tokens(&1.runs, :output))]
     ]
 
     Mix.shell().info("")
@@ -122,8 +123,8 @@ defmodule Mix.Tasks.Sanctum.VisionEval do
     end
   end
 
-  defp avg_out_tokens(runs) do
-    tokens = for %{meta: %{usage: %{output: out}}} when is_integer(out) <- runs, do: out
+  defp avg_tokens(runs, side) do
+    tokens = for %{meta: %{usage: usage}} <- runs, is_integer(usage[side]), do: usage[side]
 
     case tokens do
       [] -> "—"
@@ -151,6 +152,7 @@ defmodule Mix.Tasks.Sanctum.VisionEval do
                 name: run.item.side.name,
                 image_url: run.item.image_url,
                 ms: run.ms,
+                usage: run.meta && run.meta.usage,
                 error: run.error && inspect(run.error),
                 mismatches:
                   for {field, %{status: :mismatch} = result} <- run.comparison || %{},

--- a/lib/mix/tasks/sanctum.vision_eval.ex
+++ b/lib/mix/tasks/sanctum.vision_eval.ex
@@ -1,0 +1,321 @@
+defmodule Mix.Tasks.Sanctum.VisionEval do
+  @shortdoc "Benchmarks vision models on card-field extraction"
+
+  @moduledoc """
+  Runs one or more vision models over official catalog cards and scores their
+  `Sanctum.CardVision` extractions against the database ground truth.
+
+      # Batch eval: seeded sample of official cards, per-field accuracy table
+      mix sanctum.vision_eval --models anthropic,ollama:qwen3-vl:8b --sample 12
+
+      # Single card, several models, disagreements flagged for manual review
+      mix sanctum.vision_eval --card 01001a --models anthropic,ollama:qwen3-vl:8b
+
+      # A raw image URL works too (e.g. a homebrew card — no ground truth column)
+      mix sanctum.vision_eval --card https://…/card.png --models …
+
+  Model specs: `anthropic[:model]`, `ollama:<model>` (local, port 11434), and
+  `openrouter:<model>` (needs `OPENROUTER_API_KEY`). Batch mode writes a
+  per-card mismatch report to `tmp/vision_eval/`.
+  """
+
+  use Mix.Task
+
+  alias Sanctum.CardVision.Eval
+
+  @requirements ["app.start"]
+
+  @switches [models: :string, sample: :integer, seed: :integer, card: :string, out: :string]
+
+  @impl true
+  def run(argv) do
+    Logger.configure(level: :info)
+    {opts, _argv} = OptionParser.parse!(argv, strict: @switches)
+
+    models =
+      opts
+      |> Keyword.get(:models, "anthropic")
+      |> String.split(",", trim: true)
+      |> Enum.map(fn spec ->
+        case Eval.parse_model_spec(String.trim(spec)) do
+          {:ok, model} -> model
+          {:error, message} -> Mix.raise(message)
+        end
+      end)
+
+    case Keyword.fetch(opts, :card) do
+      {:ok, card} -> single_card(card, models)
+      :error -> batch(models, opts)
+    end
+  end
+
+  # -- Batch mode -----------------------------------------------------------------
+
+  defp batch(models, opts) do
+    sample = Keyword.get(opts, :sample, 12)
+    seed = Keyword.get(opts, :seed, 1234)
+
+    sides = Eval.sample_sides(sample, seed)
+
+    if sides == [],
+      do: Mix.raise("no official card sides with images found — run mix sanctum.sync_cards")
+
+    items = Enum.map(sides, &%{image_url: &1.image_url, side: &1})
+
+    Mix.shell().info(
+      "Evaluating #{length(models)} model(s) on #{length(items)} official cards (seed #{seed})\n"
+    )
+
+    results =
+      Enum.map(models, fn model ->
+        Mix.shell().info("#{model.label} ")
+
+        runs =
+          model
+          |> Eval.run_model(items, fn _ -> IO.write(".") end)
+          |> Enum.map(fn run ->
+            comparison =
+              run.fields && Eval.compare(run.fields, Eval.expected_fields(run.item.side))
+
+            Map.put(run, :comparison, comparison)
+          end)
+
+        IO.write("\n")
+        %{model: model, runs: runs, score: Eval.score(runs)}
+      end)
+
+    print_batch_table(results)
+    write_details(results, opts)
+  end
+
+  defp print_batch_table(results) do
+    labels = Enum.map(results, & &1.model.label)
+
+    field_rows =
+      Enum.map(Eval.fields(), fn field ->
+        [field | Enum.map(results, &percent_cell(&1.score.fields[field]))]
+      end)
+
+    summary_rows = [
+      [
+        "OVERALL"
+        | Enum.map(results, &percent_cell(%{graded: &1.score.graded, matched: &1.score.matched}))
+      ],
+      ["errors" | Enum.map(results, &to_string(&1.score.errors))],
+      ["avg latency" | Enum.map(results, &avg_latency(&1.runs))],
+      ["avg out tokens" | Enum.map(results, &avg_out_tokens(&1.runs))]
+    ]
+
+    Mix.shell().info("")
+    print_table([["field" | labels]] ++ field_rows ++ [:rule] ++ summary_rows)
+  end
+
+  defp percent_cell(%{graded: 0}), do: "—"
+
+  defp percent_cell(%{graded: graded, matched: matched}),
+    do: "#{round(matched / graded * 100)}% (#{matched}/#{graded})"
+
+  defp avg_latency(runs) do
+    case Enum.reject(runs, & &1.error) do
+      [] -> "—"
+      ok -> "#{Float.round(Enum.sum_by(ok, & &1.ms) / length(ok) / 1000, 1)}s"
+    end
+  end
+
+  defp avg_out_tokens(runs) do
+    tokens = for %{meta: %{usage: %{output: out}}} when is_integer(out) <- runs, do: out
+
+    case tokens do
+      [] -> "—"
+      tokens -> to_string(div(Enum.sum(tokens), length(tokens)))
+    end
+  end
+
+  defp write_details(results, opts) do
+    path =
+      Keyword.get_lazy(opts, :out, fn ->
+        stamp = Calendar.strftime(DateTime.utc_now(), "%Y%m%d-%H%M%S")
+        Path.join("tmp/vision_eval", "eval-#{stamp}.json")
+      end)
+
+    File.mkdir_p!(Path.dirname(path))
+
+    details =
+      Enum.map(results, fn %{model: model, runs: runs} ->
+        %{
+          model: model.label,
+          cards:
+            Enum.map(runs, fn run ->
+              %{
+                code: run.item.side.code,
+                name: run.item.side.name,
+                image_url: run.item.image_url,
+                ms: run.ms,
+                error: run.error && inspect(run.error),
+                mismatches:
+                  for {field, %{status: :mismatch} = result} <- run.comparison || %{},
+                      into: %{} do
+                    {field,
+                     %{
+                       expected: result.expected,
+                       got: result.got,
+                       similarity: result.similarity && Float.round(result.similarity, 3)
+                     }}
+                  end
+              }
+            end)
+        }
+      end)
+
+    File.write!(path, Jason.encode!(details, pretty: true))
+    Mix.shell().info("\nPer-card mismatch details: #{path}")
+  end
+
+  # -- Single-card mode --------------------------------------------------------------
+
+  defp single_card(card, models) do
+    case Eval.resolve_card(card) do
+      {:error, message} ->
+        Mix.raise(message)
+
+      {:ok, %{image_url: image_url, side: side} = item} ->
+        if side do
+          Mix.shell().info("Card: #{side.code} — #{side.name} (#{side.type})")
+        end
+
+        Mix.shell().info("Image: #{image_url}\n")
+
+        runs =
+          Enum.map(models, fn model ->
+            Mix.shell().info("running #{model.label}…")
+            [run] = Eval.run_model(model, [item])
+            Map.put(run, :model, model)
+          end)
+
+        truth = side && Eval.expected_fields(side)
+        print_single_card_table(runs, truth)
+        print_long_values(runs, truth)
+        print_errors(runs)
+    end
+  end
+
+  defp print_single_card_table(runs, truth) do
+    labels = Enum.map(runs, & &1.model.label)
+    header = ["field"] ++ if(truth, do: ["TRUTH"], else: []) ++ labels ++ [""]
+
+    rows =
+      Enum.map(Eval.fields(), fn field ->
+        values = Enum.map(runs, &(&1.fields && Map.get(&1.fields, field)))
+        truth_cells = if truth, do: [render_value(Map.get(truth, field))], else: []
+
+        ["#{field}"] ++
+          truth_cells ++
+          Enum.map(values, &render_value/1) ++
+          [flags(field, values, if(truth, do: Map.get(truth, field), else: :no_truth))]
+      end)
+
+    latency_row =
+      ["latency"] ++
+        if(truth, do: ["—"], else: []) ++
+        Enum.map(runs, &"#{Float.round(&1.ms / 1000, 1)}s") ++ [""]
+
+    Mix.shell().info("")
+    print_table([header] ++ rows ++ [:rule, latency_row])
+    Mix.shell().info("\n⚠ = models disagree · ✗ = differs from ground truth")
+  end
+
+  # Flags a row where the models disagree with each other, and (when ground
+  # truth exists) where any model differs from it.
+  defp flags(field, values, truth_value) do
+    disagree? =
+      case values do
+        [first | rest] -> Enum.any?(rest, &(!Eval.equivalent?(field, first, &1)))
+        _ -> false
+      end
+
+    wrong? =
+      truth_value != :no_truth and Enum.any?(values, &(!Eval.equivalent?(field, &1, truth_value)))
+
+    String.trim("#{if disagree?, do: "⚠"} #{if wrong?, do: "✗"}")
+  end
+
+  @doc false
+  def render_value(nil), do: "—"
+  def render_value(value) when is_binary(value), do: value
+  def render_value(value) when is_list(value), do: Enum.join(value, ", ")
+
+  def render_value(%{"value" => v} = stat) do
+    star = if stat["star"], do: "★", else: ""
+    scaling = if stat["scaling"] in [nil, "flat"], do: "", else: " #{stat["scaling"]}"
+    con = if stat["consequential"], do: " con:#{stat["consequential"]}", else: ""
+    "#{v}#{star}#{scaling}#{con}"
+  end
+
+  def render_value(value), do: to_string(value)
+
+  # Full untruncated values for the prose fields whenever they were flagged.
+  defp print_long_values(runs, truth) do
+    ~w(text flavor traits)
+    |> Enum.filter(fn field ->
+      values = Enum.map(runs, &(&1.fields && Map.get(&1.fields, field)))
+      flags(field, values, if(truth, do: Map.get(truth, field), else: :no_truth)) != ""
+    end)
+    |> Enum.each(&print_long_field(&1, runs, truth && {:truth, Map.get(truth, &1)}))
+  end
+
+  defp print_long_field(field, runs, truth) do
+    Mix.shell().info("\n── #{field} ──")
+
+    with {:truth, truth_value} <- truth do
+      Mix.shell().info("TRUTH:\n#{render_value(truth_value)}\n")
+    end
+
+    Enum.each(runs, fn run ->
+      Mix.shell().info(
+        "#{run.model.label}:\n#{render_value(run.fields && Map.get(run.fields, field))}\n"
+      )
+    end)
+  end
+
+  defp print_errors(runs) do
+    for %{error: error, model: model} when not is_nil(error) <- runs do
+      Mix.shell().info("\n#{model.label} FAILED: #{inspect(error)}")
+    end
+  end
+
+  # -- Table rendering ---------------------------------------------------------------
+
+  @cell_width 34
+
+  defp print_table(rows) do
+    cell_rows = Enum.reject(rows, &(&1 == :rule))
+
+    widths =
+      cell_rows
+      |> Enum.map(fn row -> Enum.map(row, &String.length(truncate(&1))) end)
+      |> Enum.zip_with(&Enum.max/1)
+
+    Enum.each(rows, fn
+      :rule ->
+        Mix.shell().info(Enum.map_join(widths, "─┼─", &String.duplicate("─", &1)))
+
+      row ->
+        line =
+          row
+          |> Enum.zip(widths)
+          |> Enum.map_join(" │ ", fn {cell, width} ->
+            String.pad_trailing(truncate(cell), width)
+          end)
+
+        Mix.shell().info(String.trim_trailing(line))
+    end)
+  end
+
+  defp truncate(cell) do
+    cell = cell |> to_string() |> String.replace("\n", "⏎")
+
+    if String.length(cell) > @cell_width,
+      do: String.slice(cell, 0, @cell_width - 1) <> "…",
+      else: cell
+  end
+end

--- a/lib/sanctum/card_vision.ex
+++ b/lib/sanctum/card_vision.ex
@@ -28,7 +28,9 @@ defmodule Sanctum.CardVision do
   require Logger
 
   @anthropic_url "https://api.anthropic.com/v1/messages"
-  @anthropic_model "claude-opus-4-8"
+  # Sonnet 5: benchmarked at 90% field accuracy vs Opus 4.8's 88% on the
+  # official-catalog eval (mix sanctum.vision_eval), at ~40% of the cost.
+  @anthropic_model "claude-sonnet-5"
   @anthropic_version "2023-06-01"
   @max_tokens 4096
 

--- a/lib/sanctum/card_vision.ex
+++ b/lib/sanctum/card_vision.ex
@@ -252,14 +252,7 @@ defmodule Sanctum.CardVision do
     |> Req.get()
     |> case do
       {:ok, %Req.Response{status: 200, body: binary} = resp} ->
-        content_type =
-          resp
-          |> Req.Response.get_header("content-type")
-          |> List.first("image/jpeg")
-          |> String.split(";")
-          |> hd()
-
-        {:ok, "data:#{content_type};base64," <> Base.encode64(binary)}
+        {:ok, "data:#{image_mime(binary, resp)};base64," <> Base.encode64(binary)}
 
       {:ok, %Req.Response{status: status}} ->
         {:error, {:image_fetch_failed, status}}
@@ -267,6 +260,23 @@ defmodule Sanctum.CardVision do
       {:error, exception} ->
         {:error, {:image_fetch_failed, exception}}
     end
+  end
+
+  # The bucket serves MarvelCDB scans with extension-derived content types
+  # that often disagree with the actual bytes (JPEG data in .png objects).
+  # Strict providers (Anthropic) reject data URLs whose media type mismatches
+  # the payload, so sniff the magic bytes; the header is only a fallback.
+  defp image_mime(<<0xFF, 0xD8, 0xFF, _::binary>>, _resp), do: "image/jpeg"
+  defp image_mime(<<0x89, "PNG", _::binary>>, _resp), do: "image/png"
+  defp image_mime(<<"GIF8", _::binary>>, _resp), do: "image/gif"
+  defp image_mime(<<"RIFF", _::binary-size(4), "WEBP", _::binary>>, _resp), do: "image/webp"
+
+  defp image_mime(_binary, resp) do
+    resp
+    |> Req.Response.get_header("content-type")
+    |> List.first("image/jpeg")
+    |> String.split(";")
+    |> hd()
   end
 
   # -- Shared response handling ---------------------------------------------------

--- a/lib/sanctum/card_vision.ex
+++ b/lib/sanctum/card_vision.ex
@@ -1,7 +1,7 @@
 defmodule Sanctum.CardVision do
   @moduledoc """
-  Reads a card side's printed fields off its image using the Claude API
-  (vision + structured outputs).
+  Reads a card side's printed fields off its image using a vision model
+  with structured outputs.
 
   `extract_side/1` takes the side's public image URL and returns the
   creator-editable fields that `CardSide.enrich` accepts, as a string-keyed
@@ -10,45 +10,67 @@ defmodule Sanctum.CardVision do
   omitted rather than nil, so extraction only ever fills — it never blanks
   a value the creator already entered.
 
+  Two providers are supported:
+
+    * `:anthropic` (default) — the Claude Messages API. Production path.
+    * `:openai` — any OpenAI-compatible chat-completions endpoint (Ollama,
+      OpenRouter, vLLM, …). The card image is fetched and inlined as a
+      base64 data URL because local runtimes can't fetch remote URLs.
+      Requires `:base_url`; `:api_key` as the endpoint demands.
+
   Configuration (`config :sanctum, Sanctum.CardVision`):
 
     * `:api_key` — Anthropic API key (`ANTHROPIC_API_KEY`, set in runtime.exs)
-    * `:req_options` — extra Req options merged into the request (tests
+    * `:req_options` — extra Req options merged into every request (tests
       inject a `Req.Test` plug here)
   """
 
   require Logger
 
-  @api_url "https://api.anthropic.com/v1/messages"
-  @model "claude-opus-4-8"
+  @anthropic_url "https://api.anthropic.com/v1/messages"
+  @anthropic_model "claude-opus-4-8"
   @anthropic_version "2023-06-01"
+  @max_tokens 4096
 
   @type result :: {:ok, %{String.t() => term()}} | {:error, term()}
+  @type meta :: %{model: String.t() | nil, usage: %{input: term(), output: term()}}
 
   @doc """
   Extracts the printed fields from one card face image.
 
+  Options:
+
+    * `:provider` — `:anthropic` (default) or `:openai`
+    * `:model` — model name (defaults to `#{@anthropic_model}` for Anthropic;
+      required for `:openai`)
+    * `:base_url` — OpenAI-compatible API root, e.g. `http://localhost:11434/v1`
+      (Ollama) or `https://openrouter.ai/api/v1` (required for `:openai`)
+    * `:api_key` — bearer token for `:openai` endpoints that need one
+
   Returns `{:ok, fields}` with only the fields legible on the card, or
   `{:error, reason}` — `:missing_api_key`, `:refused`, `:truncated`,
-  `{:api_error, status, message}`, `{:request_failed, exception}`, or
-  `{:unexpected_response, body}`.
+  `{:api_error, status, message}`, `{:request_failed, exception}`,
+  `{:image_fetch_failed, reason}`, or `{:unexpected_response, body}`.
   """
-  @spec extract_side(String.t()) :: result()
-  def extract_side(image_url) when is_binary(image_url) do
+  @spec extract_side(String.t(), keyword()) :: result()
+  def extract_side(image_url, opts \\ []) when is_binary(image_url) do
+    case extract_side_meta(image_url, opts) do
+      {:ok, fields, _meta} -> {:ok, fields}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc """
+  Like `extract_side/2` but also returns response metadata (model, token
+  usage) for benchmarking. See `mix sanctum.vision_eval`.
+  """
+  @spec extract_side_meta(String.t(), keyword()) ::
+          {:ok, %{String.t() => term()}, meta()} | {:error, term()}
+  def extract_side_meta(image_url, opts \\ []) when is_binary(image_url) do
     result =
-      with {:ok, api_key} <- fetch_api_key() do
-        [
-          url: @api_url,
-          headers: [
-            {"x-api-key", api_key},
-            {"anthropic-version", @anthropic_version}
-          ],
-          json: request_body(image_url),
-          receive_timeout: 120_000
-        ]
-        |> Keyword.merge(config(:req_options, []))
-        |> Req.post()
-        |> handle_response()
+      case Keyword.get(opts, :provider, :anthropic) do
+        :anthropic -> anthropic_extract(image_url, opts)
+        :openai -> openai_extract(image_url, opts)
       end
 
     case result do
@@ -65,10 +87,29 @@ defmodule Sanctum.CardVision do
     result
   end
 
-  defp request_body(image_url) do
+  # -- Anthropic provider --------------------------------------------------------
+
+  defp anthropic_extract(image_url, opts) do
+    with {:ok, api_key} <- fetch_api_key(opts) do
+      [
+        url: @anthropic_url,
+        headers: [
+          {"x-api-key", api_key},
+          {"anthropic-version", @anthropic_version}
+        ],
+        json: anthropic_body(image_url, opts),
+        receive_timeout: 120_000
+      ]
+      |> Keyword.merge(config(:req_options, []))
+      |> Req.post()
+      |> handle_anthropic_response()
+    end
+  end
+
+  defp anthropic_body(image_url, opts) do
     %{
-      model: @model,
-      max_tokens: 4096,
+      model: Keyword.get(opts, :model, @anthropic_model),
+      max_tokens: @max_tokens,
       system: system_prompt(),
       output_config: %{format: %{type: "json_schema", schema: schema()}},
       messages: [
@@ -76,21 +117,14 @@ defmodule Sanctum.CardVision do
           role: "user",
           content: [
             %{type: "image", source: %{type: "url", url: image_url}},
-            %{
-              type: "text",
-              text:
-                "Read this Marvel Champions card face and extract its printed fields. " <>
-                  "Mark anything not printed on this face as absent per the field rules."
-            }
+            %{type: "text", text: user_prompt()}
           ]
         }
       ]
     }
   end
 
-  # -- Response handling -------------------------------------------------------
-
-  defp handle_response({:ok, %Req.Response{status: 200, body: body}}) do
+  defp handle_anthropic_response({:ok, %Req.Response{status: 200, body: body}}) do
     case body do
       %{"stop_reason" => "refusal"} ->
         {:error, :refused}
@@ -99,31 +133,191 @@ defmodule Sanctum.CardVision do
         {:error, :truncated}
 
       %{"content" => content} when is_list(content) ->
-        decode_content(content, body)
+        with %{"text" => text} <- Enum.find(content, &(&1["type"] == "text")),
+             {:ok, fields} <- decode_fields(text) do
+          usage = body["usage"] || %{}
+
+          {:ok, prune(fields),
+           %{
+             model: body["model"],
+             usage: %{input: usage["input_tokens"], output: usage["output_tokens"]}
+           }}
+        else
+          _ -> {:error, {:unexpected_response, body}}
+        end
 
       _ ->
         {:error, {:unexpected_response, body}}
     end
   end
 
-  defp handle_response({:ok, %Req.Response{status: status, body: body}}) do
+  defp handle_anthropic_response(other), do: handle_http_error(other)
+
+  # -- OpenAI-compatible provider (Ollama, OpenRouter, vLLM, …) -------------------
+
+  defp openai_extract(image_url, opts) do
+    base_url = Keyword.fetch!(opts, :base_url)
+    model = Keyword.fetch!(opts, :model)
+
+    with {:ok, data_url} <- fetch_image_data_url(image_url) do
+      auth_headers =
+        case Keyword.get(opts, :api_key) do
+          key when is_binary(key) and key != "" -> [{"authorization", "Bearer " <> key}]
+          _ -> []
+        end
+
+      [
+        url: String.trim_trailing(base_url, "/") <> "/chat/completions",
+        headers: auth_headers,
+        json: openai_body(model, data_url, opts),
+        receive_timeout: Keyword.get(opts, :receive_timeout, 300_000)
+      ]
+      |> Keyword.merge(config(:req_options, []))
+      |> Req.post()
+      |> handle_openai_response()
+    end
+  end
+
+  defp openai_body(model, data_url, opts) do
+    # Temperature 0: transcription should be deterministic; Ollama model
+    # defaults (qwen3: temperature 1) otherwise make runs non-reproducible.
+    body = %{
+      model: model,
+      max_tokens: @max_tokens,
+      temperature: 0,
+      messages: [
+        %{role: "system", content: system_prompt()},
+        %{
+          role: "user",
+          content: [
+            %{type: "image_url", image_url: %{url: data_url}},
+            %{type: "text", text: user_prompt()}
+          ]
+        }
+      ],
+      response_format: %{
+        type: "json_schema",
+        json_schema: %{name: "card_fields", strict: true, schema: schema()}
+      }
+    }
+
+    # Hybrid-thinking models (e.g. qwen3-vl) burn the whole token budget on
+    # reasoning unless it's turned off; Ollama ignores `think` on this endpoint
+    # but honors `reasoning_effort`.
+    case Keyword.get(opts, :reasoning_effort) do
+      nil -> body
+      effort -> Map.put(body, :reasoning_effort, effort)
+    end
+  end
+
+  defp handle_openai_response({:ok, %Req.Response{status: 200, body: body}}) do
+    case body do
+      %{"choices" => [%{"message" => %{"refusal" => refusal}} | _]}
+      when is_binary(refusal) and refusal != "" ->
+        {:error, :refused}
+
+      %{"choices" => [%{"finish_reason" => "length"} | _]} ->
+        {:error, :truncated}
+
+      %{"choices" => [%{"message" => %{"content" => text} = message} | _]} when is_binary(text) ->
+        # With reasoning disabled, Ollama's think-parser sometimes misroutes
+        # the constrained JSON into `reasoning` and leaves `content` empty.
+        case decode_fields(text, message["reasoning"]) do
+          {:ok, fields} ->
+            usage = body["usage"] || %{}
+
+            {:ok, prune(fields),
+             %{
+               model: body["model"],
+               usage: %{input: usage["prompt_tokens"], output: usage["completion_tokens"]}
+             }}
+
+          _ ->
+            {:error, {:unexpected_response, body}}
+        end
+
+      _ ->
+        {:error, {:unexpected_response, body}}
+    end
+  end
+
+  defp handle_openai_response(other), do: handle_http_error(other)
+
+  # Local runtimes can't fetch remote URLs, so the image is inlined as a
+  # base64 data URL — works uniformly across Ollama and hosted endpoints.
+  defp fetch_image_data_url(image_url) do
+    [url: image_url]
+    |> Keyword.merge(config(:req_options, []))
+    |> Keyword.put(:decode_body, false)
+    |> Req.get()
+    |> case do
+      {:ok, %Req.Response{status: 200, body: binary} = resp} ->
+        content_type =
+          resp
+          |> Req.Response.get_header("content-type")
+          |> List.first("image/jpeg")
+          |> String.split(";")
+          |> hd()
+
+        {:ok, "data:#{content_type};base64," <> Base.encode64(binary)}
+
+      {:ok, %Req.Response{status: status}} ->
+        {:error, {:image_fetch_failed, status}}
+
+      {:error, exception} ->
+        {:error, {:image_fetch_failed, exception}}
+    end
+  end
+
+  # -- Shared response handling ---------------------------------------------------
+
+  defp handle_http_error({:ok, %Req.Response{status: status, body: body}}) do
     message =
       case body do
         %{"error" => %{"message" => message}} -> message
+        %{"error" => message} when is_binary(message) -> message
         _ -> nil
       end
 
     {:error, {:api_error, status, message}}
   end
 
-  defp handle_response({:error, exception}), do: {:error, {:request_failed, exception}}
+  defp handle_http_error({:error, exception}), do: {:error, {:request_failed, exception}}
 
-  defp decode_content(content, body) do
-    with %{"text" => text} <- Enum.find(content, &(&1["type"] == "text")),
-         {:ok, fields} <- Jason.decode(text) do
-      {:ok, prune(fields)}
-    else
-      _ -> {:error, {:unexpected_response, body}}
+  defp decode_fields(text, fallback) do
+    case decode_fields(text) do
+      {:ok, fields} -> {:ok, fields}
+      :error when is_binary(fallback) and fallback != "" -> decode_fields(fallback)
+      :error -> :error
+    end
+  end
+
+  # Open models sometimes wrap JSON in markdown fences or preamble even when
+  # asked for structured output — fall back to the outermost {...} slice.
+  defp decode_fields(text) do
+    case Jason.decode(text) do
+      {:ok, fields} when is_map(fields) ->
+        {:ok, fields}
+
+      _ ->
+        with start when not is_nil(start) <- text |> :binary.match("{") |> brace_start(),
+             stop when stop > start <- last_brace(text),
+             {:ok, fields} when is_map(fields) <-
+               Jason.decode(binary_part(text, start, stop - start + 1)) do
+          {:ok, fields}
+        else
+          _ -> :error
+        end
+    end
+  end
+
+  defp brace_start({pos, _len}), do: pos
+  defp brace_start(:nomatch), do: nil
+
+  defp last_brace(text) do
+    case :binary.matches(text, "}") do
+      [] -> -1
+      matches -> matches |> List.last() |> elem(0)
     end
   end
 
@@ -273,6 +467,11 @@ defmodule Sanctum.CardVision do
 
   # -- Prompt -------------------------------------------------------------------
 
+  defp user_prompt do
+    "Read this Marvel Champions card face and extract its printed fields. " <>
+      "Mark anything not printed on this face as absent per the field rules."
+  end
+
   defp system_prompt do
     """
     You read card faces from Marvel Champions: The Card Game and transcribe their
@@ -326,8 +525,8 @@ defmodule Sanctum.CardVision do
 
   # -- Config -------------------------------------------------------------------
 
-  defp fetch_api_key do
-    case config(:api_key, nil) do
+  defp fetch_api_key(opts) do
+    case Keyword.get(opts, :api_key, config(:api_key, nil)) do
       key when is_binary(key) and key != "" -> {:ok, key}
       _ -> {:error, :missing_api_key}
     end

--- a/lib/sanctum/card_vision/eval.ex
+++ b/lib/sanctum/card_vision/eval.ex
@@ -1,0 +1,321 @@
+defmodule Sanctum.CardVision.Eval do
+  @moduledoc """
+  Benchmarking harness for `Sanctum.CardVision` — runs one or more vision
+  models over official catalog cards (whose `CardSide` rows are ground truth)
+  and scores per-field extraction accuracy. Backs `mix sanctum.vision_eval`.
+
+  Model specs (`parse_model_spec/1`):
+
+    * `anthropic` / `anthropic:<model>` — the Claude API (production path)
+    * `ollama:<model>` — a local Ollama server, e.g. `ollama:qwen3-vl:8b`
+    * `openrouter:<model>` — OpenRouter, e.g. `openrouter:qwen/qwen3-vl-8b-instruct`
+      (needs `OPENROUTER_API_KEY`)
+  """
+
+  require Ash.Query
+
+  alias Sanctum.CardVision
+
+  @ollama_base_url "http://localhost:11434/v1"
+  @openrouter_base_url "https://openrouter.ai/api/v1"
+
+  @scalar_fields ~w(name subname type ownership aspect cost scheme scheme_star)
+  @stat_fields ~w(attack thwart defense health recover)
+  @text_fields ~w(text flavor)
+  @fields @scalar_fields ++ @stat_fields ++ ["traits"] ++ @text_fields
+
+  @text_match_threshold 0.95
+
+  def fields, do: @fields
+
+  # -- Model specs ----------------------------------------------------------------
+
+  @doc "Parses a `provider[:model]` spec into `%{label, opts}` for extract_side_meta."
+  def parse_model_spec("anthropic"), do: parse_model_spec("anthropic:claude-opus-4-8")
+
+  def parse_model_spec("anthropic:" <> model),
+    do:
+      {:ok,
+       %{label: "anthropic:#{model}", concurrency: 4, opts: [provider: :anthropic, model: model]}}
+
+  def parse_model_spec("ollama:" <> model) when model != "" do
+    # reasoning_effort "none": hybrid-thinking models (qwen3-vl) otherwise
+    # spend the whole completion budget reasoning and never emit the JSON.
+    {:ok,
+     %{
+       label: "ollama:#{model}",
+       concurrency: 1,
+       opts: [
+         provider: :openai,
+         base_url: @ollama_base_url,
+         model: model,
+         reasoning_effort: "none"
+       ]
+     }}
+  end
+
+  def parse_model_spec("openrouter:" <> model) when model != "" do
+    case System.get_env("OPENROUTER_API_KEY") do
+      key when is_binary(key) and key != "" ->
+        {:ok,
+         %{
+           label: "openrouter:#{model}",
+           concurrency: 4,
+           opts: [provider: :openai, base_url: @openrouter_base_url, model: model, api_key: key]
+         }}
+
+      _ ->
+        {:error, "openrouter:#{model} needs OPENROUTER_API_KEY in the environment"}
+    end
+  end
+
+  def parse_model_spec(spec), do: {:error, "unrecognized model spec #{inspect(spec)}"}
+
+  # -- Card selection ---------------------------------------------------------------
+
+  @doc "Seeded random sample of official card sides that have images."
+  def sample_sides(count, seed) do
+    :rand.seed(:exsss, {seed, seed, seed})
+
+    official_sides_query()
+    |> Ash.read!(authorize?: false)
+    |> Enum.shuffle()
+    |> Enum.take(count)
+  end
+
+  @doc """
+  Resolves `--card` input: a full image URL (no ground truth), a side code, or
+  a card code (its primary side).
+  """
+  def resolve_card("http" <> _ = url), do: {:ok, %{image_url: url, side: nil}}
+
+  def resolve_card(code) do
+    # Not restricted to official cards — homebrew codes resolve too; their DB
+    # values (whatever the creator entered) still make a useful truth column.
+    side =
+      Sanctum.Games.CardSide
+      |> Ash.Query.filter(code == ^code and not is_nil(image_url))
+      |> Ash.Query.limit(1)
+      |> Ash.read!(authorize?: false)
+      |> List.first()
+
+    side =
+      side ||
+        Sanctum.Games.Card
+        |> Ash.Query.filter(code == ^code)
+        |> Ash.Query.load(:primary_side)
+        |> Ash.Query.limit(1)
+        |> Ash.read!(authorize?: false)
+        |> case do
+          [%{primary_side: %{image_url: url} = primary}] when is_binary(url) -> primary
+          _ -> nil
+        end
+
+    case side do
+      nil -> {:error, "no card side with an image found for code #{inspect(code)}"}
+      side -> {:ok, %{image_url: side.image_url, side: side}}
+    end
+  end
+
+  defp official_sides_query do
+    Sanctum.Games.CardSide
+    |> Ash.Query.filter(not is_nil(image_url) and card.origin == :official)
+  end
+
+  # -- Extraction -------------------------------------------------------------------
+
+  @doc "Runs one model over a list of `%{image_url, side}` items, timing each call."
+  def run_model(model, items, progress_fun \\ fn _ -> :ok end) do
+    items
+    |> Task.async_stream(
+      fn item ->
+        {micros, result} =
+          :timer.tc(fn -> CardVision.extract_side_meta(item.image_url, model.opts) end)
+
+        progress_fun.(item)
+
+        case result do
+          {:ok, fields, meta} ->
+            %{item: item, fields: fields, meta: meta, ms: div(micros, 1000), error: nil}
+
+          {:error, reason} ->
+            %{item: item, fields: nil, meta: nil, ms: div(micros, 1000), error: reason}
+        end
+      end,
+      max_concurrency: model.concurrency,
+      timeout: :infinity
+    )
+    |> Enum.map(fn {:ok, run} -> run end)
+  end
+
+  # -- Ground truth -------------------------------------------------------------------
+
+  @doc """
+  Renders a `CardSide` into the extraction's string-keyed shape, with the same
+  absence semantics as `CardVision`'s pruning (absent fields omitted).
+  """
+  def expected_fields(side) do
+    scalars = %{
+      "name" => side.name,
+      # The catalog sync sets subname = name on ~75% of official sides even
+      # though no subtitle is printed — a model correctly reads that as absent.
+      "subname" => if(side.subname == side.name, do: nil, else: presence(side.subname)),
+      "type" => side.type && to_string(side.type),
+      "ownership" => side.ownership && to_string(side.ownership),
+      "aspect" => presence(side.aspect),
+      "cost" => side.cost,
+      "scheme" => side.scheme,
+      "scheme_star" => side.scheme_star,
+      "traits" => if(side.traits == [], do: nil, else: side.traits),
+      "text" => presence(side.text),
+      "flavor" => presence(side.flavor)
+    }
+
+    stats =
+      Map.new(@stat_fields, fn field ->
+        {field, side |> Map.fetch!(String.to_existing_atom(field)) |> stat_map()}
+      end)
+
+    scalars
+    |> Map.merge(stats)
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Map.new()
+  end
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(value), do: value
+
+  defp stat_map(%{value: nil}), do: nil
+  defp stat_map(nil), do: nil
+
+  defp stat_map(stat),
+    do: %{
+      "value" => stat.value,
+      "star" => stat.star,
+      "scaling" => to_string(stat.scaling),
+      "consequential" => stat.consequential
+    }
+
+  # -- Comparison ---------------------------------------------------------------------
+
+  @doc """
+  Compares extracted fields to expected fields. Returns a map of field name to
+  `%{status: :match | :mismatch | :skip, expected, got, similarity}` — `:skip`
+  when the field is absent on both sides (nothing to grade).
+  """
+  def compare(got, expected) do
+    Map.new(@fields, fn field ->
+      {field, compare_field(field, Map.get(got, field), Map.get(expected, field))}
+    end)
+  end
+
+  @doc """
+  Whether two extracted values for a field agree under the same normalization
+  the scoring uses (text similarity, stat/trait normalization, …). Used to
+  flag model disagreements in single-card mode.
+  """
+  def equivalent?(field, a, b), do: compare_field(field, a, b).status != :mismatch
+
+  defp compare_field(field, got, expected) do
+    base = %{expected: expected, got: got, similarity: nil}
+
+    cond do
+      is_nil(got) and is_nil(expected) ->
+        %{base | similarity: 1.0} |> Map.put(:status, :skip)
+
+      # scheme_star/booleans: extraction always emits them; absent truth = false.
+      field == "scheme_star" ->
+        put_status(base, boolean(got) == boolean(expected))
+
+      is_nil(got) or is_nil(expected) ->
+        Map.put(base, :status, :mismatch)
+
+      field in @text_fields ->
+        similarity = String.jaro_distance(normalize_text(got), normalize_text(expected))
+
+        %{base | similarity: similarity}
+        |> Map.put(:status, if(similarity >= @text_match_threshold, do: :match, else: :mismatch))
+
+      field == "traits" ->
+        put_status(base, normalize_traits(got) == normalize_traits(expected))
+
+      field in @stat_fields ->
+        put_status(base, normalize_stat(got) == normalize_stat(expected))
+
+      # Case-insensitive: cards print names in caps, the catalog in title case.
+      field in ~w(name subname) ->
+        put_status(
+          base,
+          String.downcase(normalize_text(got)) == String.downcase(normalize_text(expected))
+        )
+
+      true ->
+        put_status(base, got == expected)
+    end
+  end
+
+  defp put_status(base, true), do: Map.put(base, :status, :match)
+  defp put_status(base, false), do: Map.put(base, :status, :mismatch)
+
+  defp boolean(nil), do: false
+  defp boolean(value), do: value
+
+  defp normalize_traits(traits) when is_list(traits) do
+    traits
+    |> Enum.map(fn trait ->
+      trait |> to_string() |> String.trim_trailing(".") |> String.downcase() |> String.trim()
+    end)
+    |> Enum.sort()
+  end
+
+  defp normalize_traits(other), do: other
+
+  defp normalize_stat(%{} = stat) do
+    %{
+      value: stat["value"],
+      star: boolean(stat["star"]),
+      scaling: stat["scaling"] || "flat",
+      consequential: stat["consequential"]
+    }
+  end
+
+  defp normalize_stat(other), do: other
+
+  defp normalize_text(text) do
+    text
+    |> to_string()
+    |> String.replace(~r/[“”]/u, "\"")
+    |> String.replace(~r/[‘’]/u, "'")
+    |> String.replace(~r/[–—]/u, "-")
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
+  end
+
+  # -- Scoring ------------------------------------------------------------------------
+
+  @doc """
+  Aggregates comparison maps for one model into per-field and overall accuracy:
+  `%{fields: %{field => %{graded, matched}}, graded, matched, errors}`.
+  """
+  def score(runs_with_comparisons) do
+    field_scores =
+      Map.new(@fields, fn field ->
+        graded =
+          runs_with_comparisons
+          |> Enum.map(&get_in(&1, [:comparison, field]))
+          |> Enum.reject(&(is_nil(&1) or &1.status == :skip))
+
+        {field, %{graded: length(graded), matched: Enum.count(graded, &(&1.status == :match))}}
+      end)
+
+    totals = Map.values(field_scores)
+
+    %{
+      fields: field_scores,
+      graded: totals |> Enum.map(& &1.graded) |> Enum.sum(),
+      matched: totals |> Enum.map(& &1.matched) |> Enum.sum(),
+      errors: Enum.count(runs_with_comparisons, & &1.error)
+    }
+  end
+end

--- a/lib/sanctum/card_vision/eval.ex
+++ b/lib/sanctum/card_vision/eval.ex
@@ -31,7 +31,7 @@ defmodule Sanctum.CardVision.Eval do
   # -- Model specs ----------------------------------------------------------------
 
   @doc "Parses a `provider[:model]` spec into `%{label, opts}` for extract_side_meta."
-  def parse_model_spec("anthropic"), do: parse_model_spec("anthropic:claude-opus-4-8")
+  def parse_model_spec("anthropic"), do: parse_model_spec("anthropic:claude-sonnet-5")
 
   def parse_model_spec("anthropic:" <> model),
     do:

--- a/test/sanctum/card_vision_test.exs
+++ b/test/sanctum/card_vision_test.exs
@@ -130,6 +130,80 @@ defmodule Sanctum.CardVisionTest do
              Sanctum.Games.Stat.cast_input(fields["attack"], [])
   end
 
+  describe "openai provider" do
+    @openai_opts [provider: :openai, base_url: "http://localhost:11434/v1", model: "test-vl"]
+
+    defp stub_openai(content_fun) do
+      Req.Test.stub(CardVision, fn conn ->
+        case conn.request_path do
+          # The image fetch — any binary body will do.
+          "/cards/custom-ally.png" ->
+            conn
+            |> Plug.Conn.put_resp_content_type("image/png")
+            |> Plug.Conn.resp(200, <<137, "PNG">>)
+
+          "/v1/chat/completions" ->
+            Req.Test.json(conn, content_fun.(conn))
+        end
+      end)
+    end
+
+    test "extracts fields via a chat-completions endpoint with an inlined image" do
+      parent = self()
+
+      stub_openai(fn conn ->
+        {:ok, body, _conn} = Plug.Conn.read_body(conn)
+        send(parent, {:request_body, Jason.decode!(body)})
+
+        %{
+          "model" => "test-vl",
+          "choices" => [
+            %{
+              "finish_reason" => "stop",
+              "message" => %{"content" => Jason.encode!(%{"name" => "Test Ally", "cost" => nil})}
+            }
+          ],
+          "usage" => %{"prompt_tokens" => 1200, "completion_tokens" => 80}
+        }
+      end)
+
+      assert {:ok, fields, meta} = CardVision.extract_side_meta(@image_url, @openai_opts)
+      assert fields == %{"name" => "Test Ally"}
+      assert meta.usage == %{input: 1200, output: 80}
+
+      assert_received {:request_body, body}
+      assert body["response_format"]["json_schema"]["strict"] == true
+      [%{"content" => [%{"image_url" => %{"url" => data_url}} | _]} | _] = tl(body["messages"])
+      assert String.starts_with?(data_url, "data:image/png;base64,")
+    end
+
+    test "recovers JSON wrapped in markdown fences" do
+      stub_openai(fn _conn ->
+        %{
+          "choices" => [
+            %{
+              "finish_reason" => "stop",
+              "message" => %{"content" => "```json\n{\"name\": \"Fenced\"}\n```"}
+            }
+          ]
+        }
+      end)
+
+      assert {:ok, fields} = CardVision.extract_side(@image_url, @openai_opts)
+      assert fields == %{"name" => "Fenced"}
+    end
+
+    test "surfaces a truncated completion" do
+      stub_openai(fn _conn ->
+        %{"choices" => [%{"finish_reason" => "length", "message" => %{"content" => "{"}}]}
+      end)
+
+      capture_log(fn ->
+        assert {:error, :truncated} = CardVision.extract_side(@image_url, @openai_opts)
+      end)
+    end
+  end
+
   test "surfaces a refusal as an error" do
     Req.Test.stub(CardVision, fn conn ->
       Req.Test.json(conn, %{"stop_reason" => "refusal", "content" => []})

--- a/test/sanctum/card_vision_test.exs
+++ b/test/sanctum/card_vision_test.exs
@@ -177,6 +177,36 @@ defmodule Sanctum.CardVisionTest do
       assert String.starts_with?(data_url, "data:image/png;base64,")
     end
 
+    test "sniffs the real image type when the served content-type lies" do
+      parent = self()
+
+      Req.Test.stub(CardVision, fn conn ->
+        case conn.request_path do
+          # JPEG magic bytes served as image/png — like the Tigris scans.
+          "/cards/custom-ally.png" ->
+            conn
+            |> Plug.Conn.put_resp_content_type("image/png")
+            |> Plug.Conn.resp(200, <<0xFF, 0xD8, 0xFF, 0xE0>>)
+
+          "/v1/chat/completions" ->
+            {:ok, body, _conn} = Plug.Conn.read_body(conn)
+            send(parent, {:request_body, Jason.decode!(body)})
+
+            Req.Test.json(conn, %{
+              "choices" => [
+                %{"finish_reason" => "stop", "message" => %{"content" => "{}"}}
+              ]
+            })
+        end
+      end)
+
+      assert {:ok, _fields} = CardVision.extract_side(@image_url, @openai_opts)
+
+      assert_received {:request_body, body}
+      [%{"content" => [%{"image_url" => %{"url" => data_url}} | _]} | _] = tl(body["messages"])
+      assert String.starts_with?(data_url, "data:image/jpeg;base64,")
+    end
+
     test "recovers JSON wrapped in markdown fences" do
       stub_openai(fn _conn ->
         %{


### PR DESCRIPTION
## Why

The card-art vision extractor was hardcoded to Claude Opus via the Anthropic
API. Applying extraction at scale may be too expensive on a frontier model,
so this PR adds a way to benchmark open-weights, local, and licensed models
against the same task — and acts on the results.

## What

**`Sanctum.CardVision` provider abstraction** — `extract_side/2` now takes
options selecting a provider:

- `:anthropic` (default) — the production path, **now defaulting to
  `claude-sonnet-5`** (see benchmark below; previously `claude-opus-4-8`).
- `:openai` — any OpenAI-compatible chat-completions endpoint (Ollama,
  OpenRouter, vLLM). Same JSON schema via `response_format: json_schema`,
  image inlined as a base64 data URL, plus open-model resiliency fallbacks:
  markdown-fence/preamble JSON recovery, parsing Ollama's misrouted
  `reasoning` field, and a `:reasoning_effort` option to stop hybrid-thinking
  runaway (qwen3-vl burns the whole token budget reasoning otherwise).

`extract_side_meta/2` additionally returns model + token usage for
benchmarking.

**Image media-type sniffing** — the Tigris bucket serves MarvelCDB scans with
extension-derived content types that often disagree with the bytes (JPEG data
in `.png` objects). Anthropic 400s on mismatched data URLs, so the media type
is now sniffed from magic bytes.

**`mix sanctum.vision_eval`** — benchmark harness:

- **Batch**: seeded sample of official catalog cards (`CardSide` rows are
  ground truth), per-field accuracy table, latency + token usage, per-card
  mismatch JSON report in `tmp/vision_eval/`.
- **Single card** (`--card <code|url>`): field × model comparison table
  flagging model disagreements (⚠) and ground-truth deviations (✗), with
  full-text sections — for manual review, incl. homebrew cards via raw URL.

Model specs: `anthropic[:model]`, `ollama:<model>`, `openrouter:<model>`.

## Benchmark (12-card seeded sample, identical inputs, strict scoring)

| Model | Accuracy | ¢/card | Stat blocks (ATK/HP/SCH) |
|---|---|---|---|
| Opus 5 | 93% | 3.27¢ | perfect |
| Kimi K3 (open) | 91% | 2.04¢ | perfect |
| **Sonnet 5** ← new default | **90%** | **1.17¢** | near-perfect |
| Opus 4.8 (old default) | 88% | 3.00¢ | perfect |
| Gemma 4 31B (local) | 78% | ~0 | values right, scaling quirk |
| Haiku 4.5 | 76% | 0.49¢ | weak |
| Qwen3.5-122B (open) | 75% | 0.26¢ | good |
| Qwen3-VL-235B (open) | 57% | 0.05¢ | hallucinates zeros |

**Sonnet 5 beats Opus 4.8 on accuracy at ~40% of the cost**, hence the
default switch. Cheap open models (Qwen3.5-122B hosted, Gemma 4 31B local)
are viable for a future bulk tier with Sonnet 5 as escalation.

Scoring notes: text/flavor use Jaro similarity (≥0.95) after normalization —
the strict threshold is why even Opus 5 "fails" text (formatting conventions,
not misreads). `subname == name` catalog rows (~75%, a sync artifact) are
treated as absent; name/subname compare case-insensitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #334
- <kbd>&nbsp;1&nbsp;</kbd> #322 👈 
<!-- GitButler Footer Boundary Bottom -->