### PR TITLE
feat(decks): handle heroes with special deckbuilding rules

### DIFF
--- a/lib/sanctum/decks/hero_rules.ex
+++ b/lib/sanctum/decks/hero_rules.ex
@@ -1,0 +1,148 @@
+defmodule Sanctum.Decks.HeroRules do
+  @moduledoc """
+  Explicit deckbuilding exceptions for the handful of heroes whose *aspect and
+  copy* rules break the standard template (one aspect, up to 3 copies / 1 if
+  unique).
+
+  This is deliberately **not** a general rules engine — the exceptions are
+  bespoke text printed on each identity card and aren't exposed as structured
+  MarvelCDB data, so there is nothing to derive. Each special hero is spelled
+  out by hand, keyed by its `set`. Every other hero uses `standard/0`.
+
+  Scope note: this module covers only deckbuilding *restrictions* (which
+  aspects, how many copies). Two other hero quirks are handled elsewhere
+  because they aren't deckbuilding rules:
+
+    * **Side decks** (Doctor Strange's Invocation deck, Storm's Weather deck)
+      are a separate deck-structure feature, not an aspect/copy restriction.
+    * **Split identities** (SP//dr: SP//dr Suit + Peni Parker across two cards)
+      are an identity-structure quirk; the deckbuilder simply doesn't require
+      the hero and alter-ego sides to live on one card.
+
+  Fields:
+
+    * `max_aspects` — aspects the deck may draw from without it being "off"
+      (Spider-Woman: 2, Adam Warlock: 4; standard: 1).
+    * `equal_aspects` — the chosen aspects must contribute equal card counts
+      (Spider-Woman's Double Agent, Adam Warlock).
+    * `single_copy` — every player/basic card is limited to a single copy
+      (Adam Warlock).
+    * `off_aspect_allowance` — a spec (or `nil`) for cards the deck may include
+      from aspects *other* than its one chosen aspect. Several heroes share this
+      shape — off-aspect cards matching a trait and type, up to some limit — so
+      each fills in its own spec rather than getting a bespoke code path:
+
+          %{
+            types: [:ally],      # allowed card types (required)
+            traits: ["X-Men"],   # optional; match ANY (period/case-insensitive).
+                                 #   omit for a type-only allowance
+            resource: :energy,   # optional; require this printed resource pip
+                                 #   (:energy | :physical | :mental | :wild)
+            limit: 6 | nil,      # nil = unlimited
+            limit_by: :copies | :titles,  # default :copies
+            label: "X-Men allies"         # for the advisory message
+          }
+
+      Gamora: up to 6 attack/thwart events. Cyclops: unlimited X-Men allies.
+      Maria Hill: up to 3 S.H.I.E.L.D. supports (by distinct title). Cable:
+      unlimited player side schemes (type only). Wonder Man: unlimited events
+      with a printed energy resource.
+  """
+
+  @type allowance :: %{
+          required(:types) => [atom()],
+          required(:label) => String.t(),
+          optional(:traits) => [String.t()],
+          optional(:resource) => :energy | :physical | :mental | :wild,
+          optional(:limit) => pos_integer(),
+          optional(:limit_by) => :copies | :titles
+        }
+
+  @type t :: %__MODULE__{
+          max_aspects: pos_integer(),
+          equal_aspects: boolean(),
+          single_copy: boolean(),
+          off_aspect_allowance: allowance() | nil
+        }
+
+  defstruct max_aspects: 1,
+            equal_aspects: false,
+            single_copy: false,
+            off_aspect_allowance: nil
+
+  @doc "The deckbuilding exceptions for a hero `set`, or the standard template."
+  @spec for_set(String.t() | nil) :: t()
+  def for_set(set) do
+    case set do
+      # Double Agent: choose two aspects, equal number of cards from each.
+      "spider_woman" ->
+        %__MODULE__{max_aspects: 2, equal_aspects: true}
+
+      # No single aspect — all four, with a single copy of each card.
+      "warlock" ->
+        %__MODULE__{max_aspects: 4, equal_aspects: true, single_copy: true}
+
+      # Skilled Tactician: chosen aspect plus up to 6 attack/thwart events from
+      # any other aspect.
+      "gam" ->
+        %__MODULE__{
+          off_aspect_allowance: %{
+            traits: ["Attack", "Thwart"],
+            types: [:event],
+            limit: 6,
+            label: "attack/thwart events"
+          }
+        }
+
+      # Scott Summers: may include X-Men allies from any aspect (no limit).
+      "cyclops" ->
+        %__MODULE__{
+          off_aspect_allowance: %{
+            traits: ["X-Men"],
+            types: [:ally],
+            label: "X-Men allies"
+          }
+        }
+
+      # Maria Hill: up to 3 S.H.I.E.L.D. supports from other aspects (by title).
+      "maria_hill" ->
+        %__MODULE__{
+          off_aspect_allowance: %{
+            traits: ["S.H.I.E.L.D."],
+            types: [:support],
+            limit: 3,
+            limit_by: :titles,
+            label: "S.H.I.E.L.D. supports"
+          }
+        }
+
+      # Nathan Summers: may include player side schemes from any aspect (no
+      # trait restriction, no limit).
+      "cable" ->
+        %__MODULE__{
+          off_aspect_allowance: %{
+            types: [:player_side_scheme],
+            label: "player side schemes"
+          }
+        }
+
+      # Simon Williams: may include events with a printed energy resource from
+      # any aspect.
+      "wonder_man" ->
+        %__MODULE__{
+          off_aspect_allowance: %{
+            types: [:event],
+            resource: :energy,
+            label: "events with an energy resource"
+          }
+        }
+
+      _standard ->
+        %__MODULE__{}
+    end
+  end
+
+  @doc "The standard template (no exceptions)."
+  @spec standard() :: t()
+  def standard, do: %__MODULE__{}
+end

--- a/lib/sanctum/decks/legality.ex
+++ b/lib/sanctum/decks/legality.ex
@@ -3,14 +3,19 @@ defmodule Sanctum.Decks.Legality do
   Advisory deck-legality checks.
 
   Issues are informational only — Sanctum never blocks a save on them.
-  Identity cards carry special deckbuilding rules the app doesn't model
-  (multi-aspect heroes, card-pool restrictions), so players stay the final
-  authority; the UI just surfaces what looks off.
+  Players stay the final authority; the UI just surfaces what looks off.
+
+  A few identity cards break the standard template (multi-aspect heroes,
+  single-copy decks, off-aspect allowances). Those are spelled out per hero in
+  `Sanctum.Decks.HeroRules` and threaded in via the deck's hero `set`; the
+  checks below honor them so the advisories don't cry wolf for those heroes.
 
   `Card.deck_limit` mirrors MarvelCDB's pack `quantity`, which for a few
   cards differs from the printed "Limit 1 per deck" text (core Energy ships
   4 copies), so the deck-limit check is knowingly approximate there.
   """
+
+  alias Sanctum.Decks.HeroRules
 
   defmodule Issue do
     @moduledoc "A single advisory finding about a deck."
@@ -43,14 +48,21 @@ defmodule Sanctum.Decks.Legality do
   The deck's aspects are not passed in — they're inferred from the cards
   themselves (see `aspects_from_entries/1`), so there is no separate "chosen
   aspect" to validate against.
+
+  `hero_set` is the deck's hero `set`; it selects the hero's
+  `Sanctum.Decks.HeroRules` so the aspect and copy-limit checks respect any
+  special deckbuilding exception. Omit it (or pass `nil`) for the standard
+  template.
   """
-  @spec issues([map()], [map()]) :: [Issue.t()]
-  def issues(entries, signature_cards)
+  @spec issues([map()], [map()], String.t() | nil) :: [Issue.t()]
+  def issues(entries, signature_cards, hero_set \\ nil)
       when is_list(entries) and is_list(signature_cards) do
+    rules = HeroRules.for_set(hero_set)
+
     size_issues(entries) ++
       hero_set_issues(entries, signature_cards) ++
-      copy_limit_issues(entries) ++
-      multi_aspect_issues(entries)
+      copy_limit_issues(entries, rules) ++
+      multi_aspect_issues(entries, rules)
   end
 
   @doc """
@@ -139,11 +151,11 @@ defmodule Sanctum.Decks.Legality do
     incomplete ++ extra
   end
 
-  defp copy_limit_issues(entries) do
+  defp copy_limit_issues(entries, rules) do
     Enum.flat_map(entries, fn entry ->
       c = card(entry)
       qty = quantity(entry)
-      limit = c.deck_limit || 1
+      limit = effective_limit(entry, c, rules)
 
       cond do
         c.unique and qty > 1 ->
@@ -173,25 +185,189 @@ defmodule Sanctum.Decks.Legality do
   end
 
   # Standard decks draw from a single aspect. We don't forbid mixing — a custom
-  # or experimental deck may want to — but surface it as advisory when more than
-  # one aspect is represented.
-  defp multi_aspect_issues(entries) do
-    case aspects_from_entries(entries) do
-      aspects when length(aspects) > 1 ->
-        labels = Enum.map_join(aspects, ", ", &aspect_label/1)
+  # or experimental deck may want to — but surface it as advisory when the deck
+  # draws from more aspects than its hero is allowed.
+  #
+  # `rules.max_aspects` covers heroes built to span aspects (Spider-Woman: 2,
+  # Adam Warlock: 4). Others keep one chosen aspect but may include specific
+  # off-aspect cards (Gamora's events, Cyclops's X-Men allies, Maria Hill's
+  # S.H.I.E.L.D. supports) — those extra aspects are expected, so we check the
+  # allowance rather than warn.
+  defp multi_aspect_issues(entries, rules) do
+    aspects = aspects_from_entries(entries)
 
+    cond do
+      length(aspects) <= rules.max_aspects ->
+        equal_aspect_issues(entries, aspects, rules)
+
+      rules.off_aspect_allowance ->
+        off_aspect_allowance_issues(entries, aspects, rules.off_aspect_allowance)
+
+      true ->
+        [multi_aspect_warning(aspects)]
+    end
+  end
+
+  defp multi_aspect_warning(aspects) do
+    labels = Enum.map_join(aspects, ", ", &aspect_label/1)
+
+    %Issue{
+      code: :multi_aspect,
+      severity: :warning,
+      message: "Deck combines #{length(aspects)} aspects (#{labels})"
+    }
+  end
+
+  # Spider-Woman / Adam Warlock must contribute equal card counts per aspect.
+  # Advisory only — flag when the chosen aspects are lopsided.
+  defp equal_aspect_issues(_entries, aspects, %{equal_aspects: false}) when is_list(aspects),
+    do: []
+
+  defp equal_aspect_issues(_entries, aspects, _rules) when length(aspects) <= 1, do: []
+
+  defp equal_aspect_issues(entries, aspects, _rules) do
+    counts = aspect_counts(entries, aspects)
+
+    if counts |> Map.values() |> Enum.uniq() |> length() > 1 do
+      detail = Enum.map_join(aspects, ", ", &"#{aspect_label(&1)} #{Map.get(counts, &1, 0)}")
+
+      [
+        %Issue{
+          code: :unequal_aspects,
+          severity: :warning,
+          message: "Aspects should have equal card counts (#{detail})"
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  # Heroes with one chosen aspect plus an off-aspect card allowance (Gamora,
+  # Cyclops, Maria Hill). Treat the largest aspect as the chosen one; every
+  # other-aspect player card must fit the allowance's trait/type, and any card
+  # limit must hold. Advisory only.
+  defp off_aspect_allowance_issues(entries, aspects, spec) do
+    chosen = chosen_aspect(entries, aspects)
+    off = off_aspect_entries(entries, aspects, chosen)
+
+    cond do
+      not Enum.all?(off, &qualifies_for_allowance?(&1, spec)) ->
         [
           %Issue{
-            code: :multi_aspect,
+            code: :off_aspect_not_allowed,
             severity: :warning,
-            message: "Deck combines #{length(aspects)} aspects (#{labels})"
+            message: "Off-aspect cards must be #{spec.label}"
           }
         ]
 
-      _one_or_none ->
+      over_allowance_limit?(off, spec) ->
+        [
+          %Issue{
+            code: :off_aspect_over_limit,
+            severity: :warning,
+            message: "Too many off-aspect #{spec.label} (max #{spec.limit})"
+          }
+        ]
+
+      true ->
         []
     end
   end
+
+  # The chosen aspect is whichever contributes the most cards — off-aspect
+  # allowances ride on top of a single dominant aspect.
+  defp chosen_aspect(entries, aspects) do
+    {chosen, _count} =
+      entries
+      |> aspect_counts(aspects)
+      |> Enum.max_by(fn {_aspect, n} -> n end)
+
+    chosen
+  end
+
+  defp off_aspect_entries(entries, aspects, chosen) do
+    Enum.filter(entries, fn entry ->
+      side = primary_side(entry)
+
+      ownership(entry) == :player and quantity(entry) > 0 and
+        is_binary(side.aspect) and side.aspect in aspects and side.aspect != chosen
+    end)
+  end
+
+  defp qualifies_for_allowance?(entry, spec) do
+    side = primary_side(entry)
+
+    side.type in spec.types and
+      traits_ok?(side.traits || [], Map.get(spec, :traits)) and
+      resource_ok?(side, Map.get(spec, :resource))
+  end
+
+  # A trait-less allowance (e.g. Cable's player side schemes) constrains by type
+  # only, so any traits qualify.
+  defp traits_ok?(_card_traits, allowed) when allowed in [nil, []], do: true
+  defp traits_ok?(card_traits, allowed), do: trait_match?(card_traits, allowed)
+
+  # Wonder Man's allowance requires a printed resource pip; other allowances
+  # don't constrain resources. Static field keys (not interpolated atoms) keep
+  # Sobelow happy and the lookup total.
+  defp resource_ok?(_side, nil), do: true
+  defp resource_ok?(side, :energy), do: printed?(side, :resource_energy_count)
+  defp resource_ok?(side, :physical), do: printed?(side, :resource_physical_count)
+  defp resource_ok?(side, :mental), do: printed?(side, :resource_mental_count)
+  defp resource_ok?(side, :wild), do: printed?(side, :resource_wild_count)
+
+  defp printed?(side, field), do: (Map.get(side, field) || 0) > 0
+
+  # Traits are stored inconsistently (e.g. "S.H.I.E.L.D" vs "S.H.I.E.L.D."), so
+  # compare case-insensitively with any trailing period trimmed.
+  defp trait_match?(card_traits, allowed) do
+    normalized = MapSet.new(card_traits, &normalize_trait/1)
+    Enum.any?(allowed, &MapSet.member?(normalized, normalize_trait(&1)))
+  end
+
+  defp normalize_trait(trait) do
+    trait |> to_string() |> String.downcase() |> String.trim_trailing(".")
+  end
+
+  defp over_allowance_limit?(off, spec) do
+    case Map.get(spec, :limit) do
+      nil ->
+        false
+
+      limit ->
+        count =
+          case Map.get(spec, :limit_by, :copies) do
+            :titles -> off |> Enum.map(&card(&1).id) |> Enum.uniq() |> length()
+            :copies -> off |> Enum.map(&quantity/1) |> Enum.sum()
+          end
+
+        count > limit
+    end
+  end
+
+  # Per-aspect total quantities across the deck's player aspect cards. A nil
+  # aspect is never in `allowed` (which holds only the binary aspect strings),
+  # so basic/hero cards fall out in the filter.
+  defp aspect_counts(entries, aspects) do
+    allowed = MapSet.new(aspects)
+
+    entries
+    |> Enum.filter(fn entry ->
+      ownership(entry) == :player and quantity(entry) > 0 and
+        MapSet.member?(allowed, primary_side(entry).aspect)
+    end)
+    |> Enum.reduce(%{}, fn entry, acc ->
+      Map.update(acc, primary_side(entry).aspect, quantity(entry), &(&1 + quantity(entry)))
+    end)
+  end
+
+  # A player/basic card's copy limit, honoring Adam Warlock's single-copy rule.
+  defp effective_limit(entry, card, %{single_copy: true}) when is_map(card) do
+    if ownership(entry) in [:player, :basic], do: 1, else: card.deck_limit || 1
+  end
+
+  defp effective_limit(_entry, card, _rules), do: card.deck_limit || 1
 
   defp card(entry), do: Map.fetch!(entry, :card)
   defp quantity(entry), do: Map.fetch!(entry, :quantity)

--- a/lib/sanctum/decks/legality.ex
+++ b/lib/sanctum/decks/legality.ex
@@ -218,28 +218,41 @@ defmodule Sanctum.Decks.Legality do
     }
   end
 
-  # Spider-Woman / Adam Warlock must contribute equal card counts per aspect.
-  # Advisory only — flag when the chosen aspects are lopsided.
+  # Heroes that build across a fixed number of aspects with equal card counts:
+  # Spider-Woman (two), Adam Warlock and Gambit (all four). Advisory only — flag
+  # when the deck doesn't span the required number of aspects, or when the
+  # aspects it does span are lopsided.
   defp equal_aspect_issues(_entries, aspects, %{equal_aspects: false}) when is_list(aspects),
     do: []
 
-  defp equal_aspect_issues(_entries, aspects, _rules) when length(aspects) <= 1, do: []
-
-  defp equal_aspect_issues(entries, aspects, _rules) do
+  defp equal_aspect_issues(entries, aspects, %{max_aspects: required}) do
     counts = aspect_counts(entries, aspects)
 
-    if counts |> Map.values() |> Enum.uniq() |> length() > 1 do
-      detail = Enum.map_join(aspects, ", ", &"#{aspect_label(&1)} #{Map.get(counts, &1, 0)}")
+    cond do
+      length(aspects) != required ->
+        [
+          %Issue{
+            code: :unequal_aspects,
+            severity: :warning,
+            message:
+              "Deck should draw equally from #{required} aspects " <>
+                "(has #{length(aspects)})"
+          }
+        ]
 
-      [
-        %Issue{
-          code: :unequal_aspects,
-          severity: :warning,
-          message: "Aspects should have equal card counts (#{detail})"
-        }
-      ]
-    else
-      []
+      counts |> Map.values() |> Enum.uniq() |> length() > 1 ->
+        detail = Enum.map_join(aspects, ", ", &"#{aspect_label(&1)} #{Map.get(counts, &1, 0)}")
+
+        [
+          %Issue{
+            code: :unequal_aspects,
+            severity: :warning,
+            message: "Aspects should have equal card counts (#{detail})"
+          }
+        ]
+
+      true ->
+        []
     end
   end
 

--- a/lib/sanctum/decks/validations/validate_hero.ex
+++ b/lib/sanctum/decks/validations/validate_hero.ex
@@ -3,6 +3,8 @@ defmodule Sanctum.Decks.Validations.ValidateHero do
 
   use Ash.Resource.Validation
 
+  require Ash.Query
+
   @impl true
   def init(opts) do
     {:ok, opts}
@@ -24,15 +26,24 @@ defmodule Sanctum.Decks.Validations.ValidateHero do
     end
   end
 
-  defp validate_hero_card(%Sanctum.Heroes.Hero{card: card}) when not is_nil(card) do
+  defp validate_hero_card(%Sanctum.Heroes.Hero{card: card} = hero) when not is_nil(card) do
     sides = card.card_sides || []
-    hero_side = Enum.find(sides, &(&1.type == :hero))
-    alter_ego_side = Enum.find(sides, &(&1.type == :alter_ego))
 
-    if hero_side && alter_ego_side do
-      :ok
-    else
-      {:error, field: :hero_id, message: "hero card must have both hero and alter ego sides"}
+    cond do
+      not Enum.any?(sides, &(&1.type == :hero)) ->
+        {:error, field: :hero_id, message: "hero card must have a hero side"}
+
+      # The alter-ego form must exist, but not necessarily on the identity card
+      # itself: split-identity heroes like SP//dr spread the hero and alter-ego
+      # forms across two cards in the same set (SP//dr Suit + Peni Parker), so
+      # we look for the alter-ego side anywhere in the identity card's set. (Use
+      # the card's set, not the Hero's — they match in real data, but a Hero can
+      # be pointed at a card from another set.)
+      not set_has_alter_ego?(hero.card.set) ->
+        {:error, field: :hero_id, message: "hero must have an alter ego side"}
+
+      true ->
+        :ok
     end
   end
 
@@ -41,4 +52,14 @@ defmodule Sanctum.Decks.Validations.ValidateHero do
   end
 
   defp validate_hero_card(_), do: {:error, field: :hero_id, message: "must be a valid hero"}
+
+  # Does any card in this hero's set carry an alter-ego side? True for standard
+  # heroes (same card) and split-identity heroes (a sibling card) alike.
+  defp set_has_alter_ego?(set) do
+    Sanctum.Games.Card
+    |> Ash.Query.filter(set == ^set and exists(card_sides, type == :alter_ego))
+    |> Ash.Query.limit(1)
+    |> Ash.read!(authorize?: false)
+    |> Enum.any?()
+  end
 end

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -493,7 +493,8 @@ defmodule SanctumWeb.DeckLive.Build do
     issues =
       Legality.issues(
         Map.values(socket.assigns.entries),
-        socket.assigns.signature_cards
+        socket.assigns.signature_cards,
+        socket.assigns.deck.hero.set
       )
 
     assign(socket, :issues, issues)

--- a/lib/sanctum_web/live/deck_live/new.ex
+++ b/lib/sanctum_web/live/deck_live/new.ex
@@ -10,6 +10,8 @@ defmodule SanctumWeb.DeckLive.New do
 
   use SanctumWeb, :live_view
 
+  require Ash.Query
+
   alias Sanctum.Decks
   alias SanctumWeb.Components.DeckCards
 
@@ -49,22 +51,37 @@ defmodule SanctumWeb.DeckLive.New do
     end
   end
 
-  # Heroes whose identity card has no alter-ego side (e.g. SP//dr) fail
-  # ValidateHero on :build, so they aren't offered.
+  # A hero is buildable when its identity card has a hero side and its set has
+  # an alter-ego side somewhere. We don't require the alter-ego on the same card
+  # — split-identity heroes (SP//dr: SP//dr Suit + Peni Parker) spread the two
+  # forms across two cards in one set. Matches ValidateHero.
   defp load_heroes do
+    sets_with_alter_ego = sets_with_alter_ego()
+
     Sanctum.Heroes.Hero
     |> Ash.Query.load([:display_name, :hero_side, card: [:card_sides]])
     |> Ash.read!(authorize?: false)
-    |> Enum.filter(&buildable?/1)
+    |> Enum.filter(&buildable?(&1, sets_with_alter_ego))
     |> Enum.map(&hero_view/1)
     |> Enum.sort_by(&String.downcase(&1.name))
   end
 
-  defp buildable?(%{card: %{card_sides: sides}}) when is_list(sides) do
-    Enum.any?(sides, &(&1.type == :hero)) and Enum.any?(sides, &(&1.type == :alter_ego))
+  defp buildable?(%{card: %{card_sides: sides, set: set}}, sets_with_alter_ego)
+       when is_list(sides) do
+    Enum.any?(sides, &(&1.type == :hero)) and MapSet.member?(sets_with_alter_ego, set)
   end
 
-  defp buildable?(_hero), do: false
+  defp buildable?(_hero, _sets), do: false
+
+  # One query for every set that contains an alter-ego side, so `buildable?/2`
+  # stays a membership check instead of an N+1 lookup per hero.
+  defp sets_with_alter_ego do
+    Sanctum.Games.Card
+    |> Ash.Query.filter(exists(card_sides, type == :alter_ego))
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(& &1.set)
+    |> MapSet.new()
+  end
 
   defp hero_view(hero) do
     {gradient_from, gradient_to} = DeckCards.hero_gradient(hero)

--- a/test/sanctum/decks/legality_test.exs
+++ b/test/sanctum/decks/legality_test.exs
@@ -268,6 +268,61 @@ defmodule Sanctum.Decks.LegalityTest do
       assert id == protection.id
     end
 
+    test "Adam Warlock with an equal split across all four aspects raises no aspect issue" do
+      # Single copies (Warlock's rule) of one card per aspect, equal counts.
+      aspects =
+        for a <- ~w(aggression justice leadership protection) do
+          entry(card(%{ownership: :player, aspect: a}), 1)
+        end
+
+      singles = for i <- 1..36//1, do: entry(card(%{name: "Single #{i}"}), 1)
+
+      issues = Legality.issues(aspects ++ singles, [], "warlock")
+
+      refute Enum.any?(issues, &(&1.code in [:multi_aspect, :unequal_aspects]))
+    end
+
+    test "Adam Warlock warns when the four aspects are lopsided" do
+      # Two aggression cards vs one of each other aspect — unequal counts, but
+      # every card is still a single copy (no deck-limit noise).
+      agg1 = card(%{ownership: :player, aspect: "aggression", name: "Agg 1"})
+      agg2 = card(%{ownership: :player, aspect: "aggression", name: "Agg 2"})
+      justice = card(%{ownership: :player, aspect: "justice"})
+      leadership = card(%{ownership: :player, aspect: "leadership"})
+      protection = card(%{ownership: :player, aspect: "protection", name: "Warded"})
+
+      singles = for i <- 1..35//1, do: entry(card(%{name: "Single #{i}"}), 1)
+
+      entries =
+        [
+          entry(agg1, 1),
+          entry(agg2, 1),
+          entry(justice, 1),
+          entry(leadership, 1),
+          entry(protection, 1)
+          | singles
+        ]
+
+      issues = Legality.issues(entries, [], "warlock")
+
+      assert Enum.any?(issues, &(&1.code == :unequal_aspects))
+    end
+
+    test "Adam Warlock warns when fewer than four aspects are present" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      leadership = card(%{ownership: :player, aspect: "leadership"})
+
+      singles = for i <- 1..38//1, do: entry(card(%{name: "Single #{i}"}), 1)
+
+      issues = Legality.issues([entry(justice, 1), entry(leadership, 1) | singles], [], "warlock")
+
+      assert [%{code: :unequal_aspects, message: message}] =
+               Enum.filter(issues, &(&1.code == :unequal_aspects))
+
+      assert message =~ "4 aspects"
+      assert message =~ "has 2"
+    end
+
     test "Gamora allows up to 6 off-aspect attack/thwart events" do
       # Chosen aspect dominates; a few off-aspect attack events ride along.
       justice = card(%{ownership: :player, aspect: "justice"})

--- a/test/sanctum/decks/legality_test.exs
+++ b/test/sanctum/decks/legality_test.exs
@@ -9,7 +9,10 @@ defmodule Sanctum.Decks.LegalityTest do
     side = %{
       name: Map.get(overrides, :name, "Test Card"),
       ownership: Map.get(overrides, :ownership, :basic),
-      aspect: Map.get(overrides, :aspect)
+      aspect: Map.get(overrides, :aspect),
+      type: Map.get(overrides, :type),
+      traits: Map.get(overrides, :traits, []),
+      resource_energy_count: Map.get(overrides, :resource_energy_count, 0)
     }
 
     %{
@@ -203,6 +206,231 @@ defmodule Sanctum.Decks.LegalityTest do
       issues = Legality.issues([entry(basic, 3), entry(hero, 2) | filler(35)], [hero])
 
       refute Enum.any?(issues, &(&1.code == :multi_aspect))
+    end
+  end
+
+  describe "hero-specific exceptions (HeroRules)" do
+    test "Spider-Woman may run two aspects without a multi-aspect warning" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      leadership = card(%{ownership: :player, aspect: "leadership"})
+
+      issues =
+        Legality.issues(
+          [entry(justice, 3), entry(leadership, 3) | filler(34)],
+          [],
+          "spider_woman"
+        )
+
+      refute Enum.any?(issues, &(&1.code == :multi_aspect))
+    end
+
+    test "Spider-Woman with lopsided aspects gets an equal-count advisory" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      leadership = card(%{ownership: :player, aspect: "leadership"})
+
+      issues =
+        Legality.issues(
+          [entry(justice, 3), entry(leadership, 1) | filler(36)],
+          [],
+          "spider_woman"
+        )
+
+      assert [%{code: :unequal_aspects, severity: :warning}] =
+               Enum.filter(issues, &(&1.code == :unequal_aspects))
+    end
+
+    test "Adam Warlock may run four aspects and is capped at one copy per card" do
+      aggression = card(%{ownership: :player, aspect: "aggression"})
+      justice = card(%{ownership: :player, aspect: "justice"})
+      leadership = card(%{ownership: :player, aspect: "leadership"})
+      protection = card(%{ownership: :player, aspect: "protection", name: "Warded"})
+
+      # Single copies of 36 distinct basics — Warlock's rule applies to every
+      # card, so qty-3 fillers would (correctly) flag too.
+      singles = for i <- 1..36//1, do: entry(card(%{name: "Single #{i}"}), 1)
+
+      entries = [
+        entry(aggression, 1),
+        entry(justice, 1),
+        entry(leadership, 1),
+        # Only this card breaks the single-copy rule.
+        entry(protection, 2)
+        | singles
+      ]
+
+      issues = Legality.issues(entries, [], "warlock")
+
+      refute Enum.any?(issues, &(&1.code == :multi_aspect))
+
+      assert [%{code: :deck_limit_exceeded, card_id: id}] =
+               Enum.filter(issues, &(&1.code == :deck_limit_exceeded))
+
+      assert id == protection.id
+    end
+
+    test "Gamora allows up to 6 off-aspect attack/thwart events" do
+      # Chosen aspect dominates; a few off-aspect attack events ride along.
+      justice = card(%{ownership: :player, aspect: "justice"})
+
+      off =
+        card(%{ownership: :player, aspect: "aggression", type: :event, traits: ["Attack"]})
+
+      issues = Legality.issues([entry(justice, 10), entry(off, 3) | filler(27)], [], "gam")
+
+      refute Enum.any?(
+               issues,
+               &(&1.code in [:multi_aspect, :off_aspect_over_limit, :off_aspect_not_events])
+             )
+    end
+
+    test "Gamora warns when off-aspect cards aren't attack/thwart events" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      off = card(%{ownership: :player, aspect: "aggression", type: :ally, traits: []})
+
+      issues = Legality.issues([entry(justice, 10), entry(off, 1) | filler(29)], [], "gam")
+
+      assert Enum.any?(issues, &(&1.code == :off_aspect_not_allowed))
+    end
+
+    test "Cyclops allows unlimited off-aspect X-Men allies" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      xmen = card(%{ownership: :player, aspect: "aggression", type: :ally, traits: ["X-Men"]})
+
+      issues = Legality.issues([entry(justice, 10), entry(xmen, 3) | filler(27)], [], "cyclops")
+
+      refute Enum.any?(
+               issues,
+               &(&1.code in [:multi_aspect, :off_aspect_not_allowed, :off_aspect_over_limit])
+             )
+    end
+
+    test "Cyclops warns on off-aspect cards that aren't X-Men allies" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      # An off-aspect upgrade (not an ally) doesn't qualify.
+      off = card(%{ownership: :player, aspect: "aggression", type: :upgrade, traits: ["X-Men"]})
+
+      issues = Legality.issues([entry(justice, 10), entry(off, 1) | filler(29)], [], "cyclops")
+
+      assert Enum.any?(issues, &(&1.code == :off_aspect_not_allowed))
+    end
+
+    test "Maria Hill allows up to 3 off-aspect S.H.I.E.L.D. supports (trait spelling tolerant)" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      # Note the period-less trait spelling — matching must tolerate it.
+      s1 =
+        card(%{ownership: :player, aspect: "leadership", type: :support, traits: ["S.H.I.E.L.D"]})
+
+      s2 =
+        card(%{
+          ownership: :player,
+          aspect: "leadership",
+          type: :support,
+          traits: ["S.H.I.E.L.D."]
+        })
+
+      s3 =
+        card(%{ownership: :player, aspect: "leadership", type: :support, traits: ["S.H.I.E.L.D"]})
+
+      entries = [entry(justice, 10), entry(s1, 2), entry(s2, 2), entry(s3, 2) | filler(24)]
+      issues = Legality.issues(entries, [], "maria_hill")
+
+      refute Enum.any?(
+               issues,
+               &(&1.code in [:multi_aspect, :off_aspect_not_allowed, :off_aspect_over_limit])
+             )
+    end
+
+    test "Cable allows off-aspect player side schemes (type-only allowance)" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+
+      scheme =
+        card(%{ownership: :player, aspect: "aggression", type: :player_side_scheme, traits: []})
+
+      issues = Legality.issues([entry(justice, 10), entry(scheme, 1) | filler(29)], [], "cable")
+
+      refute Enum.any?(
+               issues,
+               &(&1.code in [:multi_aspect, :off_aspect_not_allowed, :off_aspect_over_limit])
+             )
+    end
+
+    test "Cable warns on off-aspect cards that aren't player side schemes" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      off = card(%{ownership: :player, aspect: "aggression", type: :ally, traits: []})
+
+      issues = Legality.issues([entry(justice, 10), entry(off, 1) | filler(29)], [], "cable")
+
+      assert Enum.any?(issues, &(&1.code == :off_aspect_not_allowed))
+    end
+
+    test "Wonder Man allows off-aspect events with a printed energy resource" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+
+      ionic =
+        card(%{
+          ownership: :player,
+          aspect: "aggression",
+          type: :event,
+          resource_energy_count: 1
+        })
+
+      issues =
+        Legality.issues([entry(justice, 10), entry(ionic, 3) | filler(27)], [], "wonder_man")
+
+      refute Enum.any?(
+               issues,
+               &(&1.code in [:multi_aspect, :off_aspect_not_allowed, :off_aspect_over_limit])
+             )
+    end
+
+    test "Wonder Man warns on off-aspect events without an energy resource" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      # An off-aspect event with no printed energy pip doesn't qualify.
+      plain =
+        card(%{ownership: :player, aspect: "aggression", type: :event, resource_energy_count: 0})
+
+      issues =
+        Legality.issues([entry(justice, 10), entry(plain, 1) | filler(29)], [], "wonder_man")
+
+      assert Enum.any?(issues, &(&1.code == :off_aspect_not_allowed))
+    end
+
+    test "Maria Hill warns beyond 3 distinct off-aspect S.H.I.E.L.D. supports" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+
+      supports =
+        for i <- 1..4//1 do
+          entry(
+            card(%{
+              ownership: :player,
+              aspect: "leadership",
+              type: :support,
+              traits: ["S.H.I.E.L.D."],
+              name: "SHIELD #{i}"
+            }),
+            1
+          )
+        end
+
+      issues = Legality.issues([entry(justice, 10) | supports] ++ filler(26), [], "maria_hill")
+
+      assert Enum.any?(issues, &(&1.code == :off_aspect_over_limit))
+    end
+
+    test "Gamora warns when more than 6 off-aspect cards are included" do
+      justice = card(%{ownership: :player, aspect: "justice"})
+      # Chosen aspect dominates (as a real Gamora deck does); off-aspect attack
+      # events spread across cards total 7 > 6.
+      off_a = card(%{ownership: :player, aspect: "aggression", type: :event, traits: ["Attack"]})
+      off_b = card(%{ownership: :player, aspect: "aggression", type: :event, traits: ["Attack"]})
+      off_c = card(%{ownership: :player, aspect: "aggression", type: :event, traits: ["Thwart"]})
+
+      entries =
+        [entry(justice, 10), entry(off_a, 3), entry(off_b, 3), entry(off_c, 1) | filler(23)]
+
+      issues = Legality.issues(entries, [], "gam")
+
+      assert Enum.any?(issues, &(&1.code == :off_aspect_over_limit))
     end
   end
 

--- a/test/sanctum_web/live/deck_live/new_test.exs
+++ b/test/sanctum_web/live/deck_live/new_test.exs
@@ -76,8 +76,10 @@ defmodule SanctumWeb.DeckLive.NewTest do
     assert html =~ "Grid Hero A"
   end
 
-  test "heroes without an alter-ego side are not offered", %{conn: conn} do
-    # Hero-side-only identity (SP//dr style) fails ValidateHero on :build.
+  test "heroes without an alter-ego side anywhere in the set are not offered", %{conn: conn} do
+    # A set with a hero side but no alter-ego side at all is an incomplete
+    # identity and stays out of the builder. (Contrast the split-identity test
+    # below, where the alter-ego lives on a sibling card in the same set.)
     lone_card = create(Sanctum.Games.Card, attrs: %{base_code: "new_lonex", set: "new_lone"})
 
     create(Sanctum.Games.CardSide,
@@ -105,6 +107,52 @@ defmodule SanctumWeb.DeckLive.NewTest do
     {:ok, _lv, html} = live(conn, ~p"/decks/new")
 
     refute html =~ "Loner Hero"
+  end
+
+  test "split-identity heroes (alter-ego on a sibling card) are offered", %{conn: conn} do
+    # SP//dr-style: the hero side and alter-ego side live on two different cards
+    # in the same set, so neither card carries both — but the identity is whole.
+    suit = create(Sanctum.Games.Card, attrs: %{base_code: "new_splitx", set: "new_split"})
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: suit.id,
+        name: "Split Suit",
+        type: :hero,
+        ownership: :hero,
+        code: "#{suit.code}a",
+        side_identifier: "A",
+        is_primary_side: true
+      }
+    )
+
+    pilot = create(Sanctum.Games.Card, attrs: %{base_code: "new_pilotx", set: "new_split"})
+
+    create(Sanctum.Games.CardSide,
+      attrs: %{
+        card_id: pilot.id,
+        name: "Split Pilot",
+        type: :alter_ego,
+        ownership: :hero,
+        code: "#{pilot.code}a",
+        side_identifier: "A",
+        is_primary_side: true
+      }
+    )
+
+    {:ok, _hero} =
+      Sanctum.Heroes.find_or_create_hero(%{
+        hero_name: "Split Suit",
+        alter_ego_name: "Split Pilot",
+        set: "new_split",
+        base_code: suit.base_code,
+        card_id: suit.id
+      })
+
+    conn = log_in_user(conn, user_fixture())
+    {:ok, _lv, html} = live(conn, ~p"/decks/new")
+
+    assert html =~ "Split Suit"
   end
 
   test "selecting a hero lands in the builder with a default title and signature cards", %{


### PR DESCRIPTION
Several Marvel Champions heroes break the standard *one aspect / up-to-3-copies* template. Since Sanctum doesn't enforce rules (`Sanctum.Decks.Legality` is advisory-only), the problems were (a) the deckbuilder's advisory panel **false-flagging** these decks and (b) SP//dr being **unbuildable**. This makes both correct.

### `Sanctum.Decks.HeroRules` — a curated, per-`set` exceptions table

Explicit per hero (not a general rules engine — the rules are bespoke card text with no structured MarvelCDB source). Unlisted heroes get the standard template.

| Hero | Exception |
|---|---|
| Spider-Woman | two aspects, equal counts |
| Adam Warlock | four aspects, single copy of each card |
| Gamora | chosen aspect + up to 6 attack/thwart **events** from other aspects |
| Cyclops | chosen aspect + unlimited **X-Men allies** from any aspect |
| Maria Hill | chosen aspect + up to 3 **S.H.I.E.L.D. supports** (by title) from other aspects |
| Cable | chosen aspect + unlimited **player side schemes** from any aspect |
| Wonder Man | chosen aspect + unlimited **events with a printed energy resource** |

The five off-aspect-allowance heroes share one generalized `off_aspect_allowance` spec (`types` + optional `traits`/`resource` + optional `limit`/`limit_by` + `label`) that each hero fills in explicitly.

### `Legality` honors the exceptions

`Legality.issues/3` now takes the hero `set`. The multi-aspect advisory allows the hero's aspect count (and equal-count check for Spider-Woman/Warlock); off-aspect cards that fit a hero's allowance no longer trigger a warning (non-qualifying or over-limit cards still do); and the copy-limit advisory honors Adam Warlock's single-copy rule. Trait matching normalizes the inconsistent data (`S.H.I.E.L.D` vs `S.H.I.E.L.D.`).

### SP//dr native — via identity validation, not a HeroRules flag

SP//dr's identity spans two cards (SP//dr Suit: hero/support; Peni Parker: alter_ego/upgrade), so no single card has both a hero and an alter-ego side. `ValidateHero` and the builder's hero picker no longer require both sides on one card — they require a hero side on the identity card and an alter-ego side **anywhere in that card's set**. This admits SP//dr while still rejecting genuinely alter-ego-less identities.

### Out of scope (follow-up)

Side decks — Doctor Strange's Invocation deck and Storm's Weather deck — are a separate deck-structure feature, not a deckbuilding restriction. Planned as a future phase (a `DeckCard.section`).

### Testing

- New `HeroRules` coverage in `legality_test.exs` for all seven heroes (aspect counts, single-copy, and each off-aspect allowance including trait-spelling tolerance and limits).
- `new_test.exs`: SP//dr-style split identity is offered; a truly alter-ego-less set is still rejected.
- Full suite green: **753 tests, 0 failures**; `mix format` + Credo clean.