### PR TITLE
Deck charts on the deck page and the builder

### DIFF
--- a/lib/sanctum_web/components/deck_cards.ex
+++ b/lib/sanctum_web/components/deck_cards.ex
@@ -40,8 +40,12 @@ defmodule SanctumWeb.Components.DeckCards do
       qty: qty,
       name: side.name,
       cost: CardComponent.display_value(side.cost),
+      # The raw printed cost the charts bucket on: nil for costless cards,
+      # -1 for cost X. `cost` above is the display string.
+      cost_value: side.cost,
       type: side.type,
       hero?: side.ownership == :hero,
+      permanent: card.permanent == true,
       aspect_key: aspect_key,
       aspect_bg: CardComponent.aspect_classes(aspect_key).bg,
       pips: ChampionsIcons.resource_pips(side_resources(side)),

--- a/lib/sanctum_web/components/deck_charts.ex
+++ b/lib/sanctum_web/components/deck_charts.ex
@@ -1,0 +1,572 @@
+defmodule SanctumWeb.Components.DeckCharts do
+  @moduledoc """
+  The four MarvelCDB deck charts — skill icons, cost curve, aspects, types —
+  drawn in the comic-dossier theme with plain CSS boxes and inline SVG. No
+  chart library: the panel these live in is 400px wide on the builder and the
+  data is a handful of integers, so a JS charting dep would cost more than it
+  buys.
+
+  `stats/1` takes the same `DeckCards.card_view/2` maps both deck surfaces
+  already build and returns the four datasets; `deck_charts/1` renders them.
+  Everything is derived per render — there is no chart state.
+
+  ## Semantics (ported from MarvelCDB's `app.deck_charts.js`)
+
+  All four charts count the **draw deck**: every copy of every non-permanent
+  card. The skill-icon columns stack each resource into icons printed on hero
+  (signature) cards versus everything else, matching MarvelCDB's two-series
+  column. Cost X (stored as `-1`) is excluded from the cost curve, and cards
+  with no printed cost are excluded too.
+
+  ## Color
+
+  Resource and aspect bars wear the design system's `--color-res-*` /
+  `--color-aspect-*` entity tokens. Those are fixed app-wide — a physical pip
+  is the same red in the card text, the pip column, and this chart — so they
+  are used as-is rather than re-derived for chart contrast. Card types have no
+  such token, so the palette in `@types` is purpose-built,
+  validated all-pairs colorblind-safe against the `bg-base-200` panel surface
+  (worst pair ΔE 9.1 protan / 9.3 tritan, normal-vision 15.9).
+
+  Every bar, point, and slice is **direct-labeled with its value**. That is
+  deliberate rather than decorative: this panel gets heavy use on phones, where
+  there is no hover, so a tooltip-only value would be unreadable for half the
+  audience. Titles carry the long-form breakdown for pointer users.
+  """
+
+  use Phoenix.Component
+
+  import SanctumWeb.CoreComponents, only: [panel: 1]
+
+  alias SanctumWeb.Components.ChampionsIcons
+
+  # MarvelCDB's column order: physical, mental, energy, wild.
+  @resources [
+    {:physical, "Physical", "var(--color-res-physical)"},
+    {:mental, "Mental", "var(--color-res-mental)"},
+    {:energy, "Energy", "var(--color-res-energy)"},
+    {:wild, "Wild", "var(--color-res-wild)"}
+  ]
+
+  # Hero-signature icons stack under the resource color in a recessive grey.
+  @hero_segment_color "color-mix(in srgb, var(--color-base-content) 34%, transparent)"
+
+  # Aspect colors are the app-wide entity tokens; labels match the deck-page
+  # aspect chips (`DeckCards.aspect_badges/1`).
+  @aspects [
+    {:hero, "Hero", "var(--color-aspect-hero)"},
+    {:aggression, "Aggression", "var(--color-aspect-aggression)"},
+    {:justice, "Justice", "var(--color-aspect-justice)"},
+    {:leadership, "Leadership", "var(--color-aspect-leadership)"},
+    {:protection, "Protection", "var(--color-aspect-protection)"},
+    {:pool, "Pool", "var(--color-aspect-pool)"},
+    {:basic, "Basic", "var(--color-aspect-basic)"}
+  ]
+
+  # Categorical palette for card types — see the moduledoc on how it was
+  # validated. Hues track MarvelCDB's (allies blue-ish, events red, upgrades
+  # green, resources gold) where the CVD checks allowed it.
+  @types [
+    {:ally, "Allies", "#009ea3"},
+    {:event, "Events", "#b6545a"},
+    {:support, "Supports", "#6e6eb9"},
+    {:upgrade, "Upgrades", "#197700"},
+    {:resource, "Resources", "#ab9028"},
+    {:player_side_scheme, "Side Schemes", "#a01186"}
+  ]
+
+  @other_color "var(--color-aspect-basic)"
+
+  @doc """
+  Derives the chart datasets from `DeckCards.card_view/2` maps.
+
+  Returns `%{total, resources, costs, aspects, types}`, where `total` is the
+  draw-deck size (permanent cards excluded, copies counted). An empty deck
+  yields `total: 0` and empty series, which `deck_charts/1` renders as nothing.
+  """
+  def stats(card_views) do
+    draw = Enum.filter(card_views, &(&1.qty > 0 and not &1.permanent))
+
+    %{
+      total: Enum.sum_by(draw, & &1.qty),
+      resources: resource_series(draw),
+      costs: cost_series(draw),
+      aspects: slices(draw, & &1.aspect_key, @aspects),
+      types: slices(draw, & &1.type, @types)
+    }
+  end
+
+  # Icons, not cards: a card printing two wild pips contributes two, times its
+  # quantity. Split by whether the printing is a hero signature card.
+  defp resource_series(draw) do
+    Enum.map(@resources, fn {key, label, color} ->
+      token = Atom.to_string(key)
+
+      {hero, other} = Enum.reduce(draw, {0, 0}, &add_pips(&1, &2, token))
+
+      %{key: key, token: token, label: label, color: color, hero: hero, other: other}
+    end)
+  end
+
+  defp add_pips(view, {hero, other}, token) do
+    count = view.qty * Enum.count(view.pips, &(&1 == token))
+    if view.hero?, do: {hero + count, other}, else: {hero, other + count}
+  end
+
+  # A dense 0..max series so gaps in the curve read as gaps, not as a shortcut
+  # between the costs either side of them.
+  defp cost_series(draw) do
+    counts =
+      draw
+      |> Enum.filter(&(is_integer(&1.cost_value) and &1.cost_value >= 0))
+      |> Enum.reduce(%{}, fn view, acc ->
+        Map.update(acc, view.cost_value, view.qty, &(&1 + view.qty))
+      end)
+
+    case Map.keys(counts) do
+      [] -> []
+      costs -> for cost <- 0..Enum.max(costs), do: %{cost: cost, count: counts[cost] || 0}
+    end
+  end
+
+  # Donut slices for one dimension: the known keys first, in the canonical
+  # order they're declared in, then anything else.
+  #
+  # That "anything else" bucket is load-bearing, not defensive. Aspects are
+  # data-driven now (`Sanctum.Games.Aspect`), so a homebrew aspect is a key
+  # this module has never heard of — and the donut's center prints the deck
+  # total, so a silently dropped key would make the slices stop summing to it.
+  # Unknowns get the neutral grey; interpolating `--color-aspect-<key>` for
+  # them would emit a var that doesn't exist and paint nothing.
+  defp slices(draw, key_fun, known) do
+    counts = tally(draw, key_fun)
+    known_keys = Enum.map(known, fn {key, _label, _color} -> Atom.to_string(key) end)
+
+    declared =
+      for {key, label, color} <- known, count = counts[Atom.to_string(key)] do
+        %{key: key, label: label, color: color, count: count}
+      end
+
+    other =
+      for {key, count} <- counts, key not in known_keys do
+        %{key: key, label: Phoenix.Naming.humanize(key), color: @other_color, count: count}
+      end
+
+    declared ++ Enum.sort_by(other, & &1.label)
+  end
+
+  # Aspect and type keys arrive as atoms from some loads and strings from
+  # others (the Ash enums cast either way), so every tally key is stringified.
+  defp tally(draw, key_fun) do
+    Enum.reduce(draw, %{}, fn view, acc ->
+      Map.update(acc, to_string(key_fun.(view)), view.qty, &(&1 + view.qty))
+    end)
+  end
+
+  @doc """
+  Renders the four charts as their own "Deck Stats" panel — a sibling of the
+  decklist rather than a section inside it.
+
+  Renders nothing for an empty draw deck. `stats` is the map from `stats/1`.
+  """
+  attr :stats, :map, required: true
+  attr :class, :string, default: nil
+
+  def deck_charts(assigns) do
+    ~H"""
+    <.panel :if={@stats.total > 0} class={String.trim("p-4 #{@class}")}>
+      <div class="mb-4 flex items-baseline gap-2">
+        <div class="font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
+          Deck Stats
+        </div>
+        <div class="font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em] text-base-content/35">
+          draw deck · {@stats.total} cards
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-5">
+        <.chart title="Card Skill Icons" subtitle="Hero-card icons shaded">
+          <.column_plot bars={resource_bars(@stats.resources)}>
+            <:label :let={bar}>
+              <ChampionsIcons.champions_icon token={bar.token} class="text-base" />
+            </:label>
+          </.column_plot>
+          <div class="mt-2 flex items-center gap-1.5">
+            <span
+              class="size-2.5 flex-none border border-neutral"
+              style={"background:#{hero_segment_color()}"}
+            ></span>
+            <span class="font-barlow-condensed text-xs font-bold uppercase tracking-[0.08em] text-base-content/45">
+              From hero cards
+            </span>
+          </div>
+        </.chart>
+
+        <.chart title="Card Cost" subtitle="Cost X ignored">
+          <.cost_chart points={@stats.costs} />
+        </.chart>
+
+        <.chart title="Card Aspects">
+          <.donut slices={@stats.aspects} total={@stats.total} label="Card aspects" />
+        </.chart>
+
+        <.chart title="Card Types">
+          <.donut slices={@stats.types} total={@stats.total} label="Card types" />
+        </.chart>
+      </div>
+    </.panel>
+    """
+  end
+
+  # Exposed to the template above; the swatch has to match the stacked segment.
+  defp hero_segment_color, do: @hero_segment_color
+
+  attr :title, :string, required: true
+  attr :subtitle, :string, default: nil
+  slot :inner_block, required: true
+
+  defp chart(assigns) do
+    ~H"""
+    <div>
+      <div class="font-anton text-sm uppercase tracking-[0.05em] text-base-content/85">
+        {@title}
+      </div>
+      <div
+        :if={@subtitle}
+        class="font-ibm-mono text-[10px] uppercase tracking-[0.12em] text-base-content/40"
+      >
+        {@subtitle}
+      </div>
+      <div class="mt-2.5">{render_slot(@inner_block)}</div>
+    </div>
+    """
+  end
+
+  defp resource_bars(resources) do
+    Enum.map(resources, fn res ->
+      %{
+        token: res.token,
+        label: res.label,
+        total: res.hero + res.other,
+        # Top-down, mirroring MarvelCDB's reversed stack: non-hero above hero.
+        segments: [
+          %{value: res.other, color: res.color},
+          %{value: res.hero, color: @hero_segment_color}
+        ],
+        title: resource_title(res)
+      }
+    end)
+  end
+
+  defp resource_title(%{label: label, hero: 0, other: other}), do: "#{label}: #{other}"
+
+  defp resource_title(%{label: label, hero: hero, other: other}),
+    do: "#{label}: #{hero + other} (#{other} on other cards, #{hero} on hero cards)"
+
+  # A stacked column plot in three aligned rows — values, bars, labels — so the
+  # baseline can be one unbroken rule across the whole plot instead of a
+  # per-column border broken by the gutters.
+  attr :bars, :list, required: true
+  slot :label, required: true
+
+  defp column_plot(assigns) do
+    assigns =
+      assign(assigns, :max, assigns.bars |> Enum.map(& &1.total) |> Enum.max(&>=/2, fn -> 0 end))
+
+    ~H"""
+    <div :if={@bars != []}>
+      <div class="flex gap-1.5">
+        <div
+          :for={bar <- @bars}
+          class="min-w-0 flex-1 text-center font-anton text-xs leading-none text-base-content/70"
+        >
+          {bar.total}
+        </div>
+      </div>
+
+      <div class="mt-1 flex h-[84px] items-end gap-1.5 border-b-2 border-neutral">
+        <div
+          :for={bar <- @bars}
+          title={bar.title}
+          class="flex h-full min-w-0 flex-1 items-end justify-center"
+        >
+          <div
+            class="flex w-full max-w-[56px] flex-col gap-[2px]"
+            style={"height:#{bar_height(bar.total, @max)}%"}
+          >
+            <div
+              :for={segment <- Enum.filter(bar.segments, &(&1.value > 0))}
+              class="min-h-[3px]"
+              style={"flex:#{segment.value} 1 0;background:#{segment.color}"}
+            >
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-1.5 flex gap-1.5">
+        <div :for={bar <- @bars} title={bar.title} class="min-w-0 flex-1 text-center leading-none">
+          {render_slot(@label, bar)}
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp bar_height(_total, 0), do: 0
+  defp bar_height(total, max), do: Float.round(total / max * 100, 2)
+
+  # Cost curve. Geometry is in percentages of the plot box, and the SVG holds
+  # *only* the curve — it stretches to the box with preserveAspectRatio="none"
+  # so one 0–100 coordinate space drives both the SVG points and the HTML
+  # markers/labels placed on top with `left`/`top` percentages.
+  #
+  # Text and markers are HTML, not SVG, for a reason: a scaled viewBox scales
+  # its own `font-size` too, so SVG text renders at a different pixel size on
+  # every panel width and can't match the column charts' type. In HTML they
+  # wear the same Tailwind classes as every other chart here. `vector-effect`
+  # keeps the stroke at a true 2px despite the non-uniform scale.
+  @cost_pad_x 4.0
+  @cost_curve_top 22.0
+  @cost_baseline 94.0
+
+  attr :points, :list, required: true
+
+  defp cost_chart(assigns) do
+    assigns = assign(assigns, :plot, cost_plot(assigns.points))
+
+    ~H"""
+    <p :if={@points == []} class="font-barlow-condensed text-sm italic text-base-content/45">
+      No cards with a printed cost.
+    </p>
+
+    <div :if={@points != []}>
+      <div class="relative h-[104px]">
+        <svg
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          class="absolute inset-0 size-full"
+          role="img"
+          aria-label={"Card cost curve: #{@plot.summary}"}
+        >
+          <polygon
+            points={@plot.area}
+            fill="color-mix(in srgb, var(--color-primary) 9%, transparent)"
+          />
+          <polyline
+            points={@plot.line}
+            fill="none"
+            stroke="var(--color-primary)"
+            stroke-width="2"
+            stroke-linejoin="round"
+            vector-effect="non-scaling-stroke"
+          />
+          <line
+            x1={@plot.pad_x}
+            y1={@plot.baseline}
+            x2={100 - @plot.pad_x}
+            y2={@plot.baseline}
+            stroke="var(--color-neutral)"
+            stroke-width="2"
+            vector-effect="non-scaling-stroke"
+          />
+        </svg>
+
+        <span
+          :for={point <- @plot.points}
+          title={"Cost #{point.cost}: #{point.count} cards"}
+          class="absolute size-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-primary bg-base-200"
+          style={"left:#{point.x}%;top:#{point.y}%"}
+        ></span>
+        <span
+          :for={point <- @plot.points}
+          :if={point.count > 0}
+          class="absolute -translate-x-1/2 -translate-y-full pb-1.5 font-anton text-xs leading-none text-base-content/70"
+          style={"left:#{point.x}%;top:#{point.y}%"}
+        >
+          {point.count}
+        </span>
+      </div>
+
+      <div class="relative mt-0.5 h-3">
+        <span
+          :for={point <- @plot.points}
+          class="absolute -translate-x-1/2 font-ibm-mono text-[11px] leading-none text-base-content/45"
+          style={"left:#{point.x}%"}
+        >
+          {point.cost}
+        </span>
+      </div>
+    </div>
+    """
+  end
+
+  @cost_geometry %{pad_x: @cost_pad_x, baseline: @cost_baseline}
+
+  defp cost_plot([]),
+    do: Map.merge(@cost_geometry, %{points: [], line: nil, area: nil, summary: ""})
+
+  defp cost_plot(costs) do
+    max = costs |> Enum.map(& &1.count) |> Enum.max()
+    span = 100 - 2 * @cost_pad_x
+    last = length(costs) - 1
+    height = @cost_baseline - @cost_curve_top
+
+    points =
+      costs
+      |> Enum.with_index()
+      |> Enum.map(fn {%{cost: cost, count: count}, index} ->
+        x = if last == 0, do: 50.0, else: @cost_pad_x + index * span / last
+        y = @cost_baseline - count / max * height
+        %{cost: cost, count: count, x: Float.round(x, 2), y: Float.round(y, 2)}
+      end)
+
+    line = Enum.map_join(points, " ", &"#{&1.x},#{&1.y}")
+    first = List.first(points)
+    tail = List.last(points)
+
+    Map.merge(@cost_geometry, %{
+      points: points,
+      line: line,
+      area: "#{first.x},#{@cost_baseline} #{line} #{tail.x},#{@cost_baseline}",
+      summary: Enum.map_join(points, ", ", &"cost #{&1.cost}: #{&1.count}")
+    })
+  end
+
+  # A part-of-whole split (aspects, types) as a donut with a labeled legend
+  # beside it. Slice arcs are drawn as dashed strokes on one circle so the 2px
+  # surface gaps between segments come free from the dash gap.
+  @donut_radius 38
+  # Wider than the 2px a surface gap normally needs: the aspect donut can put
+  # hero (#ce1b2e) right next to aggression (#b12020), and those two entity
+  # tokens are near-identical reds. The seam has to be unmistakable on its own.
+  @donut_gap 4
+
+  attr :slices, :list, required: true
+  attr :total, :integer, required: true
+  attr :label, :string, required: true, doc: "what the split is over, for the a11y label"
+
+  defp donut(assigns) do
+    assigns =
+      assigns
+      |> assign(:arcs, donut_arcs(assigns.slices))
+      |> assign(:radius, @donut_radius)
+
+    ~H"""
+    <div class="flex items-center gap-5">
+      <svg
+        viewBox="0 0 100 100"
+        class="aspect-square w-1/3 min-w-[104px] max-w-[176px] flex-none"
+        role="img"
+        aria-label={"#{@label}: #{Enum.map_join(@slices, ", ", &"#{&1.label} #{&1.count}")}"}
+      >
+        <!-- SVG hit-testing honors the dash pattern, so each circle is only
+             hoverable where its own arc is actually painted. -->
+        <g transform="rotate(-90 50 50)">
+          <circle
+            :for={arc <- @arcs}
+            cx="50"
+            cy="50"
+            r={@radius}
+            fill="none"
+            stroke={arc.slice.color}
+            stroke-width="16"
+            stroke-dasharray={"#{arc.length} #{arc.gap_length}"}
+            stroke-dashoffset={arc.offset}
+          >
+            <title>{slice_title(arc.slice, @total)}</title>
+          </circle>
+        </g>
+        <text
+          x="50"
+          y="53"
+          text-anchor="middle"
+          font-size="19"
+          font-family="Anton, sans-serif"
+          fill="var(--color-base-content)"
+        >
+          {@total}
+        </text>
+        <text
+          x="50"
+          y="64"
+          text-anchor="middle"
+          font-size="8"
+          font-family="'Barlow Condensed', sans-serif"
+          letter-spacing="1"
+          fill="color-mix(in srgb, var(--color-base-content) 45%, transparent)"
+        >
+          CARDS
+        </text>
+      </svg>
+
+      <!-- Capped so the right-aligned numbers can't strand a long way from the
+           label they belong to on a wide panel. The share column earns the
+           slack that's left: it's the thing a part-of-whole chart is actually
+           saying, and reading it off the arcs is guesswork. -->
+      <ul class="flex min-w-0 max-w-[18rem] flex-1 flex-col gap-1.5">
+        <!-- Same tooltip as the arc: the row is a far bigger hover target, and
+             on a narrow panel it's the only one that isn't fiddly. -->
+        <li
+          :for={slice <- @slices}
+          title={slice_title(slice, @total)}
+          class="flex items-baseline gap-2"
+        >
+          <span
+            class="size-2.5 flex-none self-center border border-neutral"
+            style={"background:#{slice.color}"}
+          ></span>
+          <span class="min-w-0 flex-1 truncate font-barlow-condensed text-sm font-semibold text-base-content/80">
+            {slice.label}
+          </span>
+          <span class="flex-none font-ibm-mono text-xs text-base-content/70">
+            {slice.count}
+          </span>
+          <span class="w-9 flex-none text-right font-ibm-mono text-xs text-base-content/40">
+            {share(slice.count, @total)}%
+          </span>
+        </li>
+      </ul>
+    </div>
+    """
+  end
+
+  defp share(_count, 0), do: 0
+  defp share(count, total), do: round(count / total * 100)
+
+  defp slice_title(%{label: label, count: count}, total),
+    do: "#{label}: #{count} cards (#{share(count, total)}%)"
+
+  # dasharray/dashoffset arcs around one circumference. A lone slice draws as a
+  # closed ring — a gap there would read as a missing segment, not a divider.
+  defp donut_arcs([]), do: []
+
+  defp donut_arcs([slice]) do
+    circumference = 2 * :math.pi() * @donut_radius
+    [%{slice: slice, length: round_2(circumference), gap_length: 0, offset: 0}]
+  end
+
+  defp donut_arcs(slices) do
+    circumference = 2 * :math.pi() * @donut_radius
+    total = Enum.sum_by(slices, & &1.count)
+
+    {arcs, _} =
+      Enum.map_reduce(slices, 0.0, fn slice, start ->
+        span = slice.count / total * circumference
+        length = max(span - @donut_gap, 1.0)
+
+        arc = %{
+          slice: slice,
+          length: round_2(length),
+          gap_length: round_2(circumference - length),
+          offset: round_2(-start)
+        }
+
+        {arc, start + span}
+      end)
+
+    arcs
+  end
+
+  defp round_2(value), do: Float.round(value * 1.0, 2)
+end

--- a/lib/sanctum_web/live/deck_live/build.ex
+++ b/lib/sanctum_web/live/deck_live/build.ex
@@ -17,6 +17,7 @@ defmodule SanctumWeb.DeckLive.Build do
 
   import SanctumWeb.Components.CardPreview
   import SanctumWeb.Components.DeckCards
+  import SanctumWeb.Components.DeckCharts
   import SanctumWeb.Components.FilterSheet
   import SanctumWeb.Components.QueryInput
 
@@ -26,6 +27,7 @@ defmodule SanctumWeb.DeckLive.Build do
   alias Sanctum.Decks.Legality
   alias Sanctum.Decks.Writeup
   alias SanctumWeb.Components.DeckCards
+  alias SanctumWeb.Components.DeckCharts
 
   on_mount {SanctumWeb.LiveUserAuth, :live_user_required}
 
@@ -570,14 +572,12 @@ defmodule SanctumWeb.DeckLive.Build do
 
   # -- deck panel data --------------------------------------------------------
 
-  # Grouped exactly like the deck page's "In This Deck" section: by card type
-  # in canonical order, hero signature cards folded into their type (marked
-  # with a lock), names sorted within each group.
-  defp panel_groups(entries, hero_gradient) do
+  # The panel's card display maps — the same shapes the deck page builds, fed
+  # to both the grouped list and the charts.
+  defp panel_card_views(entries, hero_gradient) do
     entries
     |> Map.values()
     |> Enum.map(&DeckCards.card_view(&1, hero_gradient))
-    |> DeckCards.group_by_type()
   end
 
   defp maybe_assign_count(socket, false, _count), do: socket
@@ -1253,8 +1253,15 @@ defmodule SanctumWeb.DeckLive.Build do
   attr :hero_gradient, :any, required: true
 
   defp deck_panel(assigns) do
-    assigns = assign(assigns, :groups, panel_groups(assigns.entries, assigns.hero_gradient))
-    assigns = assign(assigns, :size, deck_size(assigns.entries))
+    card_views = panel_card_views(assigns.entries, assigns.hero_gradient)
+
+    assigns =
+      assigns
+      # Grouped exactly like the deck page's "In This Deck" section: by card
+      # type in canonical order, names sorted within each group.
+      |> assign(:groups, DeckCards.group_by_type(card_views))
+      |> assign(:chart_stats, DeckCharts.stats(card_views))
+      |> assign(:size, deck_size(assigns.entries))
 
     ~H"""
     <div id={"deck-panel-#{@id}-body"} phx-hook="CardLinkPreview" class="flex flex-col gap-4 p-4">
@@ -1431,6 +1438,8 @@ defmodule SanctumWeb.DeckLive.Build do
       >
         No cards yet — tap + on a card to add it.
       </p>
+
+      <.deck_charts stats={@chart_stats} />
     </div>
     """
   end

--- a/lib/sanctum_web/live/deck_live/show.ex
+++ b/lib/sanctum_web/live/deck_live/show.ex
@@ -7,8 +7,10 @@ defmodule SanctumWeb.DeckLive.Show do
 
   import SanctumWeb.Components.CardPreview
   import SanctumWeb.Components.DeckCards
+  import SanctumWeb.Components.DeckCharts
 
   alias SanctumWeb.Components.DeckCards
+  alias SanctumWeb.Components.DeckCharts
 
   @impl true
   def render(assigns) do
@@ -246,6 +248,8 @@ defmodule SanctumWeb.DeckLive.Show do
                 </div>
               </.panel>
 
+              <.deck_charts stats={@chart_stats} />
+
               <!-- similar decks -->
               <.panel :if={@similar != []} class="p-4">
                 <div class="mb-3 font-ibm-mono text-xs uppercase tracking-[0.2em] text-base-content/50">
@@ -342,6 +346,7 @@ defmodule SanctumWeb.DeckLive.Show do
       |> assign(:deck, nil)
       |> assign(:cover, nil)
       |> assign(:groups, [])
+      |> assign(:chart_stats, DeckCharts.stats([]))
       |> assign(:similar, [])
       |> assign(:writeup, nil)
       |> assign(:card_view, "images")
@@ -424,6 +429,7 @@ defmodule SanctumWeb.DeckLive.Show do
       |> assign(:deck, data.deck)
       |> assign(:cover, data.cover)
       |> assign(:groups, data.groups)
+      |> assign(:chart_stats, data.chart_stats)
       |> assign(:owned_summary, data.owned_summary)
       |> assign(:similar, data.similar)
       |> assign(:writeup, data.writeup)
@@ -485,6 +491,7 @@ defmodule SanctumWeb.DeckLive.Show do
            deck: deck,
            cover: cover_view(deck, hero_gradient),
            groups: groups,
+           chart_stats: DeckCharts.stats(card_views),
            owned_summary: owned_summary(card_views, actor),
            similar: similar_views(deck),
            writeup: Sanctum.Decks.Writeup.render(deck.description_md),

--- a/test/sanctum_web/components/deck_charts_test.exs
+++ b/test/sanctum_web/components/deck_charts_test.exs
@@ -1,0 +1,176 @@
+defmodule SanctumWeb.Components.DeckChartsTest do
+  use ExUnit.Case, async: true
+
+  alias SanctumWeb.Components.DeckCharts
+
+  # A minimal `DeckCards.card_view/2` shape — only the fields stats/1 reads.
+  defp view(attrs) do
+    Map.merge(
+      %{
+        qty: 1,
+        permanent: false,
+        hero?: false,
+        pips: [],
+        cost_value: nil,
+        aspect_key: :basic,
+        type: :event
+      },
+      Map.new(attrs)
+    )
+  end
+
+  describe "stats/1" do
+    test "counts copies, not rows" do
+      stats = DeckCharts.stats([view(qty: 3), view(qty: 2)])
+
+      assert stats.total == 5
+    end
+
+    test "excludes permanent cards from every series" do
+      permanent =
+        view(
+          qty: 2,
+          permanent: true,
+          pips: ["wild"],
+          cost_value: 3,
+          aspect_key: :justice,
+          type: :upgrade
+        )
+
+      stats = DeckCharts.stats([permanent, view(qty: 1, cost_value: 1)])
+
+      assert stats.total == 1
+      assert Enum.all?(stats.resources, &(&1.hero + &1.other == 0))
+      assert Enum.map(stats.aspects, & &1.key) == [:basic]
+      assert Enum.map(stats.types, & &1.key) == [:event]
+      assert Enum.map(stats.costs, & &1.count) == [0, 1]
+    end
+
+    test "counts printed icons per copy and splits hero-card icons out" do
+      stats =
+        DeckCharts.stats([
+          view(qty: 2, pips: ["physical", "physical"]),
+          view(qty: 1, pips: ["physical"], hero?: true),
+          view(qty: 3, pips: ["wild"])
+        ])
+
+      by_key = Map.new(stats.resources, &{&1.key, &1})
+
+      assert by_key[:physical].other == 4
+      assert by_key[:physical].hero == 1
+      assert by_key[:wild] == %{by_key[:wild] | other: 3}
+      assert by_key[:mental].other == 0
+    end
+
+    test "always emits all four resources in MarvelCDB's column order" do
+      stats = DeckCharts.stats([view(pips: ["mental"])])
+
+      assert Enum.map(stats.resources, & &1.key) == [:physical, :mental, :energy, :wild]
+    end
+
+    test "fills cost gaps from zero so the curve dips instead of shortcutting" do
+      stats =
+        DeckCharts.stats([
+          view(cost_value: 0),
+          view(qty: 2, cost_value: 3)
+        ])
+
+      assert stats.costs == [
+               %{cost: 0, count: 1},
+               %{cost: 1, count: 0},
+               %{cost: 2, count: 0},
+               %{cost: 3, count: 2}
+             ]
+    end
+
+    test "ignores cost X and costless cards in the cost curve" do
+      stats =
+        DeckCharts.stats([
+          # Cost X is stored as -1.
+          view(cost_value: -1),
+          view(cost_value: nil),
+          view(cost_value: 1)
+        ])
+
+      assert stats.costs == [%{cost: 0, count: 0}, %{cost: 1, count: 1}]
+      assert stats.total == 3
+    end
+
+    test "has no cost series when nothing in the deck has a printed cost" do
+      assert DeckCharts.stats([view(cost_value: nil)]).costs == []
+    end
+
+    test "tallies aspects whether the key arrives as an atom or a string" do
+      stats =
+        DeckCharts.stats([
+          view(qty: 2, aspect_key: :aggression),
+          view(qty: 3, aspect_key: "aggression"),
+          view(aspect_key: :hero)
+        ])
+
+      assert stats.aspects == [
+               %{key: :hero, label: "Hero", color: "var(--color-aspect-hero)", count: 1},
+               %{
+                 key: :aggression,
+                 label: "Aggression",
+                 color: "var(--color-aspect-aggression)",
+                 count: 5
+               }
+             ]
+    end
+
+    # Aspects are data-driven (Sanctum.Games.Aspect), so a homebrew aspect is a
+    # key this module has never seen. The donut prints the deck total in its
+    # center, so every card has to land in some slice or the parts stop summing
+    # to the whole.
+    test "buckets an unknown aspect into a labeled grey slice" do
+      stats =
+        DeckCharts.stats([
+          view(qty: 4, aspect_key: :justice),
+          view(qty: 2, aspect_key: "chronomancy")
+        ])
+
+      assert stats.aspects == [
+               %{key: :justice, label: "Justice", color: "var(--color-aspect-justice)", count: 4},
+               %{
+                 key: "chronomancy",
+                 label: "Chronomancy",
+                 color: "var(--color-aspect-basic)",
+                 count: 2
+               }
+             ]
+
+      assert Enum.sum_by(stats.aspects, & &1.count) == stats.total
+    end
+
+    test "orders type slices canonically and buckets unknown types last" do
+      stats =
+        DeckCharts.stats([
+          view(type: :resource),
+          view(type: :ally),
+          view(type: :alter_ego),
+          view(qty: 4, type: :event)
+        ])
+
+      assert Enum.map(stats.types, &{&1.label, &1.count}) == [
+               {"Allies", 1},
+               {"Events", 4},
+               {"Resources", 1},
+               {"Alter ego", 1}
+             ]
+    end
+
+    test "an empty deck yields empty series" do
+      stats = DeckCharts.stats([])
+
+      assert stats.total == 0
+      assert stats.costs == []
+      assert stats.aspects == []
+      assert stats.types == []
+    end
+
+    test "ignores zero-quantity entries the builder may still hold" do
+      assert DeckCharts.stats([view(qty: 0, type: :ally)]).types == []
+    end
+  end
+end


### PR DESCRIPTION
Adds a **Deck Stats** panel — Card Skill Icons, Card Cost, Card Aspects, Card Types — below the decklist on `/decks/:id` and in the deckbuilder, porting the four charts MarvelCDB shows on a decklist.

No chart library. The panel is ~370px wide on the builder and the data is a dozen integers, so the charts are plain CSS boxes plus inline SVG in the comic-dossier theme.

## Semantics

Ported from marvelsdb's `app.deck_charts.js` (read from the local clone, not guessed):

- All four count the **draw deck** — every copy of every non-permanent card, copies not rows.
- Skill-icon columns stack **hero-signature icons** under everything else. MarvelCDB reverses its Highcharts stacks, which is why the grey lands at the bottom of each bar there and here.
- Cost X (stored `-1`) and cards with no printed cost drop out of the curve; gaps fill to `0` so the line dips instead of shortcutting between the costs either side.

## Deliberate deviations

- **Aspects and types are donuts with labeled legends**, not a column chart and a leader-line pie — both read badly at panel width. Each legend row carries count and share.
- **"Card Aspects"**, not MarvelCDB's "Card Factions": the app dropped `faction_code` for a separate aspect + ownership model.
- **Every mark is direct-labeled with its value**, rather than a y-axis plus hover. This panel gets heavy phone use, where there is no hover at all — a tooltip-only value would be unreadable for half the audience. Tooltips are additive on top (donut arcs, legend rows, cost points, skill columns).

## Notes for review

- `DeckCards.display_aspect/1` returns a **string** for the four aspects (via `side.aspect`) but the literal **atom** `:hero` / `:basic` from its ownership clauses. Caught live — it silently dropped 20 of 42 cards from the aspect chart — so every tally key is now stringified.
- Unknown aspect/type keys bucket into a labeled grey slice. Aspects are data-driven since the `Sanctum.Games.Aspect` refactor, so a homebrew aspect is a key this module has never seen, and the donut centre prints the deck total — a dropped key would stop the parts summing to the whole. Pinned by a test.
- **Cost-chart text is HTML positioned over a stretched SVG**, not SVG text. A scaled `viewBox` scales its own `font-size`, so SVG labels rendered ~16px at panel width against the column charts' 12px, and changed size with the panel. The SVG now holds only the curve (`preserveAspectRatio="none"` + `vector-effect="non-scaling-stroke"` for a true 2px line).
- Resource and aspect colors are the existing `--color-res-*` / `--color-aspect-*` entity tokens, so a physical pip is the same red here as in card text. Card types have no such token, so that palette is purpose-built and validated all-pairs colorblind-safe against `bg-base-200` (worst pair ΔE 9.1 protan / 9.3 tritan).
- Hero (`#ce1b2e`) and aggression (`#b12020`) are near-identical as tokens and can end up adjacent in the aspect ring. The slice gap is widened so the seam carries on its own; changing the tokens would desync the chart from the aspect chips and card text everywhere else.

## Testing

- 12 unit tests on `DeckCharts.stats/1` (draw-deck filter, icon splitting, cost bucketing, key normalization, unknown-key bucketing). Full suite 760 green, `mix ck` clean.
- Verified in the browser on both surfaces: deck page at 1400/390px, and the builder's real 400px column plus its mobile slide-up pane, using a throwaway account and temp deck (both since deleted).
- Confirmed the builder's charts recompute live on edit — `+` on a card moved the header 42→43 and re-derived every share.
- Checked for horizontal overflow at the narrowest layout (322px content) and read back computed font sizes to confirm the four charts share one type scale.

## Known gap

At the widest panel there is still ~40px of trailing space after the donut legends. Closing it properly means laying the four charts out 2×2 at wide container widths, the way MarvelCDB does — a layout change rather than a tweak, so it is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)