### PR TITLE
feat(cards): link card detail's Card Set to its pack browse anchor

### DIFF
--- a/lib/sanctum_web/live/card_live/detail.ex
+++ b/lib/sanctum_web/live/card_live/detail.ex
@@ -128,11 +128,24 @@ defmodule SanctumWeb.CardLive.Detail do
                 />
                 <.meta :if={@pack} label="Released" value={format_date(@pack.released_on)} />
                 <.meta :if={@pack && @pack.wave} label="Wave" value={@pack.wave.name} />
-                <.meta
-                  :if={@card.card_set}
-                  label="Card Set"
-                  value={card_set_label(@card.card_set)}
-                />
+                <div :if={@card.card_set}>
+                  <div class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/45">
+                    Card Set
+                  </div>
+                  <.link
+                    :if={@pack}
+                    navigate={"#{~p"/browse/#{@pack.code}"}##{@card.card_set.code}"}
+                    class="mt-0.5 block font-barlow-condensed text-base font-semibold hover:text-primary"
+                  >
+                    {card_set_label(@card.card_set)}
+                  </.link>
+                  <div
+                    :if={!@pack}
+                    class="mt-0.5 font-barlow-condensed text-base font-semibold"
+                  >
+                    {card_set_label(@card.card_set)}
+                  </div>
+                </div>
 
                 <div class="my-1 h-px bg-neutral"></div>
 


### PR DESCRIPTION
Links the "Card Set" field on the card detail page to that set on its
product browse page (`/browse/:pack_code#:card_set_code`), so you can
jump from a card straight to the rest of its set. Falls back to plain
text when the card has no associated pack.

Complements the reprints browsing (#326) and duplicate-card cleanup
(#325) that already merged — this is the remaining slice of that work.
