### PR TITLE
fix(mobile): prevent double-tap-to-zoom via touch-action

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -531,6 +531,10 @@ main, #game-board {
     background: var(--sanctum-canvas);
     color: var(--sanctum-ink);
     font-family: 'Barlow Condensed', system-ui, sans-serif;
+    /* Disable double-tap-to-zoom (and its ~300ms tap delay) on mobile while
+       preserving pinch-to-zoom for accessibility. user-scalable=no is worse:
+       it kills pinch zoom and modern iOS Safari ignores it anyway. */
+    touch-action: manipulation;
   }
 
   /* Tailwind v4 preflight dropped the default pointer cursor on buttons.


### PR DESCRIPTION
Adds `touch-action: manipulation` to the base `html, body` block so mobile double-tap no longer zooms the page (and the ~300ms tap delay it introduces goes away), while pinch-to-zoom is preserved for accessibility.

Chosen over the `user-scalable=no` / `maximum-scale=1` viewport approach, which kills pinch-zoom entirely and is ignored by modern iOS Safari in standalone/PWA mode anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)