### PR TITLE
feat(decks): infer aspect from cards; advisory-only deckbuilding

### DIFF
--- a/lib/sanctum/decks/legality.ex
+++ b/lib/sanctum/decks/legality.ex
@@ -33,17 +33,43 @@ defmodule Sanctum.Decks.Legality do
 
   `entries` accepts loaded `DeckCard` structs or plain maps shaped like
   `%{card: card, quantity: n, ignore_deck_limit: bool}` where `card` has its
-  `:primary_side` loaded. `aspects` is the deck's chosen aspect list (empty =
-  basic deck). `signature_cards` are the hero's signature-set cards (ownership
-  `:hero`), each expected at exactly `deck_limit` copies.
+  `:primary_side` loaded. `signature_cards` are the hero's signature-set cards
+  (ownership `:hero`), each expected at exactly `deck_limit` copies.
+
+  Each rule is a self-contained `*_issues/1|2` function returning a list of
+  `Issue`s; this is the single entrypoint that composes them. To add a rule,
+  write one function and append it here. Nothing here ever blocks a save.
+
+  The deck's aspects are not passed in — they're inferred from the cards
+  themselves (see `aspects_from_entries/1`), so there is no separate "chosen
+  aspect" to validate against.
   """
-  @spec issues([map()], [atom()], [map()]) :: [Issue.t()]
-  def issues(entries, aspects, signature_cards)
-      when is_list(entries) and is_list(aspects) and is_list(signature_cards) do
+  @spec issues([map()], [map()]) :: [Issue.t()]
+  def issues(entries, signature_cards)
+      when is_list(entries) and is_list(signature_cards) do
     size_issues(entries) ++
       hero_set_issues(entries, signature_cards) ++
       copy_limit_issues(entries) ++
-      aspect_issues(entries, aspects)
+      multi_aspect_issues(entries)
+  end
+
+  @doc """
+  The distinct aspects a deck draws from, inferred from its player cards.
+
+  Sanctum has no up-front aspect choice: a deck's aspect(s) are simply the
+  aspects of the player-owned aspect cards in it. Adding the first aspect card
+  gives the deck its aspect; removing every card of that aspect and adding a
+  different one flips it. Returned sorted so callers can compare/persist a
+  canonical value. Hero and basic cards (no aspect) never contribute.
+  """
+  @spec aspects_from_entries([map()]) :: [String.t()]
+  def aspects_from_entries(entries) when is_list(entries) do
+    entries
+    |> Enum.filter(&(ownership(&1) == :player and quantity(&1) > 0))
+    |> Enum.map(&primary_side(&1).aspect)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.sort()
   end
 
   defp size_issues(entries) do
@@ -146,18 +172,24 @@ defmodule Sanctum.Decks.Legality do
     end)
   end
 
-  defp aspect_issues(entries, aspects) do
-    for entry <- entries,
-        ownership(entry) == :player,
-        aspect = primary_side(entry).aspect,
-        not is_nil(aspect),
-        aspect not in aspects do
-      %Issue{
-        code: :off_aspect,
-        severity: :warning,
-        message: "#{entry_name(entry)} is #{aspect_label(aspect)}, outside this deck's aspects",
-        card_id: card(entry).id
-      }
+  # Standard decks draw from a single aspect. We don't forbid mixing — a custom
+  # or experimental deck may want to — but surface it as advisory when more than
+  # one aspect is represented.
+  defp multi_aspect_issues(entries) do
+    case aspects_from_entries(entries) do
+      aspects when length(aspects) > 1 ->
+        labels = Enum.map_join(aspects, ", ", &aspect_label/1)
+
+        [
+          %Issue{
+            code: :multi_aspect,
+            severity: :warning,
+            message: "Deck combines #{length(aspects)} aspects (#{labels})"
+          }
+        ]
+
+      _one_or_none ->
+        []
     end
   end
 

--- a/lib/sanctum_web/components/deck_builder.ex
+++ b/lib/sanctum_web/components/deck_builder.ex
@@ -3,7 +3,8 @@ defmodule SanctumWeb.Components.DeckBuilder do
   Deckbuilder UI pieces: the per-card quantity stepper overlaid on grid
   tiles and (via `SanctumWeb.DeckLive.Build`) the persistent deck bar.
   All controls emit `inc`/`dec` with `phx-value-card-id`; the LiveView owns
-  persistence and clamping — the stepper's max only gates the button UI.
+  persistence. The builder imposes no deckbuilding restrictions — the stepper
+  never caps quantity; over-limit picks surface as advisory issues instead.
   """
 
   use Phoenix.Component
@@ -12,14 +13,16 @@ defmodule SanctumWeb.Components.DeckBuilder do
 
   @doc """
   Quantity controls for one card. Renders a lone "+" chip at zero and a
-  `− n +` cluster above it otherwise. `max` disables (visually) the "+" at
-  the card's deck limit; it never blocks the event handler's own clamp.
+  `− n +` cluster above it otherwise. The "+" is never capped — Sanctum
+  imposes no deckbuilding limits; over-limit copies are surfaced as advisory
+  issues in the deck panel rather than blocked here.
 
   `size` fits the control to its tile: `"md"` for the browse grid, `"sm"`
   for the compact tiles in the deck panel.
   """
   attr :card_id, :string, required: true
   attr :qty, :integer, default: 0
+  # Retained for callers; no longer gates the control (see moduledoc).
   attr :max, :integer, default: 3
   attr :size, :string, default: "md", values: ~w(md sm)
   attr :class, :any, default: nil
@@ -64,13 +67,10 @@ defmodule SanctumWeb.Components.DeckBuilder do
           data-haptic
           phx-click="inc"
           phx-value-card-id={@card_id}
-          disabled={@qty >= @max}
-          title={(@qty >= @max && "At this card's limit") || "Add a copy"}
+          title="Add a copy"
           class={[
-            "flex cursor-pointer items-center justify-center transition-colors",
-            @button_class,
-            (@qty >= @max && "cursor-default text-white/25") ||
-              "text-white/80 hover:bg-success hover:text-success-content"
+            "flex cursor-pointer items-center justify-center text-white/80 transition-colors hover:bg-success hover:text-success-content",
+            @button_class
           ]}
         >
           <.icon name="hero-plus" class={@icon_class} />

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -68,7 +68,6 @@ defmodule SanctumWeb.DeckLive.Build do
       end)
 
     signature_cards = Decks.signature_cards(deck.hero_id)
-    signature_ids = MapSet.new(signature_cards, & &1.id)
 
     socket
     |> assign(:page_title, "Build · #{deck.title}")
@@ -77,7 +76,6 @@ defmodule SanctumWeb.DeckLive.Build do
     |> assign(:card_view, "images")
     |> assign(:entries, entries)
     |> assign(:signature_cards, signature_cards)
-    |> assign(:signature_ids, signature_ids)
     |> assign(:staples, load_staples())
     |> recompute_issues()
     |> assign_card_preview()
@@ -408,27 +406,20 @@ defmodule SanctumWeb.DeckLive.Build do
 
   # -- quantity plumbing ------------------------------------------------------
 
+  # No hard caps: the builder imposes no deckbuilding restrictions. Going over a
+  # card's deck limit, exceeding the hero set, or mixing aspects all persist and
+  # surface as advisory issues instead (see Sanctum.Decks.Legality).
   defp change_quantity(socket, card_id, delta) do
     qty = current_qty(socket, card_id)
     new_qty = max(qty + delta, 0)
 
-    cond do
-      new_qty == qty ->
-        socket
-
-      # Signature cards are locked to the hero set — the grid never offers
-      # them (scope excludes :hero ownership), but guard the event anyway.
-      MapSet.member?(socket.assigns.signature_ids, card_id) ->
-        put_flash(socket, :error, "Hero cards are locked to the signature set.")
-
-      delta > 0 and new_qty > max_qty(socket, card_id) ->
-        socket
-
-      true ->
-        case find_card(socket, card_id) do
-          nil -> socket
-          card -> put_quantity(socket, card, new_qty)
-        end
+    if new_qty == qty do
+      socket
+    else
+      case find_card(socket, card_id) do
+        nil -> socket
+        card -> put_quantity(socket, card, new_qty)
+      end
     end
   end
 
@@ -481,36 +472,48 @@ defmodule SanctumWeb.DeckLive.Build do
     end
   end
 
-  defp max_qty(socket, card_id) do
-    card = find_card(socket, card_id)
-
-    cond do
-      is_nil(card) -> 0
-      card.unique -> 1
-      true -> card.deck_limit || 1
-    end
-  end
-
   # A card either came in from the grid (tile_cache keeps the Card struct with
-  # its primary side attached), the current entries, or the staples row.
+  # its primary side attached), the current entries, the hero's signature set,
+  # or the staples row.
   defp find_card(socket, card_id) do
     cond do
       tile = socket.assigns.tile_cache[card_id] -> tile.card
       entry = socket.assigns.entries[card_id] -> entry.card
+      card = Enum.find(socket.assigns.signature_cards, &(&1.id == card_id)) -> card
       card = Enum.find(socket.assigns.staples, &(&1.id == card_id)) -> card
       true -> nil
     end
   end
 
+  # Aspects are inferred from the deck's cards (no up-front choice), so every
+  # card change re-derives them and issues in one pass.
   defp recompute_issues(socket) do
+    socket = sync_aspects(socket)
+
     issues =
       Legality.issues(
         Map.values(socket.assigns.entries),
-        socket.assigns.deck.aspects,
         socket.assigns.signature_cards
       )
 
     assign(socket, :issues, issues)
+  end
+
+  # Persist the inferred aspect set whenever it drifts from what's stored, so
+  # the deck browser / show page (which read the `aspects` column) stay in sync.
+  # Compared as sets to ignore ordering and avoid write churn.
+  defp sync_aspects(socket) do
+    deck = socket.assigns.deck
+    inferred = Legality.aspects_from_entries(Map.values(socket.assigns.entries))
+
+    if MapSet.new(inferred) == MapSet.new(deck.aspects) do
+      socket
+    else
+      updated =
+        Decks.set_deck_aspects!(deck, %{aspects: inferred}, actor: socket.assigns.current_user)
+
+      assign(socket, :deck, %{deck | aspects: updated.aspects})
+    end
   end
 
   defp deck_size(entries) do
@@ -1259,6 +1262,19 @@ defmodule SanctumWeb.DeckLive.Build do
         <div class="px-1 font-anton text-lg uppercase tracking-[0.04em] text-base-content">
           {@deck.title}
         </div>
+        <!-- inferred aspect(s): derived from the cards, not chosen up front -->
+        <div :if={@deck.aspects != []} class="mt-1.5 flex flex-wrap items-center gap-1.5 px-1">
+          <span
+            :for={a <- DeckCards.aspect_badges(@deck.aspects)}
+            class={[
+              "border-2 bg-black px-2 py-0.5 font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em]",
+              a.text,
+              a.border
+            ]}
+          >
+            {a.label}
+          </span>
+        </div>
         <div class="mt-1 flex items-center gap-2 px-1">
           <span class="font-anton text-sm uppercase tracking-[0.05em]">
             <span class={deck_size_class(@size)}>{@size}</span>
@@ -1348,20 +1364,12 @@ defmodule SanctumWeb.DeckLive.Build do
               />
             </.link>
             <.qty_stepper
-              :if={!row.hero?}
               card_id={row.card_id}
               qty={row.qty}
               max={row.max}
               size="sm"
               class="absolute bottom-1 right-1 z-10"
             />
-            <span
-              :if={row.hero?}
-              class="absolute bottom-1 right-1 z-10 flex size-6 items-center justify-center rounded-[4px] bg-base-100/75"
-              title="Locked to the hero set"
-            >
-              <.icon name="hero-lock-closed" class="size-3 text-white/60" />
-            </span>
           </div>
         </div>
 
@@ -1389,13 +1397,9 @@ defmodule SanctumWeb.DeckLive.Build do
             <span class="flex w-8 flex-none items-center justify-end gap-1">
               <.champions_icon :for={token <- row.pips} token={token} class="text-sm" />
             </span>
-            <!-- controls column: fixed width whether it holds a lock or steppers -->
+            <!-- controls column: every card is editable (no hard caps) -->
             <span class="flex w-[84px] flex-none items-center justify-end gap-0.5 sm:w-[52px]">
-              <span :if={row.hero?} title="Locked to the hero set" class="flex justify-end">
-                <.icon name="hero-lock-closed" class="size-3 text-base-content/35" />
-              </span>
               <button
-                :if={!row.hero?}
                 type="button"
                 data-haptic
                 phx-click="dec"
@@ -1406,18 +1410,12 @@ defmodule SanctumWeb.DeckLive.Build do
                 <.icon name="hero-minus" class="size-4 sm:size-3.5" />
               </button>
               <button
-                :if={!row.hero?}
                 type="button"
                 data-haptic
                 phx-click="inc"
                 phx-value-card-id={row.card_id}
-                disabled={row.qty >= row.max}
-                title={(row.qty >= row.max && "At this card's limit") || "Add a copy"}
-                class={[
-                  "flex size-10 cursor-pointer items-center justify-center transition-colors sm:size-6",
-                  (row.qty >= row.max && "cursor-default text-base-content/20") ||
-                    "text-base-content/50 hover:text-success"
-                ]}
+                title="Add a copy"
+                class="flex size-10 cursor-pointer items-center justify-center text-base-content/50 transition-colors hover:text-success sm:size-6"
               >
                 <.icon name="hero-plus" class="size-4 sm:size-3.5" />
               </button>

--- a/lib/sanctum_web/live/deck_live/new.ex
+++ b/lib/sanctum_web/live/deck_live/new.ex
@@ -1,8 +1,9 @@
 defmodule SanctumWeb.DeckLive.New do
   @moduledoc """
   Hero picker for building a native deck: a card-art grid of every buildable
-  hero, a name filter, and a sticky (never modal) confirm strip with title +
-  aspect choices. Creating navigates straight into the builder.
+  hero, a name filter, and a sticky (never modal) confirm strip with a title.
+  Creating navigates straight into the builder. Aspect isn't chosen here — the
+  builder infers it from the cards as they're added (see `Sanctum.Decks.Legality`).
   """
 
   use SanctumWeb, :live_view
@@ -12,14 +13,6 @@ defmodule SanctumWeb.DeckLive.New do
 
   on_mount {SanctumWeb.LiveUserAuth, :live_user_required}
 
-  @aspects [
-    {"aggression", "Aggression", "bg-aspect-aggression"},
-    {"justice", "Justice", "bg-aspect-justice"},
-    {"leadership", "Leadership", "bg-aspect-leadership"},
-    {"protection", "Protection", "bg-aspect-protection"},
-    {"pool", "'Pool", "bg-aspect-pool"}
-  ]
-
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
@@ -28,8 +21,6 @@ defmodule SanctumWeb.DeckLive.New do
      |> assign(:heroes, load_heroes())
      |> assign(:filter, "")
      |> assign(:selected, nil)
-     |> assign(:chosen_aspects, [])
-     |> assign(:aspect_options, @aspects)
      |> assign(:creating?, false)}
   end
 
@@ -47,29 +38,16 @@ defmodule SanctumWeb.DeckLive.New do
     {:noreply, assign(socket, :selected, nil)}
   end
 
-  def handle_event("toggle_aspect", %{"key" => aspect}, socket) do
-    chosen = socket.assigns.chosen_aspects
-
-    chosen =
-      if aspect in chosen do
-        List.delete(chosen, aspect)
-      else
-        chosen ++ [aspect]
-      end
-
-    {:noreply, assign(socket, :chosen_aspects, chosen)}
-  end
-
   def handle_event("create", params, socket) do
-    %{selected: selected, chosen_aspects: aspects, current_user: user} = socket.assigns
+    %{selected: selected, current_user: user} = socket.assigns
 
     if is_nil(selected) do
       {:noreply, put_flash(socket, :error, "Pick a hero first")}
     else
+      # Aspects start empty and are inferred in the builder from the cards.
       attrs = %{
         hero_id: selected.id,
-        title: Map.get(params, "title", ""),
-        aspects: aspects
+        title: Map.get(params, "title", "")
       }
 
       case Decks.build_deck(attrs, actor: user) do
@@ -188,21 +166,9 @@ defmodule SanctumWeb.DeckLive.New do
             class="min-h-[44px] w-full border-[2.5px] border-line bg-black px-3 py-2 font-barlow-condensed text-base font-bold text-base-content outline-none focus:border-primary sm:min-h-0"
           />
 
-          <div class="flex flex-wrap items-center gap-1.5">
-            <.filter_pill
-              :for={{key, label, dot_class} <- @aspect_options}
-              active={key in @chosen_aspects}
-              dot_class={dot_class}
-              type="button"
-              phx-click="toggle_aspect"
-              phx-value-key={key}
-            >
-              {label}
-            </.filter_pill>
-            <span class="ml-1 font-barlow-condensed text-xs uppercase tracking-[0.06em] text-base-content/45">
-              none = basic deck
-            </span>
-          </div>
+          <p class="font-barlow-condensed text-xs uppercase tracking-[0.06em] text-base-content/45">
+            Aspect is set automatically from the cards you add.
+          </p>
 
           <.button variant="primary" type="submit" class="w-full sm:w-auto sm:self-end">
             Start Deck

--- a/test/sanctum/decks/legality_test.exs
+++ b/test/sanctum/decks/legality_test.exs
@@ -50,7 +50,7 @@ defmodule Sanctum.Decks.LegalityTest do
 
   describe "deck size" do
     test "flags too few cards" do
-      issues = Legality.issues(filler(39), [], [])
+      issues = Legality.issues(filler(39), [])
 
       assert [%Legality.Issue{code: :too_few, severity: :warning, message: message}] = issues
       assert message =~ "39"
@@ -58,18 +58,18 @@ defmodule Sanctum.Decks.LegalityTest do
 
     test "flags too many cards" do
       assert [%Legality.Issue{code: :too_many, severity: :warning}] =
-               Legality.issues(filler(51), [], [])
+               Legality.issues(filler(51), [])
     end
 
     test "accepts 40-50 cards" do
-      assert Legality.issues(filler(40), [], []) == []
-      assert Legality.issues(filler(50), [], []) == []
+      assert Legality.issues(filler(40), []) == []
+      assert Legality.issues(filler(50), []) == []
     end
 
     test "permanent cards do not count toward deck size" do
       permanent = entry(card(%{permanent: true, name: "Permanent"}), 1)
 
-      assert Legality.issues([permanent | filler(40)], [], []) == []
+      assert Legality.issues([permanent | filler(40)], []) == []
     end
   end
 
@@ -78,7 +78,7 @@ defmodule Sanctum.Decks.LegalityTest do
       sig_a = card(%{ownership: :hero, deck_limit: 2, name: "Backflip"})
       sig_b = card(%{ownership: :hero, deck_limit: 1, name: "Black Cat"})
 
-      issues = Legality.issues([entry(sig_a, 1) | filler(39)], [], [sig_a, sig_b])
+      issues = Legality.issues([entry(sig_a, 1) | filler(39)], [sig_a, sig_b])
 
       assert [
                %{code: :hero_set_incomplete, card_id: a_id},
@@ -96,7 +96,6 @@ defmodule Sanctum.Decks.LegalityTest do
       issues =
         Legality.issues(
           [entry(sig, 3), entry(stray, 1) | filler(36)],
-          [],
           [sig]
         )
 
@@ -109,7 +108,7 @@ defmodule Sanctum.Decks.LegalityTest do
     test "exact signature set raises no hero issues" do
       sig = card(%{ownership: :hero, deck_limit: 2, name: "Backflip"})
 
-      issues = Legality.issues([entry(sig, 2) | filler(38)], [], [sig])
+      issues = Legality.issues([entry(sig, 2) | filler(38)], [sig])
 
       refute Enum.any?(issues, &(&1.code in [:hero_set_incomplete, :hero_set_extra]))
     end
@@ -119,7 +118,7 @@ defmodule Sanctum.Decks.LegalityTest do
     test "flags quantities over deck_limit" do
       over = card(%{deck_limit: 3, name: "Over Limit"})
 
-      issues = Legality.issues([entry(over, 4) | filler(36)], [], [])
+      issues = Legality.issues([entry(over, 4) | filler(36)], [])
 
       assert [%{code: :deck_limit_exceeded, severity: :error, card_id: card_id}] =
                Enum.filter(issues, &(&1.code == :deck_limit_exceeded))
@@ -130,7 +129,7 @@ defmodule Sanctum.Decks.LegalityTest do
     test "ignore_deck_limit suppresses the deck_limit finding" do
       over = card(%{deck_limit: 3, name: "Boosted"})
 
-      issues = Legality.issues([entry(over, 4, ignore_deck_limit: true) | filler(36)], [], [])
+      issues = Legality.issues([entry(over, 4, ignore_deck_limit: true) | filler(36)], [])
 
       refute Enum.any?(issues, &(&1.code == :deck_limit_exceeded))
     end
@@ -138,75 +137,86 @@ defmodule Sanctum.Decks.LegalityTest do
     test "flags duplicate uniques (without doubling up a deck_limit finding)" do
       uniq = card(%{unique: true, deck_limit: 1, name: "Unique Ally"})
 
-      issues = Legality.issues([entry(uniq, 2) | filler(38)], [], [])
+      issues = Legality.issues([entry(uniq, 2) | filler(38)], [])
 
       assert [%{code: :unique_dup, severity: :error}] =
                Enum.filter(issues, &(&1.code in [:unique_dup, :deck_limit_exceeded]))
     end
   end
 
-  describe "aspects" do
-    test "flags player cards outside the deck's aspects" do
-      justice = card(%{ownership: :player, aspect: "justice", name: "Justice Card"})
-      pool = card(%{ownership: :player, aspect: "pool", name: "Pool Card"})
-
-      issues =
-        Legality.issues(
-          [entry(justice, 3), entry(pool, 3) | filler(34)],
-          ["justice"],
-          []
-        )
-
-      assert [%{code: :off_aspect, severity: :warning, card_id: card_id, message: message}] =
-               Enum.filter(issues, &(&1.code == :off_aspect))
-
-      assert card_id == pool.id
-      assert message =~ "'Pool"
-    end
-
-    test "multi-aspect decks accept cards from every chosen aspect" do
+  describe "aspect inference" do
+    test "aspects_from_entries returns the sorted distinct player aspects" do
       justice = card(%{ownership: :player, aspect: "justice"})
-      pool = card(%{ownership: :player, aspect: "pool"})
+      aggression = card(%{ownership: :player, aspect: "aggression"})
 
-      issues =
-        Legality.issues(
-          [entry(justice, 3), entry(pool, 3) | filler(34)],
-          ["justice", "pool"],
-          []
-        )
+      entries = [entry(aggression, 2), entry(justice, 3)]
 
-      refute Enum.any?(issues, &(&1.code == :off_aspect))
+      assert Legality.aspects_from_entries(entries) == ["aggression", "justice"]
     end
 
-    test "a basic deck (no aspects) flags every player aspect card" do
+    test "a single represented aspect infers just that aspect" do
       justice = card(%{ownership: :player, aspect: "justice"})
 
-      issues = Legality.issues([entry(justice, 3) | filler(37)], [], [])
-
-      assert Enum.any?(issues, &(&1.code == :off_aspect))
+      assert Legality.aspects_from_entries([entry(justice, 3)]) == ["justice"]
     end
 
-    test "basic and hero cards never raise aspect issues" do
+    test "removing every copy drops the aspect (quantity 0 doesn't count)" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+
+      assert Legality.aspects_from_entries([entry(justice, 0)]) == []
+    end
+
+    test "hero and basic cards never contribute an aspect" do
       basic = card(%{ownership: :basic, aspect: nil})
       hero = card(%{ownership: :hero, aspect: nil, deck_limit: 2})
 
-      issues = Legality.issues([entry(basic, 3), entry(hero, 2) | filler(35)], [], [hero])
-
-      refute Enum.any?(issues, &(&1.code == :off_aspect))
+      assert Legality.aspects_from_entries([entry(basic, 3), entry(hero, 2)]) == []
     end
   end
 
-  test "a legal-looking deck returns no issues" do
+  describe "multi-aspect advisory" do
+    test "flags a deck that combines more than one aspect" do
+      justice = card(%{ownership: :player, aspect: "justice", name: "Justice Card"})
+      pool = card(%{ownership: :player, aspect: "pool", name: "Pool Card"})
+
+      issues = Legality.issues([entry(justice, 3), entry(pool, 3) | filler(34)], [])
+
+      assert [%{code: :multi_aspect, severity: :warning, message: message}] =
+               Enum.filter(issues, &(&1.code == :multi_aspect))
+
+      assert message =~ "2 aspects"
+      assert message =~ "'Pool"
+    end
+
+    test "a single-aspect deck raises no multi-aspect issue" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+
+      issues = Legality.issues([entry(justice, 3) | filler(37)], [])
+
+      refute Enum.any?(issues, &(&1.code == :multi_aspect))
+    end
+
+    test "basic and hero cards never raise a multi-aspect issue" do
+      basic = card(%{ownership: :basic, aspect: nil})
+      hero = card(%{ownership: :hero, aspect: nil, deck_limit: 2})
+
+      issues = Legality.issues([entry(basic, 3), entry(hero, 2) | filler(35)], [hero])
+
+      refute Enum.any?(issues, &(&1.code == :multi_aspect))
+    end
+  end
+
+  test "a legal-looking single-aspect deck returns no issues" do
     sig = card(%{ownership: :hero, deck_limit: 2, name: "Signature"})
     aspect_card = card(%{ownership: :player, aspect: "justice", name: "Aspect Card"})
 
     entries = [entry(sig, 2), entry(aspect_card, 3) | filler(35)]
 
-    assert Legality.issues(entries, ["justice"], [sig]) == []
+    assert Legality.issues(entries, [sig]) == []
   end
 
   test "issue codes are stable atoms (UI contract)" do
-    issues = Legality.issues(filler(10), [], [])
+    issues = Legality.issues(filler(10), [])
     assert Enum.all?(issues, &match?(%Legality.Issue{}, &1))
     assert codes(issues) == [:too_few]
   end

--- a/test/sanctum_web/live/deck_live/build_test.exs
+++ b/test/sanctum_web/live/deck_live/build_test.exs
@@ -144,7 +144,7 @@ defmodule SanctumWeb.DeckLive.BuildTest do
     refute Map.has_key?(deck_quantities(deck.id), card.id)
   end
 
-  test "inc clamps at the card's deck limit", %{conn: conn} do
+  test "inc is not capped at the deck limit; the excess is advisory only", %{conn: conn} do
     card = player_card("Limited Ally", deck_limit: 1)
     %{lv: lv, deck: deck} = mount_builder(conn, "build_lv_c")
 
@@ -152,10 +152,12 @@ defmodule SanctumWeb.DeckLive.BuildTest do
 
     inc = "#builder-grid button[phx-click='inc'][phx-value-card-id='#{card.id}']"
     lv |> element(inc) |> render_click()
-    # The + is disabled at max; a forced event must still not exceed it.
+    # No hard cap: a second copy persists past the deck limit...
     render_click(lv, "inc", %{"card-id" => card.id})
 
-    assert deck_quantities(deck.id)[card.id] == 1
+    assert deck_quantities(deck.id)[card.id] == 2
+    # ...and surfaces as an advisory issue instead of being blocked.
+    assert render(lv) =~ "exceeds its deck limit"
   end
 
   test "filter sheet changes rewrite the query and narrow the grid", %{conn: conn} do
@@ -206,13 +208,16 @@ defmodule SanctumWeb.DeckLive.BuildTest do
            )
   end
 
-  test "signature quantities cannot be changed through events", %{conn: conn} do
+  test "signature quantities can be changed through events (no lock)", %{conn: conn} do
     %{lv: lv, deck: deck, signature: signature} = mount_builder(conn, "build_lv_e")
 
     render_async(lv)
+    # Hero cards are no longer locked — editing them persists...
     render_click(lv, "inc", %{"card-id" => signature.id})
 
-    assert deck_quantities(deck.id)[signature.id] == 2
+    assert deck_quantities(deck.id)[signature.id] == 3
+    # ...and over-running the signature set surfaces as an advisory issue.
+    assert render(lv) =~ "exceeds the hero set"
   end
 
   test "staples quick-add is idempotent and hardcodes 1x", %{conn: conn} do
@@ -287,15 +292,14 @@ defmodule SanctumWeb.DeckLive.BuildTest do
       assert Sanctum.Decks.get_deck!(deck.id, authorize?: false).title == deck.title
     end
 
-    test "hero signature rows are locked (no steppers)", %{conn: conn} do
+    test "hero signature rows are editable in the panel (no lock)", %{conn: conn} do
       %{lv: lv, signature: signature} = mount_builder(conn, "build_lv_j")
       render_async(lv)
 
       html = render(lv)
       assert html =~ "#{signature.code}" or html =~ "Signature"
-      assert html =~ "hero-lock-closed"
-      # No panel stepper targets the signature card.
-      refute has_element?(
+      # The signature card now carries a panel stepper like any other card.
+      assert has_element?(
                lv,
                "[phx-click='dec'][phx-value-card-id='#{signature.id}']"
              )

--- a/test/sanctum_web/live/deck_live/new_test.exs
+++ b/test/sanctum_web/live/deck_live/new_test.exs
@@ -115,7 +115,6 @@ defmodule SanctumWeb.DeckLive.NewTest do
     {:ok, lv, _html} = live(conn, ~p"/decks/new")
 
     lv |> element("button[phx-value-id='#{hero.id}']") |> render_click()
-    lv |> element("#deck-confirm .filter_pill, #deck-confirm button", "Justice") |> render_click()
 
     assert {:error, {:live_redirect, %{to: to}}} =
              lv |> form("#deck-confirm", %{title: "Test Build"}) |> render_submit()
@@ -127,7 +126,8 @@ defmodule SanctumWeb.DeckLive.NewTest do
 
     assert deck.title == "Test Build"
     assert deck.owner_id == user.id
-    assert deck.aspects == ["justice"]
+    # No up-front aspect choice — a fresh deck has no aspect until cards are added.
+    assert deck.aspects == []
     assert Enum.map(deck.deck_cards, & &1.card_id) == [signature.id]
     assert hd(deck.deck_cards).quantity == 2
   end


### PR DESCRIPTION
## What & why

Adopts a **"no restrictions, advisory warnings only"** philosophy in the deckbuilder. Sanctum now lets you build any deck you want and surfaces rule deviations as advisory issues rather than blocking them — opening the door to custom content that doesn't follow normal deckbuilding rules and making the rules system easy to adapt as the game changes.

## Changes

**Aspect is inferred, not chosen**
- `DeckLive.New` drops the up-front aspect toggle pills. New decks start with `aspects: []`; a hint reads *"Aspect is set automatically from the cards you add."*
- New `Legality.aspects_from_entries/1` infers a deck's aspect(s) from its player cards. The builder persists the inferred set via the existing `set_aspects` action whenever it drifts (compared as sets to avoid write churn), so the browser / show page / stats / export — all of which read `deck.aspects` — keep working unchanged.
- The builder's deck panel shows the inferred aspect as badges.

**Composable rules engine**
- `Legality.issues/2` is the single entrypoint composing self-contained per-rule functions. Dropped the external `aspects` argument (now inferred).
- Replaced the old `off_aspect` rule with an advisory `multi_aspect` warning: *"Deck combines 2 aspects (Aggression, Justice)"* when more than one aspect is present.

**Removed the remaining hard restrictions**
- The `qty_stepper` `+` is no longer capped at the deck limit, and `change_quantity` no longer refuses over-limit copies. The already-written `copy_limit_issues` warning now actually surfaces.
- Hero/signature cards are no longer locked — they're editable steppers in both panel views. `hero_set_issues` warnings surface instead.

## Testing

- `mix compile --warnings-as-errors` clean; Credo clean on changed files.
- **115 deck tests pass**, including rewritten tests asserting the new behavior (over-limit persists + warns, hero cards editable + warn, aspect inferred) plus new coverage for `aspects_from_entries/1` and the multi-aspect advisory.
- **Verified end-to-end in the running app** (LiveView + DB): fresh deck `[]` → add aggression card → `["aggression"]` + badge → add justice card → `["aggression","justice"]` + multi-aspect warning → remove aggression → flips to `["justice"]`; and a 4th copy of a limit-3 card persists (qty 4) with an *"exceeds its deck limit"* advisory instead of being blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)